### PR TITLE
Add redirect for lang select page

### DIFF
--- a/src/_includes/layouts/splash.njk
+++ b/src/_includes/layouts/splash.njk
@@ -1,14 +1,37 @@
+---js
+{
+  pagination: {
+    data: "collections.all",
+    size: 1,
+    alias: "redirect",
+    before: function (data) {
+      return data.reduce((redirects, page) => {
+        if (Array.isArray(page.data.redirect_from)) {
+          for (let url of page.data.redirect_from) {
+            redirects.push({ to: page.url, from: url });
+          }
+        } else if (typeof page.data.redirect_from === 'string') {
+          redirects.push({ to: page.url, from: page.data.redirect_from });
+        }
+        return redirects;
+      }, []);
+    },
+    addAllPagesToCollections: false,
+  },
+  permalink: "{{ redirect.from }}/index.html",
+  eleventyExcludeFromCollections: true,
+}
+---
 <!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>{{ title }}</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-    </head>
-    <body>
-        <main>
-            {{ content | safe }}
-        </main>
-    </body>
+<html lang="en-US">
+  <meta charset="utf-8" />
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ redirect.to | url }}" />
+  <script>
+    location = '{{ redirect.to | url }}';
+  </script>
+  <meta http-equiv="refresh" content="0; url={{ redirect.to | url }}" />
+  <meta name="robots" content="noindex" />
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ redirect.to | url }}">Click here if you are not redirected.</a>
 </html>

--- a/src/en/pages/index.md
+++ b/src/en/pages/index.md
@@ -3,6 +3,7 @@ title: Home
 layout: "layouts/base.njk"
 permalink: /en/
 translationKey: "index"
+redirect_from: /
 ---
 
 # Homepage title

--- a/src/index.md
+++ b/src/index.md
@@ -1,12 +1,12 @@
 ---
-title: Alpha design system documentation
+title: GC design system
 layout: "layouts/splash.njk"
 ---
 
 <div class="landing-page">
   <h1>Alpha design system</h1>
   <div class="landing-page__btns">
-    <gcds-button type="link" href="/en/" lang="en">English</gcds-button>
-    <gcds-button type="link" href="/fr/" lang="fr">Français</gcds-button>
+    <gcds-button button-type="link" href="/en/" lang="en">English</gcds-button>
+    <gcds-button button-type="link" href="/fr/" lang="fr">Français</gcds-button>
   </div>
 </div>


### PR DESCRIPTION
# Summary | Résumé

When landing on https://cds-snc.github.io/gcds-docs/, should now redirect to https://cds-snc.github.io/gcds-docs/en instead of presenting a language selection screen.
