### PR TITLE
Tab navigation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -64,6 +64,11 @@ module.exports = function (eleventyConfig) {
         })
       }
     });
+
+    arr.sort(function (a, b) {
+      return a.data.order - b.data.order;
+    });
+
     return pages;
   });
 
@@ -247,7 +252,7 @@ module.exports = function (eleventyConfig) {
     pathPrefix: process.env.PATH_PREFIX || "/",
     dir: {
       input: "src",
-      output: "_site"
+      output: "_site",
     },
   };
 };

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -65,10 +65,6 @@ module.exports = function (eleventyConfig) {
       }
     });
 
-    arr.sort(function (a, b) {
-      return a.data.order - b.data.order;
-    });
-
     return pages;
   });
 

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{{ title }} - {{ base[locale].gcds }}</title>
+    <title>{% block page_title %}{{ title }} - {{ base[locale].gcds }}{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- Utility framework -->
@@ -31,7 +31,7 @@
     <div class="content-wrapper">
 
       <main id="mc" class="container-xl mx-auto general-layout flow">
-        {{ content | safe }}
+        {% block content %}{{ content | safe }}{% endblock %}
       </main>
 
       <gcds-footer display="compact" lang="{{ locale }}"></gcds-footer>

--- a/src/_includes/layouts/token-documentation.njk
+++ b/src/_includes/layouts/token-documentation.njk
@@ -1,24 +1,31 @@
----
-layout: "layouts/base.njk"
----
+{% extends "layouts/base.njk" %}
+
 
 {% if tags %}
     {% set tabs = collections.all | tabs(tags[0]) %}
-
-    {{ tabs.header.templateContent | safe }}
-
-    <ul>
-        <li>
-            <a href={{tabs.usage.url}}>
-            {{ documentation[locale].usage }}
-            </a>
-        </li>
-        <li>
-            <a href={{tabs.tokens.url}}>
-            {{ documentation[locale].tokens }}
-            </a>
-        </li>
-    </ul>
+    {% block page_title %}{{ title }} - {{ tabs.header.data.title }} - {{ base[locale].gcds }}{% endblock %}
 {% endif %}
 
-{{ content | safe }}
+{% block content %}
+    
+    {% if tabs %}
+        {{ tabs.header.templateContent | safe }}
+        <nav class="tabs" aria-label="{{ navLabel or title }}">
+            <ul>
+                {% for key, tab in tabs %}
+                    {% if tab.url %}
+                        <li class="tab">
+                            <a href={{ tab.url }} {{ 'aria-current=page' if tab.url == page.url}}>
+                                {{ tab.data.title }}
+                                {{ tab.data.order }}
+                            </a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
+        </nav>
+    {% endif %}
+    
+    {{ content | safe }}
+
+{% endblock %}

--- a/src/_includes/layouts/token-documentation.njk
+++ b/src/_includes/layouts/token-documentation.njk
@@ -17,7 +17,6 @@
                         <li class="tab">
                             <a href={{ tab.url }} {{ 'aria-current=page' if tab.url == page.url}}>
                                 {{ tab.data.title }}
-                                {{ tab.data.order }}
                             </a>
                         </li>
                     {% endif %}

--- a/src/_includes/layouts/token-documentation.njk
+++ b/src/_includes/layouts/token-documentation.njk
@@ -12,11 +12,11 @@
         {{ tabs.header.templateContent | safe }}
         <nav class="tabs" aria-label="{{ navLabel or title }}">
             <ul>
-                {% for key, tab in tabs %}
-                    {% if tab.url %}
+                {% for key, tab in documentation[locale] %}
+                    {% if tabs[key].url %}
                         <li class="tab">
-                            <a href={{ tab.url }} {{ 'aria-current=page' if tab.url == page.url}}>
-                                {{ tab.data.title }}
+                            <a href={{ tabs[key].url }} {{ 'aria-current=page' if tabs[key].url == page.url}}>
+                                {{ tab }}
                             </a>
                         </li>
                     {% endif %}

--- a/src/en/foundations/colour/base.md
+++ b/src/en/foundations/colour/base.md
@@ -1,6 +1,9 @@
 ---
+title: Colour
 permalink: false
-tags: ['colourEN', 'header']
+tags: ["colourEN", "header"]
 ---
 
 # Colour
+
+Colour tokens store the colour variables for styling components.

--- a/src/en/foundations/colour/base.md
+++ b/src/en/foundations/colour/base.md
@@ -4,6 +4,6 @@ permalink: false
 tags: ["colourEN", "header"]
 ---
 
-# Colour
+# {{ title }}
 
 Colour tokens store the colour variables for styling components.

--- a/src/en/foundations/colour/tokens.md
+++ b/src/en/foundations/colour/tokens.md
@@ -3,7 +3,6 @@ title: Tokens
 layout: "layouts/token-documentation.njk"
 translationKey: "colourTokens"
 tags: ["colourEN", "tokens"]
-order: 2
 tokenTable:
   headers:
     color-preview: ""
@@ -13,7 +12,7 @@ tokenTable:
     rgb: RGB
 ---
 
-## Tokens
+## {{ title }}
 
 Display tokens here
 

--- a/src/en/foundations/colour/tokens.md
+++ b/src/en/foundations/colour/tokens.md
@@ -1,8 +1,9 @@
 ---
-title: Colour - Foundations
+title: Tokens
 layout: "layouts/token-documentation.njk"
 translationKey: "colourTokens"
 tags: ["colourEN", "tokens"]
+order: 2
 tokenTable:
   headers:
     color-preview: ""

--- a/src/en/foundations/colour/usage.md
+++ b/src/en/foundations/colour/usage.md
@@ -1,5 +1,5 @@
 ---
-title: Use case
+title: Accessibility and colour tokens
 layout: "layouts/token-documentation.njk"
 eleventyNavigation:
   key: colourEN
@@ -10,7 +10,6 @@ eleventyNavigation:
   description: This is the foundation
   thumbnail: /images/en/foundations/foundation.png
   alt: This is an image of the foundation
-order: 1
 permalink: /en/foundations/colour/
 translationKey: "colour"
 tags: ["colourEN", "usage"]
@@ -40,7 +39,7 @@ tokenTable:
     focus-textForm: The focus text form colour should only be applied when focusing on form elements. Do not use this token for elements that aren’t form elements.
 ---
 
-## Accessibility and colour tokens
+## {{ title }}
 
 Ensure that the contrast ratio of text and interactive elements meets level AA of the Web Content Accessibility Guidelines (WCAG 2.1).
 

--- a/src/en/foundations/colour/usage.md
+++ b/src/en/foundations/colour/usage.md
@@ -1,5 +1,5 @@
 ---
-title: Colour - Foundations
+title: Use case
 layout: "layouts/token-documentation.njk"
 eleventyNavigation:
   key: colourEN
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the foundation
   thumbnail: /images/en/foundations/foundation.png
   alt: This is an image of the foundation
+order: 1
 permalink: /en/foundations/colour/
 translationKey: "colour"
 tags: ["colourEN", "usage"]

--- a/src/en/foundations/spacing/base.md
+++ b/src/en/foundations/spacing/base.md
@@ -4,4 +4,4 @@ permalink: false
 tags: ["spacingEN", "header"]
 ---
 
-# Spacing
+# {{ title }}

--- a/src/en/foundations/spacing/base.md
+++ b/src/en/foundations/spacing/base.md
@@ -1,6 +1,7 @@
 ---
+title: Spacing
 permalink: false
-tags: ['spacingEN', 'header']
+tags: ["spacingEN", "header"]
 ---
 
 # Spacing

--- a/src/en/foundations/spacing/tokens.md
+++ b/src/en/foundations/spacing/tokens.md
@@ -1,5 +1,6 @@
 ---
-title: Spacing - Foundations
+title: Tokens
+order: 2
 layout: "layouts/token-documentation.njk"
 translationKey: "spacingTokens"
 tags: ["spacingEN", "tokens"]

--- a/src/en/foundations/spacing/tokens.md
+++ b/src/en/foundations/spacing/tokens.md
@@ -1,6 +1,5 @@
 ---
 title: Guidance on using spacing
-order: 2
 layout: "layouts/token-documentation.njk"
 translationKey: "spacingTokens"
 tags: ["spacingEN", "tokens"]

--- a/src/en/foundations/spacing/tokens.md
+++ b/src/en/foundations/spacing/tokens.md
@@ -1,5 +1,5 @@
 ---
-title: Tokens
+title: Guidance on using spacing
 order: 2
 layout: "layouts/token-documentation.njk"
 translationKey: "spacingTokens"
@@ -12,7 +12,7 @@ tokenTable:
     value: Rem
 ---
 
-## Guidance on using spacing
+## {{ title }}
 
 Spacing of elements can be used to create visual hierarchy for content and guide focus to certain elements. Too dense information can be hard to digest for a user, so make sure to leave enough space in the user interfaces.
 

--- a/src/en/foundations/spacing/usage.md
+++ b/src/en/foundations/spacing/usage.md
@@ -1,5 +1,5 @@
 ---
-title: Use case
+title: Spacing usage
 order: 1
 layout: "layouts/token-documentation.njk"
 eleventyNavigation:
@@ -16,4 +16,4 @@ translationKey: "spacing"
 tags: ["spacingEN", "usage"]
 ---
 
-## Spacing usage
+## {{ title }}

--- a/src/en/foundations/spacing/usage.md
+++ b/src/en/foundations/spacing/usage.md
@@ -1,6 +1,5 @@
 ---
 title: Spacing usage
-order: 1
 layout: "layouts/token-documentation.njk"
 eleventyNavigation:
   key: spacingEN

--- a/src/en/foundations/spacing/usage.md
+++ b/src/en/foundations/spacing/usage.md
@@ -1,5 +1,6 @@
 ---
-title: Spacing - Foundations
+title: Use case
+order: 1
 layout: "layouts/token-documentation.njk"
 eleventyNavigation:
   key: spacingEN
@@ -12,7 +13,7 @@ eleventyNavigation:
   alt: This is an image of the foundation
 permalink: /en/foundations/spacing/
 translationKey: "spacing"
-tags: ['spacingEN', 'usage']
+tags: ["spacingEN", "usage"]
 ---
 
 ## Spacing usage

--- a/src/en/foundations/typography/base.md
+++ b/src/en/foundations/typography/base.md
@@ -4,4 +4,4 @@ permalink: false
 tags: ["typographyEN", "header"]
 ---
 
-# Typography
+# {{ title }}

--- a/src/en/foundations/typography/base.md
+++ b/src/en/foundations/typography/base.md
@@ -1,6 +1,7 @@
 ---
+title: Typography
 permalink: false
-tags: ['typographyEN', 'header']
+tags: ["typographyEN", "header"]
 ---
 
 # Typography

--- a/src/en/foundations/typography/tokens.md
+++ b/src/en/foundations/typography/tokens.md
@@ -31,7 +31,7 @@ tokenTable:
     fontWeights-bold: Bold
 ---
 
-## Tokens
+## {{ title }}
 
 Font values in the Text and Heading tables are read using the following template: font weight, font size in rem, line height as a percentage of font size, and the font family. The font family also contains fallback values. The value of font tokens follow the [shorthand font property specification](https://w3c.github.io/csswg-drafts/css-fonts/#font-prop).
 

--- a/src/en/foundations/typography/tokens.md
+++ b/src/en/foundations/typography/tokens.md
@@ -1,6 +1,5 @@
 ---
 title: Tokens
-order: 2
 layout: "layouts/token-documentation.njk"
 translationKey: "typographyTokens"
 tags: ["typographyEN", "tokens"]

--- a/src/en/foundations/typography/tokens.md
+++ b/src/en/foundations/typography/tokens.md
@@ -1,5 +1,6 @@
 ---
-title: Typography - Foundations
+title: Tokens
+order: 2
 layout: "layouts/token-documentation.njk"
 translationKey: "typographyTokens"
 tags: ["typographyEN", "tokens"]

--- a/src/en/foundations/typography/usage.md
+++ b/src/en/foundations/typography/usage.md
@@ -1,5 +1,6 @@
 ---
-title: Typography - Foundations
+title: Use case
+order: 1
 layout: "layouts/token-documentation.njk"
 eleventyNavigation:
   key: typographyEN
@@ -12,7 +13,7 @@ eleventyNavigation:
   alt: This is an image of the foundation
 permalink: /en/foundations/typography/
 translationKey: "typography"
-tags: ['typographyEN', 'usage']
+tags: ["typographyEN", "usage"]
 ---
 
 ## Typography usage

--- a/src/en/foundations/typography/usage.md
+++ b/src/en/foundations/typography/usage.md
@@ -1,5 +1,5 @@
 ---
-title: Use case
+title: Typography usage
 order: 1
 layout: "layouts/token-documentation.njk"
 eleventyNavigation:
@@ -16,4 +16,4 @@ translationKey: "typography"
 tags: ["typographyEN", "usage"]
 ---
 
-## Typography usage
+## {{ title }}

--- a/src/en/foundations/typography/usage.md
+++ b/src/en/foundations/typography/usage.md
@@ -1,6 +1,5 @@
 ---
 title: Typography usage
-order: 1
 layout: "layouts/token-documentation.njk"
 eleventyNavigation:
   key: typographyEN

--- a/src/styles/components/_tabs.scss
+++ b/src/styles/components/_tabs.scss
@@ -1,0 +1,41 @@
+nav.tabs {
+  --flow-spacing: var(--gcds-spacing-600);
+
+  ul {
+    width: 100%;
+    display: flex;
+    background-color: var(--gcds-color-grayscale-100);
+    gap: var(--gcds-spacing-100);
+    flex-wrap: wrap;
+    padding-block-start: var(--gcds-spacing-100);
+    padding-inline: var(--gcds-spacing-100);
+  }
+
+  a {
+    display: block;
+    border-radius: var(--gcds-button-border-radius)
+      var(--gcds-button-border-radius) 0 0;
+    padding: var(--gcds-spacing-150);
+    color: var(--gcds-text-default);
+
+    &:hover {
+      background-color: var(--gcds-color-grayscale-50);
+    }
+
+    &:focus {
+      border-radius: 0;
+      background-color: var(--gcds-focus-background);
+      color: var(--gcds-focus-text);
+      text-decoration: none;
+    }
+
+    &[aria-current="page"] {
+      background-color: var(--gcds-color-grayscale-0);
+      text-decoration: none;
+    }
+  }
+}
+
+nav.tabs + * {
+  --flow-spacing: var(--gcds-spacing-400);
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -88,5 +88,34 @@ table {
   table .spacing-preview {
     background-color: var(--gcds-color-blue-500); }
 
+nav.tabs {
+  --flow-spacing: var(--gcds-spacing-600); }
+  nav.tabs ul {
+    width: 100%;
+    display: flex;
+    background-color: var(--gcds-color-grayscale-100);
+    gap: var(--gcds-spacing-100);
+    flex-wrap: wrap;
+    padding-block-start: var(--gcds-spacing-100);
+    padding-inline: var(--gcds-spacing-100); }
+  nav.tabs a {
+    display: block;
+    border-radius: var(--gcds-button-border-radius) var(--gcds-button-border-radius) 0 0;
+    padding: var(--gcds-spacing-150);
+    color: var(--gcds-text-default); }
+    nav.tabs a:hover {
+      background-color: var(--gcds-color-grayscale-50); }
+    nav.tabs a:focus {
+      border-radius: 0;
+      background-color: var(--gcds-focus-background);
+      color: var(--gcds-focus-text);
+      text-decoration: none; }
+    nav.tabs a[aria-current="page"] {
+      background-color: var(--gcds-color-grayscale-0);
+      text-decoration: none; }
+
+nav.tabs + * {
+  --flow-spacing: var(--gcds-spacing-400); }
+
 .flow > * + * {
   margin-block-start: var(--flow-spacing, var(--gcds-spacing-400)); }


### PR DESCRIPTION
# Summary | Résumé

Tabs component available. Needs a `<nav>` so we'll need to update some templates as we go to set it up within a `<nav>` container and give it a proper label. 

Additionally, this PR also sets up the tabs for the token documentation pages.
- Reworked the `token-documentation` template to loop through documentation locales, then display if a sub page exists. I think we could make this a generic partial for component documentation too. 
- Reworked base template to use nunjuck blocks, so that its easier to set data within templates. The blocks have the same default content, so this doesn't break existing pages. 

