### PR TITLE
Update content partials

### DIFF
--- a/src/_data/errormessage.js
+++ b/src/_data/errormessage.js
@@ -1,20 +1,22 @@
 module.exports = {
   en : {
-    heading: "Handling required fields and error messages",
+    heading: "Handle error messages and validation",
     listitems: [
-      "Use the required attribute for fields that must be filled in. This will place “required” at the end of the field label. Avoid adding red text and additional symbols or punctuation, like the asterisk (*).",
-      "Use the error message component to address missing and invalid entries for all required inputs. Avoid using them for optional ones.",
-      "Place an inline error message just before the input (either to its immediate left or above it) so it's noticeable.",
-      "Avoid placing hint text or error messages below the container where they might be hidden.",
+      "Use the `required` atrribute to activate the required validator. Validation will happen by default on the `onBlur` event.",
+      "If you need to change the validation event, use the `validate-on` attribute. Validation can happen on blur, when the element loses focus, or manually with the validate method.",
+      "Use the `required` attribute for fields that must be filled in. This places “(required)” at the end of the label.",
+      "Keep the default `error-message` attribute for a required input that needs validation. A missing or invalid entry will prompt an inline error message.",
+      "Remove the default `error-message` attribute if the input is optional.",
     ]
   },
   fr: {
-    heading: "Handling required fields and error messages",
+    heading: "Traitez les messages d'erreur et la validation",
     listitems: [
-      "Use the required attribute for fields that must be filled in. This will place “required” at the end of the field label. Avoid adding red text and additional symbols or punctuation, like the asterisk (*).",
-      "Use the error message component to address missing and invalid entries for all required inputs. Avoid using them for optional ones.",
-      "Place an inline error message just before the input (either to its immediate left or above it) so it's noticeable.",
-      "Avoid placing hint text or error messages below the container where they might be hidden.",
+      "Utilisez l'attribut « required » pour activer le validateur nécessaire. La validation s'effectuera par défaut pendant l'événement `onBlur`.",
+      "Si vous devez modifier l'événement de validation, utilisez l'attribut « validate-on ». Une validation onBlur est possible lorsque l'élément n'est plus ciblé. Il est également possible de procéder à une validation manuelle avec la méthode « validate ».",
+      "Employez l'attribut « required » pour les champs obligatoires. Cet attribut insérera la mention « (obligatoire) » à la fin de la case à cocher.",
+      "Conservez l'attribut « error-message » par défaut pour une zone de texte obligatoire qui doit être validée. Une entrée manquante ou non valide affichera un message d'erreur intercalé.",
+      "Supprimez l'attribut « error-message » par défaut si la zone de texte est facultative.",
     ]
   }
 }

