### PR TITLE
Add new pages + partials

### DIFF
--- a/src/_data/documentation.js
+++ b/src/_data/documentation.js
@@ -1,18 +1,18 @@
 module.exports = {
-    en : {
-        usecase: "Use case",
-        usage: "Usage",
-        design: "Design",
-        code: "Code",
-        tokens: "Tokens",
-        "othernames": "Other names: "
-    },
-    fr: {
-        usecase: "Cas d'utilisation",
-        usage: "Usage",
-        design: "Design",
-        code: "Code",
-        tokens: "Tokens",
-        "othernames": "Autres noms : "
-    }
+  en : {
+    usecase: "Use case",
+    usage: "Usage",
+    design: "Design",
+    code: "Code",
+    tokens: "Tokens",
+    othernames: "Other names: "
+  },
+  fr: {
+    usecase: "Cas d'utilisation",
+    usage: "Usage",
+    design: "Design",
+    code: "Code",
+    tokens: "Tokens",
+    othernames: "Autres noms : "
+  }
 }

--- a/src/_data/documentation.js
+++ b/src/_data/documentation.js
@@ -4,13 +4,15 @@ module.exports = {
         usage: "Usage",
         design: "Design",
         code: "Code",
-        tokens: "Tokens"
+        tokens: "Tokens",
+        "othernames": "Other names: "
     },
     fr: {
         usecase: "Cas d'utilisation",
         usage: "Usage",
         design: "Design",
         code: "Code",
-        tokens: "Tokens"
+        tokens: "Tokens",
+        "othernames": "Autres noms : "
     }
 }

--- a/src/_data/helpus.js
+++ b/src/_data/helpus.js
@@ -3,14 +3,14 @@ module.exports = {
     heading: "Help us improve",
     paragraph: "Have questions? Something you'd change or you'd like to see? Share your feedback with us to help improve GC Design System.",
     feedback: "Give feedback",
-    feedbackHref: "/en/contact",
+    feedbackHref: "/en/contact/#contact-us",
     github: "Get involved on GitHub"
   },
   fr: {
     heading: "Aidez-nous à nous améliorer",
     paragraph: "Avez-vous des questions? Y a-t-il quelque chose que vous changeriez ou ajouteriez? Faites-nous part de vos commentaires pour nous aider à améliorer Système de design GC.",
     feedback: "Fournir des commentaires",
-    feedbackHref: "/fr/contactez/",
+    feedbackHref: "/fr/contactez/#contactez-nous",
     github: "S'impliquer sur GitHub"
   }
 }

