### PR TITLE
Fix iframe scroll + 404 page

### DIFF
--- a/src/404.md
+++ b/src/404.md
@@ -6,10 +6,10 @@ eleventyExcludeFromCollections: true
 locale: en
 ---
 
-<h1>
+<h1 class="mt-300 mb-400">
     Page could not be found | <span lang="fr">Page introuvable</span>
 </h1>
 
 Check you’ve entered the correct web address.
 
-<p lang="fr">Assurez-vous d’avoir saisi la bonne adresse Web.</p>
+<p class="mb-400" lang="fr">Assurez-vous d’avoir saisi la bonne adresse Web.</p>

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -1,7 +1,6 @@
+{% set itemUrl = '' %}
 
 {% for lgg in site.languages %}
-  {% set translatedUrl = "/" + lgg.code + "/" %}
-
   {# Only render opposite language link #}
   {% if lgg.code != locale %}
     {# loop through all the content of the site #}
@@ -9,18 +8,20 @@
       {# for each item in the loop, check if
       - its translationKey matches the current item translationKey
       - its locale matches the code of the language we are looping through #}
-      {% if item.data.translationKey == translationKey and item.data.locale == lgg.code %}
+      {% if item.data.translationKey == translationKey and item.data.locale == lgg.code and item.url %}
 
-        <gcds-header
-          lang="{{ locale }}"
-          skip-to-href="#mc"
-          lang-href='{{ item.url }}'
-        >
-          {% include "partials/nav.njk" %}
-          {% include "partials/breadcrumbs.njk" %}
-        </gcds-header>
+        {% set itemUrl = item.url %}
 
       {% endif %}
     {% endfor %}
   {% endif %}
 {% endfor %}
+
+<gcds-header
+  lang="{{ locale }}"
+  skip-to-href="#mc"
+  lang-href='{{ itemUrl }}'
+>
+  {% include "partials/nav.njk" %}
+  {% include "partials/breadcrumbs.njk" %}
+</gcds-header>

--- a/src/en/components/button/code.md
+++ b/src/en/components/button/code.md
@@ -27,7 +27,7 @@ Use a button for important actions a person using a product can initiate.
 
 <iframe
   title="Overview of gcds-button properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-button--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-button--default"
   width="1200"
   height="1920"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/checkbox/code.md
+++ b/src/en/components/checkbox/code.md
@@ -26,7 +26,7 @@ Use a checkbox with a [fieldset]({{ links.fieldset }}) when you are expecting th
 
 <iframe
   title="Overview of gcds-checkbox properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-checkbox--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-checkbox--default"
   width="1200"
   height="1760"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/details/code.md
+++ b/src/en/components/details/code.md
@@ -28,7 +28,7 @@ To help a reader's experience accessing details content:
 
 <iframe
   title="Overview of gcds-details properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-details--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-details--default"
   width="1200"
   height="865"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/error-message/code.md
+++ b/src/en/components/error-message/code.md
@@ -40,7 +40,7 @@ A person who receives an error message needs to:
 
 <iframe
   title="Overview of gcds-error-message properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-error-message--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-message--default"
   width="1200"
   height="675"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/fieldset/code.md
+++ b/src/en/components/fieldset/code.md
@@ -35,7 +35,7 @@ The fieldset will only validate [checkbox]({{ links.checkbox }}) and [radio butt
 
 <iframe
   title="Overview of gcds-fieldset properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-fieldset--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-fieldset--default"
   width="1200"
   height="1540"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/footer/code.md
+++ b/src/en/components/footer/code.md
@@ -53,7 +53,7 @@ Choose the **full display** if you need to include:
 
 <iframe
   title="Overview of gcds-footer properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-footer--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-footer--default"
   width="1200"
   height="1110"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/header/code.md
+++ b/src/en/components/header/code.md
@@ -42,7 +42,7 @@ Use this header landmark to communicate a Government of Canada digital service o
 
 <iframe
   title="Overview of gcds-header properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-header--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-header--default"
   width="1200"
   height="1535"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/input/code.md
+++ b/src/en/components/input/code.md
@@ -25,7 +25,7 @@ Use an input to ask for information short, one-line response.
 
 <iframe
   title="Overview of gcds-input properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-input--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-input--default"
   width="1200"
   height="1985"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/radio/code.md
+++ b/src/en/components/radio/code.md
@@ -25,7 +25,7 @@ The radio helps users to make a choice by limiting their options.
 
 <iframe
   title="Overview of gcds-radio properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-radio--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-radio--default"
   width="1200"
   height="1670"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/stepper/code.md
+++ b/src/en/components/stepper/code.md
@@ -20,7 +20,7 @@ Use the `current-step` attribute to indicate the step that the user is on and th
 
 <iframe
   title="Overview of gcds-stepper properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-stepper--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-stepper--default"
   width="1200"
   height="800"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/textarea/code.md
+++ b/src/en/components/textarea/code.md
@@ -29,7 +29,7 @@ The text area gives users the option to provide the information they want to sha
 
 <iframe
   title="Overview of gcds-textarea properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-textarea--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-textarea--default"
   width="1200"
   height="1825"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/champ-de-saisie/code.md
+++ b/src/fr/composants/champ-de-saisie/code.md
@@ -26,7 +26,7 @@ Utilisez un champ de saisie pour obtenir une réponse courte d'une ligne.
 
 <iframe
   title="Overview of gcds-input properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-input--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-input--default"
   width="1200"
   height="1985"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/zone-de-texte/code.md
+++ b/src/fr/composants/zone-de-texte/code.md
@@ -29,7 +29,7 @@ La zone de texte donne aux utilisateur·rice·s la possibilité de fournir les r
 
 <iframe
   title="Overview of gcds-textarea properties and events."
-  src="https://cds-snc.github.io/gcds-components/?path=/docs/components-textarea--default&viewMode=docs&shortcuts=false&singleStory=true"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-textarea--default"
   width="1200"
   height="1825"
   style="display: block; margin: 0 auto;"


### PR DESCRIPTION
# Summary | Résumé

Fix rendering and usability issues with 404 page and code pages.

- Switch iframe src to prevent scrolling on load
- Change header rendering partial to properly render header on 404 page and pages without a `translationKey`