--- a/src/_data/errormessage.js
+++ b/src/_data/errormessage.js
@@ -3,7 +3,7 @@ module.exports = {
     heading: "Handle error messages and validation",
     listitems: [
       "Use the `required` atrribute to activate the required validator. Validation will happen by default on the `onBlur` event.",
-      "If you need to change the validation event, use the `validate-on` attribute. Validation can happen on blur, when the element loses focus, or manually with the validate method.",
+      "If you need to change the validation event, use the `validate-on` attribute. Validation can happen on blur, when the element loses focus, or manually with the `validate()` method.",
       "Use the `required` attribute for fields that must be filled in. This places “(required)” at the end of the label.",
       "Keep the default `error-message` attribute for a required input that needs validation. A missing or invalid entry will prompt an inline error message.",
       "Remove the default `error-message` attribute if the input is optional.",
@@ -12,11 +12,11 @@ module.exports = {
   fr: {
     heading: "Traitez les messages d'erreur et la validation",
     listitems: [
-      "Utilisez l'attribut « required » pour activer le validateur nécessaire. La validation s'effectuera par défaut pendant l'événement `onBlur`.",
-      "Si vous devez modifier l'événement de validation, utilisez l'attribut « validate-on ». Une validation onBlur est possible lorsque l'élément n'est plus ciblé. Il est également possible de procéder à une validation manuelle avec la méthode « validate ».",
-      "Employez l'attribut « required » pour les champs obligatoires. Cet attribut insérera la mention « (obligatoire) » à la fin de la case à cocher.",
-      "Conservez l'attribut « error-message » par défaut pour une zone de texte obligatoire qui doit être validée. Une entrée manquante ou non valide affichera un message d'erreur intercalé.",
-      "Supprimez l'attribut « error-message » par défaut si la zone de texte est facultative.",
+      "Utilisez l'attribut `required` pour activer le validateur nécessaire. La validation s'effectuera par défaut pendant l'événement `onBlur`.",
+      "Si vous devez modifier l'événement de validation, utilisez l'attribut `validate-on`. Une validation onBlur est possible lorsque l'élément n'est plus ciblé. Il est également possible de procéder à une validation manuelle avec la méthode `validate()`.",
+      "Employez l'attribut `required` pour les champs obligatoires. Cet attribut insérera la mention « (obligatoire) » à la fin de la case à cocher.",
+      "Conservez l'attribut `error-message` par défaut pour une zone de texte obligatoire qui doit être validée. Une entrée manquante ou non valide affichera un message d'erreur intercalé.",
+      "Supprimez l'attribut `error-message` par défaut si la zone de texte est facultative.",
     ]
   }
 }

--- a/src/_data/getcode.js
+++ b/src/_data/getcode.js
@@ -1,21 +1,21 @@
 module.exports = {
     en : {
       heading: "Get your code",
-      paragraph: "Generate different instances of the component by selecting its code properties.",
+      paragraph: "Generate an instance of the component you need by selecting its code properties.",
       listitems: [
-        "Choose code values to get the instance you want.",
-        "Get the code and pull it into your environment.",
-        "Add any copy you need to the component (like text for a label).",
+        "1. Explore by choosing different code values to generate the instance you want.",
+        "2. Get the code and pull it into your environment.",
+        "3. Add any copy you need to the component (like text for a label).",
       ],
       note: "**Note:** The code builder uses English for all code elements."
     },
     fr: {
       heading: "Get your code",
-      paragraph: "Generate different instances of the component by selecting its code properties.",
+      paragraph: "Generate an instance of the component you need by selecting its code properties.",
       listitems: [
-        "Choose code values to get the instance you want.",
-        "Get the code and pull it into your environment.",
-        "Add any copy you need to the component (like text for a label).",
+        "1. Explore by choosing different code values to generate the instance you want.",
+        "2. Get the code and pull it into your environment.",
+        "3. Add any copy you need to the component (like text for a label).",
       ],
       note: "**Note:** The code builder uses English for all code elements."
     }

--- a/src/_data/getcode.js
+++ b/src/_data/getcode.js
@@ -1,0 +1,22 @@
+module.exports = {
+    en : {
+      heading: "Get your code",
+      paragraph: "Generate different instances of the component by selecting its code properties.",
+      listitems: [
+        "Choose code values to get the instance you want.",
+        "Get the code and pull it into your environment.",
+        "Add any copy you need to the component (like text for a label).",
+      ],
+      note: "**Note:** The code builder uses English for all code elements."
+    },
+    fr: {
+      heading: "Get your code",
+      paragraph: "Generate different instances of the component by selecting its code properties.",
+      listitems: [
+        "Choose code values to get the instance you want.",
+        "Get the code and pull it into your environment.",
+        "Add any copy you need to the component (like text for a label).",
+      ],
+      note: "**Note:** The code builder uses English for all code elements."
+    }
+  }

--- a/src/_data/hint.js
+++ b/src/_data/hint.js
@@ -1,18 +1,18 @@
 module.exports = {
   en : {
-    heading: "Keep hint text static and perceivable",
+    heading: "Include hint text and error message text for task success",
     listitems: [
+      "Include error message text for all required inputs. Avoid using error messages for optional ones.",
       "Add hint text to help a person provide a complete value in the input and avoid an error state.",
-      "Use the hint text attribute to add the hint text below the label and above the field.",
-      "Avoid placing hint text in the container where it will disappear once the field is selected.",
+      "Avoid adding hint text in the field container where it will disappear once the field is selected.",
     ]
   },
   fr: {
-    heading: "Keep hint text static and perceivable",
+    heading: "Ajoutez du texte explicatif et un message d'erreur pour favoriser la réussite de la tâche",
     listitems: [
-      "Add hint text to help a person provide a complete value in the input and avoid an error state.",
-      "Use the hint text attribute to add the hint text below the label and above the field.",
-      "Avoid placing hint text in the container where it will disappear once the field is selected.",
+      "Incluez un message d'erreur pour tous les champs de saisie obligatoires. Évitez d'inclure des messages d'erreur pour les champs de saisie facultatifs.",
+      "Ajoutez du texte explicatif pour aider l'utilisateur·rice à fournir une valeur valide dans le champs de saisie et ainsi éviter les erreurs.",
+      "Évitez d'ajouter du texte explicatif dans la boîte du champ, où il s'effacera une fois le champ sélectionné.",
     ]
   }
 }

--- a/src/_includes/partials/error-message.njk
+++ b/src/_includes/partials/error-message.njk
@@ -1,9 +1,7 @@
-<h3 class="mt-500 mb-400">{{ errormessage[locale].heading }}</h3>
+### {{ errormessage[locale].heading }}
 
-<ul class="list-disc">
-  {% for value in errormessage[locale].listitems %}
-    <li>
-      {{ value }}
-    </li>
-  {% endfor %}
-</ul>
+{% for value in errormessage[locale].listitems %}
+
+- {{ value }}
+
+{% endfor %}

--- a/src/_includes/partials/getcode.njk
+++ b/src/_includes/partials/getcode.njk
@@ -1,0 +1,11 @@
+### {{ getcode[locale].heading }}
+
+{{ getcode[locale].paragraph }}
+
+{% for value in getcode[locale].listitems %}
+
+- {{ value }}
+
+{% endfor %}
+
+{{ getcode[locale].note }}

--- a/src/_includes/partials/getcode.njk
+++ b/src/_includes/partials/getcode.njk
@@ -4,7 +4,7 @@
 
 {% for value in getcode[locale].listitems %}
 
-- {{ value }}
+{{ value }}
 
 {% endfor %}
 

--- a/src/_includes/partials/hint.njk
+++ b/src/_includes/partials/hint.njk
@@ -1,9 +1,7 @@
-<h3 class="mt-500 mb-400">{{ hint[locale].heading }}</h3>
+### {{ hint[locale].heading }}
 
-<ul class="list-disc">
-  {% for value in hint[locale].listitems %}
-    <li>
-      {{ value }}
-    </li>
-  {% endfor %}
-</ul>
+{% for value in hint[locale].listitems %}
+
+- {{ value }}
+
+{% endfor %}

--- a/src/en/components/button/code.md
+++ b/src/en/components/button/code.md
@@ -23,13 +23,7 @@ Use a button for important actions a person using a product can initiate.
 - A skip-to-content button lets a person skip a cluster of navigation links and jump to the main content.
 - To avoid covering up content, configure the button to push down content so it's not floating, For desktop, place skip-to-content button at top left of the page so it doesn't interrupt the flow.
 
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-button properties and events."

--- a/src/en/components/checkbox/code.md
+++ b/src/en/components/checkbox/code.md
@@ -17,20 +17,11 @@ Use a checkbox when you are expecting the user to select more than one option fr
 - Position checkboxes to the left of their corresponding labels. This makes them easier to find, especially with screen magnifiers.
 - Avoid removing focus states in checkboxes.
 
-### How to use validators with the required property
+{% include "partials/error-message.njk" %}
 
-When applying the validator to the
+{% include "partials/hint.njk" %}
 
-- Use the required property to activate the required validator. Validation will happen by default on the onBlur event.
-- If you need to change the validation event, use the validate-on attribute. Validation can happen on blur, when the element loses focus, or manually with the validate method.
-
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-checkbox properties and events."

--- a/src/en/components/details/code.md
+++ b/src/en/components/details/code.md
@@ -24,13 +24,7 @@ To help a reader's experience accessing details content:
 - Make summary titles distinct so people know the difference. Identical or similar titles can be confused.
 - Avoid placing one details component inside another, where no one would know to look for that content.
 
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-details properties and events."

--- a/src/en/components/error-message/code.md
+++ b/src/en/components/error-message/code.md
@@ -36,13 +36,7 @@ A person who receives an error message needs to:
 - Be able to make the changes.
 - Resubmit or revalidate without having to fill out the whole form again.
 
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-error-message properties and events."

--- a/src/en/components/fieldset/code.md
+++ b/src/en/components/fieldset/code.md
@@ -12,12 +12,7 @@ Use a fieldset to group together related form elements or components and make th
 
 ## Accessibility and coding for fieldsets
 
-### Handling required fields and error messages
-
-- Use the required attribute for fieldset groupings that need to be filled in. This places "required" at the end of the legend.
-- Use the disabled attribute to disable the group of form fields within the fieldset. Avoid disabling required fields.
-- Keep the default error-message attribute for required fieldset groupings and for components that need validation, like an email input. Missing and invalid entries will prompt an inline error message just before the fieldset grouping.
-- Remove the default error-message attribute if a fieldset is optional.
+{% include "partials/error-message.njk" %}
 
 ### Keep hint text static and perceivable
 
@@ -36,13 +31,7 @@ The fieldset will only validate checkbox and radio button children.
 - Use the required property to activate  the required validator. Validation will happen by default on the onBlur event.
 - If you need to change the validation event, use the validate-on attribute. Validation can happen on blur, when the element loses focus, or manually with the validate method.
 
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-fieldset properties and events."

--- a/src/en/components/file-uploader/code.md
+++ b/src/en/components/file-uploader/code.md
@@ -7,3 +7,9 @@ date: "git Last Modified"
 ---
 
 ## Code
+
+{% include "partials/error-message.njk" %}
+
+{% include "partials/hint.njk" %}
+
+{% include "partials/getcode.njk" %}

--- a/src/en/components/footer/code.md
+++ b/src/en/components/footer/code.md
@@ -48,13 +48,7 @@ Choose the **full display** if you need to include:
 }
 - Pass an element with the slot="list" attribute to replace the list element in the main band navigation landmark.
 
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-footer properties and events."

--- a/src/en/components/header/code.md
+++ b/src/en/components/header/code.md
@@ -38,13 +38,7 @@ Use this header landmark to communicate a Government of Canada digital service o
 - Add the breadcrumb component by passing an element with the slot="breadcrumb" attribute. This will place the breadcrumb in the header below the language toggle, signature and search slot.
 - Add the phase banner by passing an element with the slot="banner" attribute. This will place the element across the top of the header under the topnav element.
 
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-header properties and events."

--- a/src/en/components/input/code.md
+++ b/src/en/components/input/code.md
@@ -17,27 +17,11 @@ Use an input to ask for information short, one-line response.
 - Set the input to span almost the entire container, like at 90%, when you're usure of the character count of the response.
 - Use the maximum 75 characters for responses without a fixed length.
 
-### Handle error messages and validation
+{% include "partials/error-message.njk" %}
 
-- Use the required property to activate the required validator. Validation will happen by default on the onBlur event.
-- If you need to change the validation event, use the validate-on attribute. Validation can happen on blur, when the element loses focus, or manually with the validate method.
-- Use the required attribute for fields that must be filled in. This places "(required)" at the end of the checkbox.
-- Keep the default error-message attribute for a required input that needs validation. A missing or invalid entry will prompt an inline error message.
-- Remove the default error-message attribute if the input is optional.
+{% include "partials/hint.njk" %}
 
-### Include hint text and error message text for task success
-
-- Include error message text for all required text areas. Avoid using error messages for optional ones.
-- Add hint text to help a person provide a complete value in the input and avoid an error state.
-- Avoid adding hint text in the field container where it will disappear once the field is selected.
-
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-input properties and events."

--- a/src/en/components/radio/code.md
+++ b/src/en/components/radio/code.md
@@ -21,13 +21,7 @@ The radio helps users to make a choice by limiting their options.
 - For required groups, set the required attribute in the fieldset. Setting the required attribute  applies validation and error handling to the radio group.
 - For required radios, add the required attribute to the first and last of the set of radio buttons. This way a person using assistive technology can read the group from either the top or bottom and still see that it's required.
 
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-radio properties and events."

--- a/src/en/components/select/code.md
+++ b/src/en/components/select/code.md
@@ -7,3 +7,9 @@ date: "git Last Modified"
 ---
 
 ## Code
+
+{% include "partials/error-message.njk" %}
+
+{% include "partials/hint.njk" %}
+
+{% include "partials/getcode.njk" %}

--- a/src/en/components/stepper/code.md
+++ b/src/en/components/stepper/code.md
@@ -14,16 +14,9 @@ Use a stepper as a guide when a sequence (form or process) can be divided into l
 
 ### Use each step for a goal
 
-
 Use the current step to indicate the step that the user is on and the total steps to indicate the overall number of steps.
 
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-stepper properties and events."

--- a/src/en/components/textarea/code.md
+++ b/src/en/components/textarea/code.md
@@ -21,27 +21,11 @@ The text area gives users the option to provide the information they want to sha
 - Avoid setting width any lower than 50% (1/2 width).
 - Use the maximum for responses without a fixed length.
 
-### Handle error messages and validation
+{% include "partials/error-message.njk" %}
 
-- Use the required property to activate the required validator. Validation will happen by default on the onBlur event.
-- If you need to change the validation event, use the validate-on attribute. Validation can happen on blur, when the element loses focus, or manually with the validate method.
-- Use the required attribute for fields that must be filled in. This places "(required)" at the end of the checkbox.
-- Keep the default error-message attribute for a required text area that needs validation. A missing or invalid entry will prompt an inline error message.
-- Remove the default error-message attribute if the text area is optional.
+{% include "partials/hint.njk" %}
 
-### Include hint text and error message text for task success
-
-- Include error message text for all required text areas. Avoid using error messages for optional ones.
-- Add hint text to help a person provide a complete value in the text area and avoid an error state.
-- Avoid adding hint text in the field container where it will disappear once the field is selected.
-
-## Get your code
-
-Generate code for a component instance by choosing properties in the values column, based on the code elements in the properties table.
-
-Select "Get code" once you have the properties you need. That will generate code for the instance you're building.
-
-Pull that code into your environment and you'll have a component with all the code values you chose.
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-textarea properties and events."

--- a/src/fr/composants/champ-de-saisie/code.md
+++ b/src/fr/composants/champ-de-saisie/code.md
@@ -18,20 +18,11 @@ Utilisez un champ de saisie pour obtenir une réponse courte d'une ligne.
 - Réglez la saisie de manière à ce qu'elle couvre presque toute la boîte, par exemple à 90 %, lorsque vous ne savez pas la longueur exacte de la réponse.
 - Utilisez le maximum de 75 caractères pour les réponses sans longueur fixe.
 
-### Traitez les messages d'erreur et la validation
+{% include "partials/error-message.njk" %}
 
-- Utilisez la propriété « required » pour activer le validateur nécessaire. La validation s'effectuera par défaut pendant l'événement onBlur.
-- Si vous devez modifier l'événement de validation, utilisez l'attribut « validate-on ». Une validation onBlur est possible lorsque l'élément n'est plus ciblé. Il est également possible de procéder à une validation manuelle avec la méthode « validate ».
-- Employez l'attribut « required » pour les champs obligatoires. Cet attribut insérera la mention « (obligatoire) » à la fin de la case à cocher. Une entrée manquante ou non valide affichera un [message d'erreur](/fr/composants/message-derreur/) intercalé.
-- Supprimez l'attribut « error-message » par défaut si le champs de saisie est facultatif.
+{% include "partials/hint.njk" %}
 
-### Ajoutez du texte explicatif et un message d'erreur pour favoriser la réussite de la tâche
-
-- Incluez un [message d'erreur](/fr/composants/message-derreur/) pour tous les champs de saisie obligatoires. Évitez d'inclure des messages d'erreur pour les champs de saisie facultatifs.
-- Ajoutez du texte explicatif pour aider l'utilisateur·rice à fournir une valeur valide dans le champs de saisie et ainsi éviter les erreurs.
-- Évitez d'ajouter du texte explicatif dans la boîte du champ, où il s'effacera une fois le champ sélectionné.
-
-## TO DO: Get code content
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-input properties and events."

--- a/src/fr/composants/zone-de-texte/code.md
+++ b/src/fr/composants/zone-de-texte/code.md
@@ -21,21 +21,11 @@ La zone de texte donne aux utilisateur·rice·s la possibilité de fournir les r
 - Évitez de définir une largeur inférieure à 50 % (1/2 largeur).
 - Utilisez le maximum pour les réponses sans longueur fixe.
 
-### Traitez les messages d'erreur et la validation
+{% include "partials/error-message.njk" %}
 
-- Utilisez la propriété « required » pour activer le validateur nécessaire. La validation s'effectuera par défaut pendant l'événement onBlur.
-- Si vous devez modifier l'événement de validation, utilisez l'attribut « validate-on ». Une validation onBlur est possible lorsque l'élément n'est plus ciblé. Il est également possible de procéder à une validation manuelle avec la méthode « validate ».
-- Employez l'attribut « required » pour les champs obligatoires. Cet attribut insérera la mention « (obligatoire) » à la fin de la case à cocher.
-- Conservez l'attribut « error-message » par défaut pour une zone de texte obligatoire qui doit être validée. Une entrée manquante ou non valide affichera un [message d'erreur](/fr/composants/message-derreur/) intercalé.
-- Supprimez l'attribut « error-message » par défaut si la zone de texte est facultative.
+{% include "partials/hint.njk" %}
 
-### Ajoutez du texte explicatif et un message d'erreur pour favoriser la réussite de la tâche
-
-- Incluez un [message d'erreur](/fr/composants/message-derreur/) pour toutes les zones de texte obligatoires. Évitez d'inclure des [messages d'erreur](/fr/composants/message-derreur/) pour les zones de texte facultatives.
-- Ajoutez du texte explicatif pour aider l'utilisateur·rice à fournir une valeur valide dans la zone de texte et ainsi éviter les erreurs.
-- Évitez d'ajouter du texte explicatif dans la boîte du champ, où il s'effacera une fois le champ sélectionné.
-
-## TO DO: Get code content
+{% include "partials/getcode.njk" %}
 
 <iframe
   title="Overview of gcds-textarea properties and events."


### PR DESCRIPTION
# Summary | Résumé

Add new getcode partial for the Get your code section (English only atm).

Add hint, error-message and getcode partials to component pages.

**Note:** French version of error-message partial content will need a revision to correct always referencing checkbox