### PR TITLE
Switch anchor links to just headings

### DIFF
--- a/utils/anchor.js
+++ b/utils/anchor.js
@@ -11,21 +11,7 @@ const anchor = (md, options) => {
     const contentToken = tokens[index + 1];
     const slug = slugify(contentToken.content);
 
-    if (tokens[index].tag === 'h2' || tokens[index].tag === 'h3') {
-      return `
-        <${tokens[index].tag} id="${slug}">
-            <a class="${options.anchorClass}" href="#${slug}">`;
-    }
-    return `<${tokens[index].tag}>`;
-  };
-
-  md.renderer.rules.heading_close = function(tokens, index) {
-    if (tokens[index].tag === 'h2' || tokens[index].tag === 'h3') {
-      return `
-            </a>
-        </${tokens[index].tag}>`;
-    }
-    return `</${tokens[index].tag}>`;
+    return `<${tokens[index].tag} id="${slug}">`;
   };
 };
 


### PR DESCRIPTION
# Summary | Résumé

Based on user feedback, remove heading anchor links and switch to just using headings.