--- a/src/_data/lookingfor.js
+++ b/src/_data/lookingfor.js
@@ -1,7 +1,8 @@
 module.exports = {
   en : {
     heading: "Looking for another component?",
-    paragraph: "Check out our <a href=\"/en/components/\">component page</a>. If the component's not there, send us feedback on what you'd like us to work on next.",
+    coparagraph: "Check out our <a href=\"/en/components/\">component page</a>. If the component's not there, send us feedback on what you'd like us to work on next.",
+    csparagraph: "Share your feedback with us to help improve GC Design System or you can check out what's coming soon.",
     feedback: "Give feedback",
     feedbackHref: "/en/contact/#contact-us",
     gotocomponents: "Go to Component overview",
@@ -10,13 +11,14 @@ module.exports = {
     gotocomingsoonhref: "/en/coming-soon/"
   },
   fr: {
-    heading: "Looking for another component?",
-    paragraph: "Check out our <a href=\"/en/components/\">component page</a>. If the component's not there, send us feedback on what you'd like us to work on next.",
+    heading: "Vous cherchez un autre composant?",
+    coparagraph: "Rendez vous sur notre <a href=\"/fr/composants/\">page de composants</a>. S'il y manque un composant, écrivez nous pour nous faire savoir les composants que vous souhaitez voir dans le futur.",
+    csparagraph: "Faites-nous part de vos commentaires pour l'amélioration de Système de design GC ou découvrez nos futures fonctionnalités.",
     feedback: "Fournir des commentaires",
     feedbackHref: "/fr/contactez/#contactez-nous",
-    gotocomponents: "Go to Component overview",
-    gotocomponentshref: "/en/components/",
-    gotocomingsoon: "Go to Coming soon",
-    gotocomingsoonhref: "/en/coming-soon/"
+    gotocomponents: "Passer au survol des composants",
+    gotocomponentshref: "/fr/composants/",
+    gotocomingsoon: "Découvrir les prochaines nouveautés",
+    gotocomingsoonhref: "/fr/developpement-en-cours/"
   }
 }

--- a/src/_data/lookingfor.js
+++ b/src/_data/lookingfor.js
@@ -1,0 +1,22 @@
+module.exports = {
+  en : {
+    heading: "Looking for another component?",
+    paragraph: "Check out our <a href=\"/en/components/\">component page</a>. If the component's not there, send us feedback on what you'd like us to work on next.",
+    feedback: "Give feedback",
+    feedbackHref: "/en/contact/#contact-us",
+    gotocomponents: "Go to Component overview",
+    gotocomponentshref: "/en/components/",
+    gotocomingsoon: "Go to Coming soon",
+    gotocomingsoonhref: "/en/coming-soon/"
+  },
+  fr: {
+    heading: "Looking for another component?",
+    paragraph: "Check out our <a href=\"/en/components/\">component page</a>. If the component's not there, send us feedback on what you'd like us to work on next.",
+    feedback: "Fournir des commentaires",
+    feedbackHref: "/fr/contactez/#contactez-nous",
+    gotocomponents: "Go to Component overview",
+    gotocomponentshref: "/en/components/",
+    gotocomingsoon: "Go to Coming soon",
+    gotocomingsoonhref: "/en/coming-soon/"
+  }
+}

--- a/src/_includes/layouts/component-overview.njk
+++ b/src/_includes/layouts/component-overview.njk
@@ -5,3 +5,5 @@ layout: "layouts/base.njk"
 {{ content | safe }}
 
 {% include "partials/card-list.njk" %}
+
+{% include "partials/lookingfor.njk" %}

--- a/src/_includes/layouts/component-overview.njk
+++ b/src/_includes/layouts/component-overview.njk
@@ -4,30 +4,4 @@ layout: "layouts/base.njk"
 
 {{ content | safe }}
 
-{% set components = "componentsFR" if locale == "fr" else "componentsEN" %}
-
-{% set navPages = collections.all | eleventyNavigation(components) | sortAlpha %}
-
-<div class="bg-light mb-500 p-400">
-  <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" gap="400">
-  {%- for entry in navPages %}
-    {% if entry.url %}
-      <li class="list-none bg-white p-400 component-preview-box">
-        <a class="link-inherit link-no-underline" href={{entry.url}}>
-          <h3 class="d-flex align-items-start justify-content-between mb-150 pb-150 bb-sm">
-            {{ entry.title }}
-            {% if entry.tag %}
-              <span class="font-caption {% if entry.tag === 'Core' %}bg-black{% else %}bg-light-blue{% endif %} mt-100 ms-250 px-150 py-50 radius-md">
-                {{ entry.tag }}
-              </span>
-            {% endif %}
-          </h3>
-          <p class="mb-150 text-secondary"><small><em>Other names: {{ entry.otherNames }}</em></small></p>
-          <p class="mb-150">{{ entry.description }}</p>
-          <img src="{{ entry.thumbnail }}" alt="" />
-        </a>
-      </li>
-    {% endif %}
-  {%- endfor -%}
-  </gcds-grid>
-</div>
+{% include "partials/card-list.njk" %}

--- a/src/_includes/layouts/foundations-overview.njk
+++ b/src/_includes/layouts/foundations-overview.njk
@@ -4,18 +4,6 @@ layout: "layouts/base.njk"
 
 {{ content | safe }}
 
-{% set tokens = "foundationsFR" if locale == "fr" else "foundationsEN" %}
+{% include "partials/card-list.njk" %}
 
-{% set navPages = collections.all | eleventyNavigation(tokens) %}
-
-<ul>
-{%- for entry in navPages %}
-  <li>
-    <a href={{entry.url}}>
-      {{ entry.title }}
-      {{ entry.description }}
-      {{ entry.thumbnail }}
-    </a>
-  </li>
-{%- endfor -%}
-</ul>
+{% include "partials/helpus.njk" %}

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -46,6 +46,8 @@
         <section class="container-xl mx-auto xl:px-0 sm:px-500 px-300">
           {% block content %}{{ content | safe }}{% endblock %}
 
+          {% include "partials/helpus.njk" %}
+
           <gcds-date-modified class="mb-400 font-caption">
             {{ page.date | dateLastModified}}
           </gcds-date-modified>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -37,7 +37,7 @@
                 <article class="sm:py-550 py-450 xl:ps-0 sm:ps-500 ps-450 sm:pe-550 pe-400 bg-dark bg-full-width">
                   <h1 class="mb-400">Canadian Digital Service<br/>GC Design System</h1>
                   <p class="mb-400">Build modern, accessible, human government services people can use.</p>
-                  <a class="link-inherit" href="/en/contact/">About us</a>
+                  <a class="link-inherit" href="/en/contact/#about-gc-design-system">About us</a>
                 </article>
               </div>
             </div>

--- a/src/_includes/layouts/installation.njk
+++ b/src/_includes/layouts/installation.njk
@@ -36,6 +36,8 @@ layout: "layouts/base.njk"
   <gcds-button type="link" href="/en/components/">Browse components</gcds-button>
 </div>
 
+{% set removeBorder = true %}
+
 {% include "partials/helpus.njk" %}
 
 <script>

--- a/src/_includes/layouts/token-documentation.njk
+++ b/src/_includes/layouts/token-documentation.njk
@@ -26,6 +26,10 @@
 
     {{ content | safe }}
 
+    {% if tags[1] == "tokens" %}
+        {% set removeBorder = true %}
+    {% endif %}
+
     {% include "partials/helpus.njk" %}
 
 {% endblock %}

--- a/src/_includes/partials/card-list.njk
+++ b/src/_includes/partials/card-list.njk
@@ -25,7 +25,7 @@
             {% endif %}
           </h3>
           {% if entry.otherNames %}
-          <p class="mb-150 text-secondary"><small><em>Other names: {{ entry.otherNames }}</em></small></p>
+          <p class="mb-150 text-secondary"><small><em>{{ documentation[locale].othernames }}{{ entry.otherNames }}</em></small></p>
           {% endif %}
           <p class="mb-150">{{ entry.description }}</p>
           <img src="{{ entry.thumbnail }}" alt="" />

--- a/src/_includes/partials/card-list.njk
+++ b/src/_includes/partials/card-list.njk
@@ -1,0 +1,39 @@
+{% set components = [cardlist.type, locale | upper] | join %}
+
+{% if (cardlist.type == "components") %}
+  {% set navPages = collections.all | eleventyNavigation(components) | sortAlpha %}
+  {% set columnsDesktop = "1fr 1fr 1fr" %}
+{% else %}
+  {% set navPages = collections.all | eleventyNavigation(components) %}
+  {% set columnsDesktop = "1fr 1fr" %}
+{% endif %}
+
+<div class="bg-light mb-500 p-400">
+  <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="{{ columnsDesktop }}" gap="400">
+  {%- for entry in navPages %}
+    {% if entry.state == cardlist.state %}
+      <li class="list-none bg-white p-400 component-preview-box">
+        {% if entry.state == "published" %}
+        <a class="link-inherit link-no-underline" href={{entry.url}}>
+        {% endif %}
+          <h3 class="d-flex align-items-start justify-content-between mb-150 pb-150 bb-sm">
+            {{ entry.title }}
+            {% if entry.tag %}
+              <span class="font-caption {% if entry.tag === 'Core' %}bg-black{% else %}bg-light-blue{% endif %} mt-100 ms-250 px-150 py-50 radius-md">
+                {{ entry.tag }}
+              </span>
+            {% endif %}
+          </h3>
+          {% if entry.otherNames %}
+          <p class="mb-150 text-secondary"><small><em>Other names: {{ entry.otherNames }}</em></small></p>
+          {% endif %}
+          <p class="mb-150">{{ entry.description }}</p>
+          <img src="{{ entry.thumbnail }}" alt="" />
+        {% if entry.state == "published" %}
+        </a>
+        {% endif %}
+      </li>
+    {% endif %}
+  {%- endfor -%}
+  </gcds-grid>
+</div>

--- a/src/_includes/partials/helpus.njk
+++ b/src/_includes/partials/helpus.njk
@@ -1,33 +1,33 @@
-<hr />
+<section class="pt-100 mt-400 {% if removeBorder %} {% else %}bt-sm b-dark {% endif %}">
+  <h2 class="mt-300 mb-400">
+    {{ helpus[locale].heading }}
+  </h2>
 
-<h2 class="mt-500 mb-400">
-  {{ helpus[locale].heading }}
-</h2>
+  <p class="mb-400">
+    {{ helpus[locale].paragraph }}
+  </p>
 
-<p class="mb-400">
-	{{ helpus[locale].paragraph }}
-</p>
+  <ul class="mb-600">
+    <li class="md:d-inline sm:d-block me-200">
+      <gcds-button
+        type="link"
+        button-role="primary"
+        href="{{ helpus[locale].feedbackHref }}"
+      >
+        {{ helpus[locale].feedback }}
+      </gcds-button>
+    </li>
 
-<ul class="mb-600">
-	<li class="md:d-inline sm:d-block me-200">
-		<gcds-button
-			type="link"
-			button-role="primary"
-			href="{{ helpus[locale].feedbackHref }}"
-		>
-			{{ helpus[locale].feedback }}
-		</gcds-button>
-	</li>
-
-	<li class="md:d-inline sm:d-block mt-150 md:mt-0">
-		<gcds-button
-			type="link"
-			button-role="secondary"
-			target="_blank"
-			href="https://github.com/cds-snc/gcds-components"
-			lang="{{ locale }}"
-		>
-			{{ helpus[locale].github }}
-		</gcds-button>
-	</li>
-</ul>
+    <li class="md:d-inline sm:d-block mt-150 md:mt-0">
+      <gcds-button
+        type="link"
+        button-role="secondary"
+        target="_blank"
+        href="https://github.com/cds-snc/gcds-components"
+        lang="{{ locale }}"
+      >
+        {{ helpus[locale].github }}
+      </gcds-button>
+    </li>
+  </ul>
+</section>

--- a/src/_includes/partials/lookingfor.njk
+++ b/src/_includes/partials/lookingfor.njk
@@ -1,0 +1,40 @@
+{% if translationKey == "components" %}
+  {% set linkText = lookingfor[locale]["gotocomingsoon"] %}
+  {% set linkHref = lookingfor[locale]["gotocomingsoonhref"] %}
+{% else %}
+  {% set linkText = lookingfor[locale]["gotocomponents"] %}
+  {% set linkHref = lookingfor[locale]["gotocomponentshref"] %}
+{% endif %}
+
+<section class="pt-100 mt-400">
+  <h2 class="mt-300 mb-400">
+    {{ lookingfor[locale].heading }}
+  </h2>
+
+  <p class="mb-400">
+    {{ lookingfor[locale].paragraph | safe }}
+  </p>
+
+  <ul class="mb-600">
+    <li class="md:d-inline sm:d-block me-200">
+      <gcds-button
+        type="link"
+        button-role="primary"
+        href="{{ lookingfor[locale].feedbackHref }}"
+      >
+        {{ lookingfor[locale].feedback }}
+      </gcds-button>
+    </li>
+
+    <li class="md:d-inline sm:d-block mt-150 md:mt-0">
+      <gcds-button
+        type="link"
+        button-role="secondary"
+        href="{{ linkHref }}"
+        lang="{{ locale }}"
+      >
+        {{ linkText }}
+      </gcds-button>
+    </li>
+  </ul>
+</section>

--- a/src/_includes/partials/lookingfor.njk
+++ b/src/_includes/partials/lookingfor.njk
@@ -1,9 +1,11 @@
 {% if translationKey == "components" %}
   {% set linkText = lookingfor[locale]["gotocomingsoon"] %}
   {% set linkHref = lookingfor[locale]["gotocomingsoonhref"] %}
+  {% set paragraph = lookingfor[locale]["csparagraph"] %}
 {% else %}
   {% set linkText = lookingfor[locale]["gotocomponents"] %}
   {% set linkHref = lookingfor[locale]["gotocomponentshref"] %}
+  {% set paragraph = lookingfor[locale]["coparagraph"] %}
 {% endif %}
 
 <section class="pt-100 mt-400">
@@ -12,7 +14,7 @@
   </h2>
 
   <p class="mb-400">
-    {{ lookingfor[locale].paragraph | safe }}
+    {{ paragraph | safe }}
   </p>
 
   <ul class="mb-600">

--- a/src/en/coming-soon.md
+++ b/src/en/coming-soon.md
@@ -1,0 +1,12 @@
+---
+title: Coming soon
+translationKey: comingsoon
+layout: "layouts/component-overview.njk"
+cardlist:
+  type: components
+  state: coming-soon
+---
+
+# {{ title }}
+
+We’re sharing components as we build them. Check out what components we’re currently working on and what’s on the way.

--- a/src/en/coming-soon.md
+++ b/src/en/coming-soon.md
@@ -2,6 +2,11 @@
 title: Coming soon
 translationKey: comingsoon
 layout: "layouts/component-overview.njk"
+eleventyNavigation:
+  key: comingsoonEN
+  title: Coming soon
+  locale: en
+  hideMain: true
 cardlist:
   type: components
   state: coming-soon

--- a/src/en/components/button/use-case.md
+++ b/src/en/components/button/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: An interactive object that highlights an action.
   thumbnail: /images/en/components/preview-button.svg
   alt: This is an image of the component
+  state: published
 translationKey: "button"
 tags: ['buttonEN', 'usage']
 permalink: /en/components/button/

--- a/src/en/components/checkbox/use-case.md
+++ b/src/en/components/checkbox/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: A question where any available options can be selected.
   thumbnail: /images/common/components/preview-checkbox.svg
   alt: This is an image of the component
+  state: published
 translationKey: "checkbox"
 tags: ['checkboxEN', 'usage']
 permalink: /en/components/checkbox/

--- a/src/en/components/components.md
+++ b/src/en/components/components.md
@@ -8,6 +8,9 @@ eleventyNavigation:
   order: 2
 translationKey: "components"
 date: "git Last Modified"
+cardlist:
+  type: components
+  state: published
 ---
 
 # {{ title }}

--- a/src/en/components/date-modified/use-case.md
+++ b/src/en/components/date-modified/use-case.md
@@ -1,16 +1,17 @@
 ---
-title: date-modified - Components
+title: Date modified
 layout: "layouts/component-documentation.njk"
 eleventyNavigation:
   key: datemodifiedEN
   title: Date modified
   locale: en
   parent: componentsEN
-  otherNames:  Component
-  description: This is the component
+  otherNames:  last modified
+  description: A timestamp of the last -page update.
   thumbnail: /images/common/components/preview-date-modified.svg
   alt: This is an image of the component
   tag: Core
+  state: coming-soon
 translationKey: "datemodified"
 tags: ['datemodifiedEN', 'usage']
 permalink: /en/components/date-modified/

--- a/src/en/components/details/use-case.md
+++ b/src/en/components/details/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: An interactive toggle to hide and expose content.
   thumbnail: /images/common/components/preview-details.svg
   alt: This is an image of the component
+  state: published
 translationKey: "details"
 tags: ['detailsEN', 'usage']
 permalink: /en/components/details/

--- a/src/en/components/error-summary/base.md
+++ b/src/en/components/error-summary/base.md
@@ -1,0 +1,13 @@
+---
+github: https://github.com/cds-snc/gcds-components/tree/main/src/components/gcds-error-summary
+figma: https://www.figma.com/community/file/1128687821123298228
+permalink: false
+tags: ['errorsummaryEN', 'header']
+---
+
+# error-summary
+
+This element will have the content below it
+
+{% docLinks locale stage figma github %}
+{% enddocLinks %}

--- a/src/en/components/error-summary/code.md
+++ b/src/en/components/error-summary/code.md
@@ -1,0 +1,8 @@
+---
+title: Error summary
+layout: "layouts/component-documentation.njk"
+translationKey: "errorsummaryCode"
+tags: ['errorsummaryEN', 'code']
+---
+
+## Code

--- a/src/en/components/error-summary/design.md
+++ b/src/en/components/error-summary/design.md
@@ -1,0 +1,8 @@
+---
+title: Error summary
+layout: "layouts/component-documentation.njk"
+translationKey: "errorsummaryDesign"
+tags: ['errorsummaryEN', 'design']
+---
+
+## Design

--- a/src/en/components/error-summary/use-case.md
+++ b/src/en/components/error-summary/use-case.md
@@ -1,0 +1,19 @@
+---
+title: Error summary
+layout: "layouts/component-documentation.njk"
+eleventyNavigation:
+  key: errorsummaryEN
+  title: Error summary
+  locale: en
+  parent: componentsEN
+  otherNames: Error overview
+  description: A list of user errors on a page or in a flow.
+  thumbnail:  /images/common/components/preview-error-summary.svg
+  alt: This is an image of the component
+  state: coming-soon
+translationKey: "errorsummary"
+tags: ['errorsummaryEN', 'usage']
+permalink: /en/components/error-summary/
+---
+
+## Use case

--- a/src/en/components/fieldset/use-case.md
+++ b/src/en/components/fieldset/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: A group of multiple form components.
   thumbnail: /images/common/components/preview-fieldset.svg
   alt: This is an image of the component
+  state: published
 translationKey: "fieldset"
 tags: ['fieldsetEN', 'usage']
 permalink: /en/components/fieldset/

--- a/src/en/components/file-uploader/use-case.md
+++ b/src/en/components/file-uploader/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: A file selector for upload.
   thumbnail: /images/en/components/preview-file-uploader.svg
   alt: This is an image of the component
+  state: coming-soon
 translationKey: "fileuploader"
 tags: ['fileuploaderEN', 'usage']
 permalink: /en/components/file-uploader/

--- a/src/en/components/footer/use-case.md
+++ b/src/en/components/footer/use-case.md
@@ -11,6 +11,7 @@ eleventyNavigation:
   thumbnail: /images/common/components/preview-footer.svg
   alt: This is an image of the component
   tag: Core
+  state: published
 translationKey: "footer"
 tags: ['footerEN', 'usage']
 permalink: /en/components/footer/

--- a/src/en/components/header/use-case.md
+++ b/src/en/components/header/use-case.md
@@ -11,6 +11,7 @@ eleventyNavigation:
   thumbnail: /images/common/components/preview-header.svg
   alt: This is an image of the component
   tag: Core
+  state: published
 translationKey: "header"
 tags: ['headerEN', 'usage']
 permalink: /en/components/header/

--- a/src/en/components/icon/use-case.md
+++ b/src/en/components/icon/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: A visual cue to help users understand the context.
   thumbnail: /images/common/components/preview-icons.svg
   alt: This is an image of the component
+  state: coming-soon
 translationKey: "icon"
 tags: ['iconEN', 'usage']
 permalink: /en/components/icon/

--- a/src/en/components/input/use-case.md
+++ b/src/en/components/input/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: A space to enter short-form information.
   thumbnail: /images/common/components/preview-input.svg
   alt: This is an image of the component
+  state: published
 translationKey: "input"
 tags: ['inputEN', 'usage']
 permalink: /en/components/input/

--- a/src/en/components/pagination/use-case.md
+++ b/src/en/components/pagination/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: A navigation signpost for a series of non-process pages.
   thumbnail: /images/common/components/preview-pagination.svg
   alt: This is an image of the component
+  state: coming-soon
 translationKey: "pagination"
 tags: ['paginationEN', 'usage']
 permalink: /en/components/pagination/

--- a/src/en/components/radio/use-case.md
+++ b/src/en/components/radio/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: A question with a set of options for single selections.
   thumbnail: /images/common/components/preview-radio.svg
   alt: This is an image of the component
+  state: published
 translationKey: "radio"
 tags: ['radioEN', 'usage']
 permalink: /en/components/radio/

--- a/src/en/components/select/use-case.md
+++ b/src/en/components/select/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: A list of options with a single-option choice.
   thumbnail: /images/common/components/preview-select.svg
   alt: This is an image of the component
+  state: coming-soon
 translationKey: "select"
 tags: ['selectEN', 'usage']
 permalink: /en/components/select/

--- a/src/en/components/stepper/use-case.md
+++ b/src/en/components/stepper/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: A progress tracker for a multi-step process.
   thumbnail: /images/en/components/preview-stepper.svg
   alt: This is an image of the component
+  state: published
 translationKey: "stepper"
 tags: ['stepperEN', 'usage']
 permalink: /en/components/stepper/

--- a/src/en/components/textarea/use-case.md
+++ b/src/en/components/textarea/use-case.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: A space to enter long-form information.
   thumbnail: /images/common/components/preview-textarea.svg
   alt: This is an image of the component
+  state: published
 translationKey: "textarea"
 tags: ['textareaEN', 'usage']
 permalink: /en/components/textarea/

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -11,16 +11,28 @@ contactForm: en
 date: "git Last Modified"
 ---
 
-# Contact us
+# About GC Design System
+
+## Build modern, accessible, human government services people can use
+
+GC Design System pairs code with designs and guidance based on federal standards and accessibility best practice. <a href="#" target="_blank">Reusable components <gcds-icon name="external-link" label="Opens in a new tab." margin-left="200" /></a> and <a href="#" target="_blank">styles <gcds-icon name="external-link" label="Opens in a new tab." margin-left="200" /></a> help you to build forms, websites, and applications.
+
+This is a design system for the Canadian Digital Service built by a small team of public servants. We believe modern, efficient design and development can improve the quality of people’s experiences with government services. We hope to raise the bar for consistent, inclusive user interfaces across digital products.
+
+GC Design System works in the environment you want to work in. You’ll get the same patterns and styles across products and browsers without having to code from scratch or redefine values. It works independently of GC Web and the Web Experience Toolkit (WET).
+
+Have questions? Something you’d change or you’d like to see? Share your feedback with us to help improve GC Design System.
+
+## Contact us
 
 Ask the GC Design System team about a component in the design system or request a component you'd like to see.
 
-Fill out the following form or submit an issue through GitHub for [tokens]({{ "https://github.com/cds-snc/gcds-tokens" | url}}), [components]({{ "https://github.com/cds-snc/gcds-components" | url}}), or [documentation]({{ "https://github.com/cds-snc/gcds-docs" | url}}).
+Fill out the following form or submit an issue through GitHub for <a href="https://github.com/cds-snc/gcds-tokens" target="_blank">tokens <gcds-icon name="external-link" label="Opens in a new tab." margin-left="200" /></a>, <a href="https://github.com/cds-snc/gcds-components" target="_blank">components <gcds-icon name="external-link" label="Opens in a new tab." margin-left="200" /></a>, or <a href="https://github.com/cds-snc/gcds-docs" target="_blank">documentation <gcds-icon name="external-link" label="Opens in a new tab." margin-left="200" /></a>.
 
 <form class="my-500 contact-us-form" name="contactEN" method="post">
   <input type="hidden" name="form-name" value="contactEN" />
-  <gcds-input type="text" input-id="name" label="Full name" required></gcds-input>
-  <gcds-input type="email" input-id="email" label="Email address" required></gcds-input>
+  <gcds-input type="text" input-id="name" label="Full name" size="30" required></gcds-input>
+  <gcds-input type="email" input-id="email" label="Email address" size="30" required></gcds-input>
   <gcds-textarea label="Message" textarea-id="message" required></gcds-textarea>
   <div hidden>
     <gcds-input type="text" input-id="bot-field" label="bot"></gcds-input>

--- a/src/en/foundations/colour/usage.md
+++ b/src/en/foundations/colour/usage.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the foundation
   thumbnail: /images/en/foundations/foundation.png
   alt: This is an image of the foundation
+  state: published
 permalink: /en/foundations/colour/
 translationKey: "colour"
 tags: ["colourEN", "usage"]

--- a/src/en/foundations/design-tokens/design-tokens.md
+++ b/src/en/foundations/design-tokens/design-tokens.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the foundation
   thumbnail: /images/en/foundations/foundation.png
   alt: This is an image of the foundation
+  state: published
 translationKey: "designtokens"
 date: "git Last Modified"
 ---

--- a/src/en/foundations/foundations.md
+++ b/src/en/foundations/foundations.md
@@ -9,6 +9,9 @@ eleventyNavigation:
 translationKey: "foundatons"
 github: https://github.com/cds-snc/gcds-tokens
 date: "git Last Modified"
+cardlist:
+  type: foundations
+  state: published
 ---
 
 # {{ title }}

--- a/src/en/foundations/spacing/usage.md
+++ b/src/en/foundations/spacing/usage.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the foundation
   thumbnail: /images/en/foundations/foundation.png
   alt: This is an image of the foundation
+  state: published
 permalink: /en/foundations/spacing/
 translationKey: "spacing"
 tags: ["spacingEN", "usage"]

--- a/src/en/foundations/typography/usage.md
+++ b/src/en/foundations/typography/usage.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the foundation
   thumbnail: /images/en/foundations/foundation.png
   alt: This is an image of the foundation
+  state: published
 permalink: /en/foundations/typography/
 translationKey: "typography"
 tags: ["typographyEN", "usage"]

--- a/src/fr/bases/bases.md
+++ b/src/fr/bases/bases.md
@@ -9,6 +9,9 @@ eleventyNavigation:
 translationKey: "foundatons"
 github: https://github.com/cds-snc/gcds-tokens
 date: "git Last Modified"
+cardlist:
+  type: foundations
+  state: published
 ---
 
 # {{ title }}

--- a/src/fr/bases/couleur/usage.md
+++ b/src/fr/bases/couleur/usage.md
@@ -11,6 +11,7 @@ eleventyNavigation:
   description: This is the foundation
   thumbnail: /images/fr/bases/foundation.png
   alt: This is an image of the foundation
+  state: published
 permalink: /fr/bases/couleur/
 tags: ['colourFR', 'usage']
 date: "git Last Modified"

--- a/src/fr/bases/espacement/usage.md
+++ b/src/fr/bases/espacement/usage.md
@@ -11,6 +11,7 @@ eleventyNavigation:
   description: This is the foundation
   thumbnail: /images/fr/bases/foundation.png
   alt: This is an image of the foundation
+  state: published
 permalink: /fr/bases/espacement/
 tags: ['spacingFR', 'usage']
 date: "git Last Modified"

--- a/src/fr/bases/typographie/usage.md
+++ b/src/fr/bases/typographie/usage.md
@@ -11,6 +11,7 @@ eleventyNavigation:
   description: This is the foundation
   thumbnail: /images/fr/bases/foundation.png
   alt: This is an image of the foundation
+  state: published
 github: https://github.com/cds-snc/gcds-tokens
 permalink: /fr/bases/typographie/
 tags: ['typographyFR', 'usage']

--- a/src/fr/bases/unites-de-style/unites-de-style.md
+++ b/src/fr/bases/unites-de-style/unites-de-style.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the foundation
   thumbnail: /images/fr/bases/foundation.png
   alt: This is an image of the foundation
+  state: published
 translationKey: "designtokens"
 date: "git Last Modified"
 ---

--- a/src/fr/composants/Case-a-cocher/case-dusage.md
+++ b/src/fr/composants/Case-a-cocher/case-dusage.md
@@ -8,8 +8,9 @@ eleventyNavigation:
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/common/components/preview-checkbox.svg
   alt: This is an image of the component
+  state: published
 translationKey: "checkbox"
 tags: ['checkboxFR', 'usage']
 permalink: /fr/composants/case-a-cocher/

--- a/src/fr/composants/bouton/case-dusage.md
+++ b/src/fr/composants/bouton/case-dusage.md
@@ -8,8 +8,9 @@ eleventyNavigation:
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/en/components/preview-button.svg
   alt: This is an image of the component
+  state: published
 translationKey: "button"
 tags: ['buttonFR', 'usage']
 permalink: /fr/composants/bouton/

--- a/src/fr/composants/champ-de-saisie/case-dusage.md
+++ b/src/fr/composants/champ-de-saisie/case-dusage.md
@@ -8,8 +8,9 @@ eleventyNavigation:
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/common/components/preview-input.svg
   alt: This is an image of the component
+  state: published
 translationKey: "input"
 tags: ['inputFR', 'usage']
 permalink: /fr/composants/champ-de-saisie/

--- a/src/fr/composants/composants.md
+++ b/src/fr/composants/composants.md
@@ -8,6 +8,9 @@ eleventyNavigation:
   order: 2
 translationKey: "components"
 date: "git Last Modified"
+cardlist:
+  type: components
+  state: published
 ---
 
 # Composants

--- a/src/fr/composants/date-de-modification/case-dusage.md
+++ b/src/fr/composants/date-de-modification/case-dusage.md
@@ -1,14 +1,14 @@
 ---
-title: date-de-modification - Composants
+title: Date de modification
 layout: "layouts/component-documentation.njk"
 eleventyNavigation:
   key: datemodifiedFR
-  title: date-de-modification
+  title: Date de modification
   locale: fr
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/common/components/preview-date-modified.svg
   alt: This is an image of the component
   state: coming-soon
 translationKey: "datemodified"

--- a/src/fr/composants/date-de-modification/case-dusage.md
+++ b/src/fr/composants/date-de-modification/case-dusage.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the component
   thumbnail: /images/fr/composants/component.png
   alt: This is an image of the component
+  state: coming-soon
 translationKey: "datemodified"
 tags: ['datemodifiedFR', 'usage']
 permalink: /fr/composants/date-de-modification/

--- a/src/fr/composants/details/case-dusage.md
+++ b/src/fr/composants/details/case-dusage.md
@@ -8,8 +8,9 @@ eleventyNavigation:
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/common/components/preview-details.svg
   alt: This is an image of the component
+  state: published
 translationKey: "details"
 tags: ['detailsFR', 'usage']
 permalink: /fr/composants/details/

--- a/src/fr/composants/en-tete/case-dusage.md
+++ b/src/fr/composants/en-tete/case-dusage.md
@@ -8,8 +8,9 @@ eleventyNavigation:
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/common/components/preview-header.svg
   alt: This is an image of the component
+  state: published
 translationKey: "header"
 tags: ['headerFR', 'usage']
 permalink: /fr/composants/en-tete/

--- a/src/fr/composants/icone/case-dusage.md
+++ b/src/fr/composants/icone/case-dusage.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the component
   thumbnail: /images/fr/composants/component.png
   alt: This is an image of the component
+  state: coming-soon
 translationKey: "icon"
 tags: ['iconFR', 'usage']
 permalink: /fr/composants/icone/

--- a/src/fr/composants/icone/case-dusage.md
+++ b/src/fr/composants/icone/case-dusage.md
@@ -1,14 +1,14 @@
 ---
-title: icone - Composants
+title: Icône
 layout: "layouts/component-documentation.njk"
 eleventyNavigation:
   key: iconFR
-  title: icone
+  title: Icône
   locale: fr
   parent: componentsFR
-  otherNames:  Component
-  description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  otherNames: glyphe, image, symbole
+  description: Un repère visuel pour aider les utilisateur·rice·s à comprendre le contexte.
+  thumbnail: /images/common/components/preview-icons.svg
   alt: This is an image of the component
   state: coming-soon
 translationKey: "icon"

--- a/src/fr/composants/indicateur-detape/case-dusage.md
+++ b/src/fr/composants/indicateur-detape/case-dusage.md
@@ -8,8 +8,9 @@ eleventyNavigation:
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/en/components/preview-stepper.svg
   alt: This is an image of the component
+  state: published
 translationKey: "stepper"
 tags: ['stepperFR', 'usage']
 permalink: /fr/composants/indicateur-detape/

--- a/src/fr/composants/jeu-de-champs/case-dusage.md
+++ b/src/fr/composants/jeu-de-champs/case-dusage.md
@@ -8,8 +8,9 @@ eleventyNavigation:
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/common/components/preview-fieldset.svg
   alt: This is an image of the component
+  state: published
 translationKey: "fieldset"
 tags: ['fieldsetFR', 'usage']
 permalink: /fr/composants/jeu-de-champs/

--- a/src/fr/composants/pagination/case-dusage.md
+++ b/src/fr/composants/pagination/case-dusage.md
@@ -1,14 +1,14 @@
 ---
-title: pagination - Composants
+title: Pagination
 layout: "layouts/component-documentation.njk"
 eleventyNavigation:
   key: paginationFR
-  title: pagination
+  title: Pagination
   locale: fr
   parent: componentsFR
-  otherNames:  Component
-  description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  otherNames:  navigation entre les pages
+  description: Un indicateur de navigation pour une série de pages sans processus.
+  thumbnail: /images/common/components/preview-pagination.svg
   alt: This is an image of the component
   state: coming-soon
 translationKey: "pagination"

--- a/src/fr/composants/pagination/case-dusage.md
+++ b/src/fr/composants/pagination/case-dusage.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the component
   thumbnail: /images/fr/composants/component.png
   alt: This is an image of the component
+  state: coming-soon
 translationKey: "pagination"
 tags: ['paginationFR', 'usage']
 permalink: /fr/composants/pagination/

--- a/src/fr/composants/pied-de-page/case-dusage.md
+++ b/src/fr/composants/pied-de-page/case-dusage.md
@@ -8,8 +8,9 @@ eleventyNavigation:
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/common/components/preview-footer.svg
   alt: This is an image of the component
+  state: published
 translationKey: "footer"
 tags: ['footerFR', 'usage']
 permalink: /fr/composants/pied-de-page/

--- a/src/fr/composants/radio/case-dusage.md
+++ b/src/fr/composants/radio/case-dusage.md
@@ -8,8 +8,9 @@ eleventyNavigation:
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/common/components/preview-radio.svg
   alt: This is an image of the component
+  state: published
 translationKey: "radio"
 tags: ['radioFR', 'usage']
 permalink: /fr/composants/radio/

--- a/src/fr/composants/resume-de-erreurs/base.md
+++ b/src/fr/composants/resume-de-erreurs/base.md
@@ -1,0 +1,13 @@
+---
+github: https://github.com/cds-snc/gcds-components/tree/main/src/components/gcds-error-summary
+figma: https://www.figma.com/community/file/1128687821123298228
+permalink: false
+tags: ['errorsummaryFR', 'header']
+---
+
+# resume-de-erreurs
+
+This element will have the content below it
+
+{% docLinks locale stage figma github %}
+{% enddocLinks %}

--- a/src/fr/composants/resume-de-erreurs/case-dusage.md
+++ b/src/fr/composants/resume-de-erreurs/case-dusage.md
@@ -1,0 +1,19 @@
+---
+title: Résumé des erreurs
+layout: "layouts/component-documentation.njk"
+eleventyNavigation:
+  key: errorsummaryFR
+  title: Résumé des erreurs
+  locale: fr
+  parent: componentsFR
+  otherNames: vue d’ensemble des erreurs
+  description: Liste des erreurs rencontrées par l’utilisateur·rice sur une page ou dans le cadre d’un flux.
+  thumbnail: /images/common/components/preview-error-summary.svg
+  alt: This is an image of the component
+  state: coming-soon
+translationKey: "errorsummary"
+tags: ['errorsummaryFR', 'usage']
+permalink: /fr/composants/resume-de-erreurs/
+---
+
+## Use case

--- a/src/fr/composants/resume-de-erreurs/code.md
+++ b/src/fr/composants/resume-de-erreurs/code.md
@@ -1,0 +1,8 @@
+---
+title: resume-de-erreurs - Composants
+layout: "layouts/component-documentation.njk"
+translationKey: "errorsummaryCode"
+tags: ['errorsummaryFR', 'code']
+---
+
+## Code

--- a/src/fr/composants/resume-de-erreurs/design.md
+++ b/src/fr/composants/resume-de-erreurs/design.md
@@ -1,0 +1,8 @@
+---
+title: resume-de-erreurs - Composants
+layout: "layouts/component-documentation.njk"
+translationKey: "errorsummaryDesign"
+tags: ['errorsummaryFR', 'design']
+---
+
+## Design

--- a/src/fr/composants/selection/case-dusage.md
+++ b/src/fr/composants/selection/case-dusage.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the component
   thumbnail: /images/fr/composants/component.png
   alt: This is an image of the component
+  state: coming-soon
 translationKey: "select"
 tags: ['selectFR', 'usage']
 permalink: /fr/composants/selection/

--- a/src/fr/composants/selection/case-dusage.md
+++ b/src/fr/composants/selection/case-dusage.md
@@ -1,14 +1,14 @@
 ---
-title: selection - Composants
+title: Sélection
 layout: "layouts/component-documentation.njk"
 eleventyNavigation:
   key: selectFR
-  title: selection
+  title: Sélection
   locale: fr
   parent: componentsFR
-  otherNames:  Component
-  description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  otherNames: menu déroulant, menu de sélection
+  description: Une liste d’options permettant de choisir une option unique. 
+  thumbnail: /images/common/components/preview-select.svg
   alt: This is an image of the component
   state: coming-soon
 translationKey: "select"

--- a/src/fr/composants/televerseur-de-fichiers/case-dusage.md
+++ b/src/fr/composants/televerseur-de-fichiers/case-dusage.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: This is the component
   thumbnail: /images/fr/composants/component.png
   alt: This is an image of the component
+  state: coming-soon
 translationKey: "fileuploader"
 tags: ['fileuploaderFR', 'usage']
 permalink: /fr/composants/televerseur-de-fichiers/

--- a/src/fr/composants/televerseur-de-fichiers/case-dusage.md
+++ b/src/fr/composants/televerseur-de-fichiers/case-dusage.md
@@ -1,14 +1,14 @@
 ---
-title: televerseur-de-fichiers - Composants
+title: Téléverseur de fichiers
 layout: "layouts/component-documentation.njk"
 eleventyNavigation:
   key: fileuploaderFR
-  title: televerseur-de-fichiers
+  title: Téléverseur de fichiers
   locale: fr
   parent: componentsFR
-  otherNames:  Component
-  description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  otherNames: saisie de fichier, zone de dépôt
+  description: Un sélecteur de fichier en vue d’un téléversement.
+  thumbnail: /images/fr/components/preview-date-modified.svg
   alt: This is an image of the component
   state: coming-soon
 translationKey: "fileuploader"

--- a/src/fr/composants/zone-de-texte/case-dusage.md
+++ b/src/fr/composants/zone-de-texte/case-dusage.md
@@ -8,8 +8,9 @@ eleventyNavigation:
   parent: componentsFR
   otherNames:  Component
   description: This is the component
-  thumbnail: /images/fr/composants/component.png
+  thumbnail: /images/common/components/preview-textarea.svg
   alt: This is an image of the component
+  state: published
 translationKey: "textarea"
 tags: ['textareaFR', 'usage']
 permalink: /fr/composants/zone-de-texte/

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -19,8 +19,8 @@ Remplissez les champs suivants ou ouvrez une issue sur GitHub dans le dépôt de
 
 <form class="my-500 contact-us-form" name="contactFR" method="post">
   <input type="hidden" name="form-name" value="contactFR" />
-  <gcds-input type="text" input-id="name" label="Nom complet" required></gcds-input>
-  <gcds-input type="email" input-id="email" label="Adresse courriel" required></gcds-input>
+  <gcds-input type="text" input-id="name" label="Nom complet" size="30" required></gcds-input>
+  <gcds-input type="email" input-id="email" label="Adresse courriel" size="30" required></gcds-input>
   <gcds-textarea label="Message" textarea-id="message" required></gcds-textarea>
   <div hidden>
     <gcds-input type="text" input-id="bot-field" label="bot"></gcds-input>

--- a/src/fr/developpement-en-cours.md
+++ b/src/fr/developpement-en-cours.md
@@ -1,0 +1,11 @@
+---
+title: Développement en cours
+translationKey: comingsoon
+layout: "layouts/component-overview.njk"
+cardlist:
+  type: components
+  state: coming-soon
+---
+
+# {{ title }}
+

--- a/src/fr/developpement-en-cours.md
+++ b/src/fr/developpement-en-cours.md
@@ -2,6 +2,11 @@
 title: Développement en cours
 translationKey: comingsoon
 layout: "layouts/component-overview.njk"
+eleventyNavigation:
+  key: comingsoonFR
+  title: Développement en cours
+  locale: fr
+  hideMain: true
 cardlist:
   type: components
   state: coming-soon


### PR DESCRIPTION
# Summary | Résumé

Add multiple new pages and partials to help support them.

- Added coming-soon page
- Added card-list partial to render list of cards used on foundations, components and coming soon
  -  Added new `state` key to `eleventyNavigation`. Two options of ` published` and `coming-soon` to set which page the component renders on.
  - `cardlist` object added to overview pages frontmatter with a `type` and `state` key for rendering in card-list partial
- Added a `lookingfor` partial to load the "Looking for a component section". (needs translation)
- Added additional option to remove border from top of `helpus` partial. Set before including partial.
- Added About us section to english contact page.
