### PR TITLE
Fix tab rendering + table a11y fix

### DIFF
--- a/src/_includes/layouts/component-documentation.njk
+++ b/src/_includes/layouts/component-documentation.njk
@@ -1,5 +1,9 @@
 {% extends "layouts/base.njk" %}
 
+{% if tags %}
+  {% set tabs = collections.all | tabs(tags[0]) %}
+{% endif %}
+
 {% block content %}
   {% if tabs %}
     {{ tabs.header.templateContent | safe }}

--- a/src/_includes/layouts/token-documentation.njk
+++ b/src/_includes/layouts/token-documentation.njk
@@ -1,5 +1,9 @@
 {% extends "layouts/base.njk" %}
 
+{% if tags %}
+  {% set tabs = collections.all | tabs(tags[0]) %}
+{% endif %}
+
 {% block content %}
   {% if tabs %}
     {{ tabs.header.templateContent | safe }}

--- a/src/_includes/partials/token_table.njk
+++ b/src/_includes/partials/token_table.njk
@@ -2,7 +2,11 @@
     <table class="table-display-token-{{type}}">
         <tr>
             {%- for header in tokenTable.headers -%}
+                {% if header[0] == "color-preview" or header[0] == "spacing-preview" or header[0] == "font-preview"  %}
+                <td>{{ header[1] }}</td>
+                {% else %}
                 <th>{{ header[1] }}</th>
+                {% endif %}
             {%- endfor -%}
         </tr>
     {%- comment -%}


### PR DESCRIPTION
# Summary | Résumé

- Fix tab rendering by adding tabs collection back to component/foundation documentation layouts
- Change token_table partial to render an empty `<td>` instead of `<th>` in table heading row for preview coloumns
