### PR TITLE
Fix format when copying code from code examples

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,6 +7,7 @@ const slugify = require("./utils/slugify");
 const contextMenu = require("./utils/context-menu");
 const markdownAnchor = require("./utils/anchor");
 const svgContents = require("eleventy-plugin-svg-contents");
+const codeClipboard = require("eleventy-plugin-code-clipboard");
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy("./src/styles/style.css");
@@ -26,6 +27,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(syntaxHighlight, {
     templateFormats: ['md']
   });
+  eleventyConfig.addPlugin(codeClipboard);
 
   eleventyConfig.addFilter("sortCollection", (arr) => {
     // get unsorted items
@@ -55,7 +57,7 @@ module.exports = function (eleventyConfig) {
     html: true,
     breaks: false,
     linkify: false
-  }).use(markdownAnchor);
+  }).use(markdownAnchor).use(codeClipboard.markdownItCopyButton);
   markdownLibrary.disable('blockquote');
   markdownLibrary.disable('code');
 
@@ -83,7 +85,6 @@ module.exports = function (eleventyConfig) {
       <gcds-button button-type="button" button-role="secondary" button-style="text-only" onclick="copyCodeShowcase(this, '${id}', '${lang}');" onblur="this.innerText = '${langStrings[lang].copy}'">${langStrings[lang].copy}</gcds-button>
       <div class="showcase" id="${id}" aria-hidden="true">
         ${content}
-        <code class="copy-code" id="${id}-copy">${copyCode}</code>
       </div>
     </div>
     `}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@11ty/eleventy": "^0.12.1",
     "@11ty/eleventy-navigation": "^0.3.2",
+    "eleventy-plugin-code-clipboard": "^0.0.8",
     "gcds-components": "^0.1.1",
     "markdown-it": "^12.2.0",
     "moment": "^2.29.1",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -49,5 +49,7 @@
         {% if contactForm %}
             {% include "partials/contactform.njk" %}
         {% endif %}
+
+        {% initClipboardJS %}
     </body>
 </html>

--- a/src/scripts/code-showcase.js
+++ b/src/scripts/code-showcase.js
@@ -10,9 +10,16 @@ function toggleCodeShowcase(trigger, id) {
 }
 
 function copyCodeShowcase(trigger, id, lang) {
-    const element = document.querySelector(`#${id}-copy`);
+    const parentElement = document.getElementById(id);
+    const codeElement = parentElement.querySelector("code");
+    const copyButton = parentElement.querySelector(".code-copy");
 
-    navigator.clipboard.writeText(element.innerText);
+    // Change values to slect right code element
+    // The ID attribute is not set properly due to how we render our code elements
+    codeElement.setAttribute("id", `code-${id}`);
+    copyButton.setAttribute("data-clipboard-target", `#code-${id}`);
+    copyButton.click();
+
     if (lang == "en") {
         trigger.innerText = "Copied";
     } else {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -378,11 +378,19 @@ body > div.sidebar-layout,
  */
 
 .code-showcase > div.showcase[aria-hidden="true"] {
-  display: none;
-  visibility: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  left: 0px;
+  margin: 0px;
+  overflow: hidden;
+  position: absolute;
+  text-align: center;
+  top: 10px;
+  width: 1px;
+  z-index: 3;
 }
 
-.code-showcase code.copy-code {
+.code-copy {
   display: none;
   visibility: hidden;
 }


### PR DESCRIPTION
# Summary | Résumé

Use code clipboard plugin to preserve formatting when clicking the `Copy code` button.
