### PR TITLE
changing figma links to point at the figma community page

### DIFF
--- a/src/en/components/forms/input/input.md
+++ b/src/en/components/forms/input/input.md
@@ -17,7 +17,7 @@ onThisPage:
   5: How to write a good input label
   6: When to use hint text and error messages
 github: https://github.com/cds-snc/gcds-components/tree/main/src/components/gcds-input
-figma: https://www.figma.com/file/4KWj8wnnXoq6cA6yl0dnsR/GC-Components?node-id=2%3A598
+figma: https://www.figma.com/community/file/1128687821123298228
 ---
 
 <header>

--- a/src/en/components/forms/textarea/textarea.md
+++ b/src/en/components/forms/textarea/textarea.md
@@ -17,7 +17,7 @@ onThisPage:
   5: How to write good text area labels
   6: When to use hint text and error messages
 github: https://github.com/cds-snc/gcds-components/tree/main/src/components/gcds-textarea
-figma: https://www.figma.com/file/4KWj8wnnXoq6cA6yl0dnsR/GC-Components?node-id=3%3A599
+figma: https://www.figma.com/community/file/1128687821123298228
 ---
 
 <header>

--- a/src/en/components/interface-elements/button/button.md
+++ b/src/en/components/interface-elements/button/button.md
@@ -15,7 +15,7 @@ onThisPage:
   4: Where to place a button
   5: How to write a good button label
 github: https://github.com/cds-snc/gcds-components/tree/main/src/components/gcds-button
-figma: https://www.figma.com/file/4KWj8wnnXoq6cA6yl0dnsR/GC-Components?node-id=40%3A56
+figma: https://www.figma.com/community/file/1128687821123298228
 ---
 
 <header>

--- a/src/fr/composants/elements-dinterface/bouton/bouton.md
+++ b/src/fr/composants/elements-dinterface/bouton/bouton.md
@@ -16,7 +16,7 @@ onThisPage:
   4: Où placer les boutons
   5: Rédiger un bon libellé de bouton
 github: https://github.com/cds-snc/gcds-components/tree/main/src/components/gcds-button
-figma: https://www.figma.com/file/4KWj8wnnXoq6cA6yl0dnsR/GC-Components?node-id=40%3A56
+figma: https://www.figma.com/community/file/1128687821123298228
 ---
 
 <header>

--- a/src/fr/composants/formulaires/champ-de-saisie/champ-de-saisie.md
+++ b/src/fr/composants/formulaires/champ-de-saisie/champ-de-saisie.md
@@ -17,7 +17,7 @@ onThisPage:
   5: Rédiger une bonne étiquette
   6: Texte d’aide et messages d’erreur
 github: https://github.com/cds-snc/gcds-components/tree/main/src/components/gcds-input
-figma: https://www.figma.com/file/4KWj8wnnXoq6cA6yl0dnsR/GC-Components?node-id=2%3A598
+figma: https://www.figma.com/community/file/1128687821123298228
 ---
 
 <header>

--- a/src/fr/composants/formulaires/zone-de-texte/zone-de-texte.md
+++ b/src/fr/composants/formulaires/zone-de-texte/zone-de-texte.md
@@ -17,7 +17,7 @@ onThisPage:
   5: Rédiger une bonne étiquette
   6: Texte d’aide et messages d’erreur
 github: https://github.com/cds-snc/gcds-components/tree/main/src/components/gcds-textarea
-figma: https://www.figma.com/file/4KWj8wnnXoq6cA6yl0dnsR/GC-Components?node-id=3%3A599
+figma: https://www.figma.com/community/file/1128687821123298228
 ---
 
 <header>


### PR DESCRIPTION
Changing figma links to point to the community file.

Moving forward we should point all figma links at this community page instead of our master file.
