### PR TITLE
Updated tabs

### DIFF
--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -2,10 +2,11 @@
 a[href] {
   text-underline-offset: -0.1em;
   text-decoration-color: currentColor;
+  text-decoration-thickness: var(--gcds-border-width-sm);
 
   &:hover {
     color: var(--gcds-hover-default);
-    text-underline-offset: 0em;
+    text-underline-offset: -0.1em;
     text-decoration-thickness: var(--gcds-border-width-md);
   }
 
@@ -17,7 +18,9 @@ a[href] {
   }
 }
 
-a[href]:not([class*="link-inherit"]):not([class*="link-light"]):not(:focus):not(:hover) {
+a[href]:not([class*="link-inherit"]):not([class*="link-light"]):not(:focus):not(
+    :hover
+  ) {
   color: var(--gcds-link-default);
 }
 

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -11,10 +11,13 @@ a[href] {
   }
 
   &:focus {
+    border-radius: var(--gcds-border-radius-sm);
     background-color: var(--gcds-focus-background);
     color: var(--gcds-focus-text);
     text-decoration: none;
-    outline: var(--gcds-border-width-md) solid var(--gcds-focus-background);
+    box-shadow: 0 0 0 var(--gcds-border-width-md) var(--gcds-color-grayscale-0);
+    outline-offset: var(--gcds-border-width-md);
+    outline: var(--gcds-spacing-50) solid var(--gcds-focus-background);
   }
 }
 

--- a/src/styles/components/_tabs.scss
+++ b/src/styles/components/_tabs.scss
@@ -2,6 +2,7 @@ nav.tabs {
   ul {
     list-style: none;
     margin-inline-start: 0;
+    margin-bottom: var(--gcds-spacing-500);
     width: var(--gcds-container-full);
     display: flex;
     background-color: var(--gcds-color-grayscale-0);
@@ -41,10 +42,13 @@ nav.tabs {
     }
 
     &:focus {
-      border-radius: 0;
       background-color: var(--gcds-focus-background);
       color: var(--gcds-focus-text);
       text-decoration: none;
+    }
+
+    &[aria-current="page"]:focus {
+      border-color: var(--gcds-focus-background );
     }
   }
 }

--- a/src/styles/components/_tabs.scss
+++ b/src/styles/components/_tabs.scss
@@ -4,11 +4,12 @@ nav.tabs {
     margin-inline-start: 0;
     width: var(--gcds-container-full);
     display: flex;
-    background-color: var(--gcds-color-grayscale-100);
+    background-color: var(--gcds-color-grayscale-0);
     gap: var(--gcds-spacing-100);
     flex-wrap: wrap;
     padding-block-start: var(--gcds-spacing-100);
     padding-inline: var(--gcds-spacing-100);
+    border-bottom: 2px solid gray;
   }
 
   a {
@@ -20,6 +21,9 @@ nav.tabs {
 
     &[aria-current="page"] {
       background-color: var(--gcds-color-grayscale-0);
+      border: 2px solid gray;
+      border-bottom: 0 solid white;
+      box-shadow: 0 4px 0 -2px var(--gcds-color-grayscale-0);
       text-decoration: none;
     }
 

--- a/src/styles/components/_tabs.scss
+++ b/src/styles/components/_tabs.scss
@@ -9,7 +9,8 @@ nav.tabs {
     flex-wrap: wrap;
     padding-block-start: var(--gcds-spacing-100);
     padding-inline: var(--gcds-spacing-100);
-    border-bottom: 2px solid gray;
+    border-bottom: var(--gcds-border-width-md) solid
+      var(--gcds-color-grayscale-100);
   }
 
   a {
@@ -21,9 +22,10 @@ nav.tabs {
 
     &[aria-current="page"] {
       background-color: var(--gcds-color-grayscale-0);
-      border: 2px solid gray;
-      border-bottom: 0 solid white;
-      box-shadow: 0 4px 0 -2px var(--gcds-color-grayscale-0);
+      border: var(--gcds-border-width-md) solid var(--gcds-color-grayscale-100);
+      border-bottom: 0 solid var(--gcds-color-grayscale-0);
+      box-shadow: 0 var(--gcds-border-width-xl) 0
+        calc(var(--gcds-border-width-md) * -1) var(--gcds-color-grayscale-0);
       text-decoration: none;
     }
 

--- a/src/styles/components/_tabs.scss
+++ b/src/styles/components/_tabs.scss
@@ -7,8 +7,6 @@ nav.tabs {
     background-color: var(--gcds-color-grayscale-0);
     gap: var(--gcds-spacing-100);
     flex-wrap: wrap;
-    padding-block-start: var(--gcds-spacing-100);
-    padding-inline: var(--gcds-spacing-100);
     border-bottom: var(--gcds-border-width-md) solid
       var(--gcds-color-grayscale-100);
   }
@@ -17,8 +15,11 @@ nav.tabs {
     display: block;
     border-radius: var(--gcds-button-border-radius)
       var(--gcds-button-border-radius) 0 0;
-    padding: var(--gcds-spacing-150);
+    padding: var(--gcds-spacing-200) var(--gcds-spacing-200)
+      var(--gcds-spacing-150) var(--gcds-spacing-200);
     color: var(--gcds-text-default);
+    margin-top: var(--gcds-spacing-150);
+    margin-bottom: var(--gcds-spacing-50);
 
     &[aria-current="page"] {
       background-color: var(--gcds-color-grayscale-0);
@@ -27,6 +28,12 @@ nav.tabs {
       box-shadow: 0 var(--gcds-border-width-xl) 0
         calc(var(--gcds-border-width-md) * -1) var(--gcds-color-grayscale-0);
       text-decoration: none;
+      font-weight: bold;
+      padding: var(--gcds-spacing-300) var(--gcds-spacing-200)
+        var(--gcds-spacing-250) var(--gcds-spacing-200);
+      margin-top: 0;
+      margin-bottom: 0;
+      pointer-events: none;
     }
 
     &:hover {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -61,11 +61,12 @@
 
 a[href] {
   text-underline-offset: -0.1em;
-  text-decoration-color: currentColor; }
+  text-decoration-color: currentColor;
+  text-decoration-thickness: var(--gcds-border-width-sm); }
 
 a[href]:hover {
   color: var(--gcds-hover-default);
-  text-underline-offset: 0em;
+  text-underline-offset: -0.1em;
   text-decoration-thickness: var(--gcds-border-width-md); }
 
 a[href]:focus {
@@ -74,7 +75,9 @@ a[href]:focus {
   text-decoration: none;
   outline: var(--gcds-border-width-md) solid var(--gcds-focus-background); }
 
-a[href]:not([class*="link-inherit"]):not([class*="link-light"]):not(:focus):not(:hover) {
+a[href]:not([class*="link-inherit"]):not([class*="link-light"]):not(:focus):not(
+:hover
+) {
   color: var(--gcds-link-default); }
 
 h1 {
@@ -256,22 +259,27 @@ nav.tabs ul {
   background-color: var(--gcds-color-grayscale-0);
   gap: var(--gcds-spacing-100);
   flex-wrap: wrap;
-  padding-block-start: var(--gcds-spacing-100);
-  padding-inline: var(--gcds-spacing-100);
   border-bottom: var(--gcds-border-width-md) solid var(--gcds-color-grayscale-100); }
 
 nav.tabs a {
   display: block;
   border-radius: var(--gcds-button-border-radius) var(--gcds-button-border-radius) 0 0;
-  padding: var(--gcds-spacing-150);
-  color: var(--gcds-text-default); }
+  padding: var(--gcds-spacing-200) var(--gcds-spacing-200) var(--gcds-spacing-150) var(--gcds-spacing-200);
+  color: var(--gcds-text-default);
+  margin-top: var(--gcds-spacing-150);
+  margin-bottom: var(--gcds-spacing-50); }
 
 nav.tabs a[aria-current="page"] {
   background-color: var(--gcds-color-grayscale-0);
   border: var(--gcds-border-width-md) solid var(--gcds-color-grayscale-100);
   border-bottom: 0 solid var(--gcds-color-grayscale-0);
   box-shadow: 0 var(--gcds-border-width-xl) 0 calc(var(--gcds-border-width-md) * -1) var(--gcds-color-grayscale-0);
-  text-decoration: none; }
+  text-decoration: none;
+  font-weight: bold;
+  padding: var(--gcds-spacing-300) var(--gcds-spacing-200) var(--gcds-spacing-250) var(--gcds-spacing-200);
+  margin-top: 0;
+  margin-bottom: 0;
+  pointer-events: none; }
 
 nav.tabs a:hover {
   background-color: var(--gcds-color-grayscale-50); }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -70,10 +70,13 @@ a[href]:hover {
   text-decoration-thickness: var(--gcds-border-width-md); }
 
 a[href]:focus {
+  border-radius: var(--gcds-border-radius-sm);
   background-color: var(--gcds-focus-background);
   color: var(--gcds-focus-text);
   text-decoration: none;
-  outline: var(--gcds-border-width-md) solid var(--gcds-focus-background); }
+  box-shadow: 0 0 0 var(--gcds-border-width-md) var(--gcds-color-grayscale-0);
+  outline-offset: var(--gcds-border-width-md);
+  outline: var(--gcds-spacing-50) solid var(--gcds-focus-background); }
 
 a[href]:not([class*="link-inherit"]):not([class*="link-light"]):not(:focus):not(
 :hover
@@ -254,6 +257,7 @@ table .spacing-preview {
 nav.tabs ul {
   list-style: none;
   margin-inline-start: 0;
+  margin-bottom: var(--gcds-spacing-500);
   width: var(--gcds-container-full);
   display: flex;
   background-color: var(--gcds-color-grayscale-0);
@@ -285,10 +289,12 @@ nav.tabs a:hover {
   background-color: var(--gcds-color-grayscale-50); }
 
 nav.tabs a:focus {
-  border-radius: 0;
   background-color: var(--gcds-focus-background);
   color: var(--gcds-focus-text);
   text-decoration: none; }
+
+nav.tabs a[aria-current="page"]:focus {
+  border-color: var(--gcds-focus-background); }
 
 .hero {
   margin: calc(-1 * var(--gcds-spacing-200));

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -258,7 +258,7 @@ nav.tabs ul {
   flex-wrap: wrap;
   padding-block-start: var(--gcds-spacing-100);
   padding-inline: var(--gcds-spacing-100);
-  border-bottom: 2px solid gray; }
+  border-bottom: var(--gcds-border-width-md) solid var(--gcds-color-grayscale-100); }
 
 nav.tabs a {
   display: block;
@@ -268,9 +268,9 @@ nav.tabs a {
 
 nav.tabs a[aria-current="page"] {
   background-color: var(--gcds-color-grayscale-0);
-  border: 2px solid gray;
-  border-bottom: 0 solid white;
-  box-shadow: 0 4px 0 -2px var(--gcds-color-grayscale-0);
+  border: var(--gcds-border-width-md) solid var(--gcds-color-grayscale-100);
+  border-bottom: 0 solid var(--gcds-color-grayscale-0);
+  box-shadow: 0 var(--gcds-border-width-xl) 0 calc(var(--gcds-border-width-md) * -1) var(--gcds-color-grayscale-0);
   text-decoration: none; }
 
 nav.tabs a:hover {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -253,11 +253,12 @@ nav.tabs ul {
   margin-inline-start: 0;
   width: var(--gcds-container-full);
   display: flex;
-  background-color: var(--gcds-color-grayscale-100);
+  background-color: var(--gcds-color-grayscale-0);
   gap: var(--gcds-spacing-100);
   flex-wrap: wrap;
   padding-block-start: var(--gcds-spacing-100);
-  padding-inline: var(--gcds-spacing-100); }
+  padding-inline: var(--gcds-spacing-100);
+  border-bottom: 2px solid gray; }
 
 nav.tabs a {
   display: block;
@@ -267,6 +268,9 @@ nav.tabs a {
 
 nav.tabs a[aria-current="page"] {
   background-color: var(--gcds-color-grayscale-0);
+  border: 2px solid gray;
+  border-bottom: 0 solid white;
+  box-shadow: 0 4px 0 -2px var(--gcds-color-grayscale-0);
   text-decoration: none; }
 
 nav.tabs a:hover {


### PR DESCRIPTION
## This Pull Request consists of the following work:

### 1) Updating the navigation tabs styling

- The old tabs had some issues with accessibility so they have been redesigned
- Code has been updated to match the [changes in figma](https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=3891-10337&t=ez54izbXzhGHAlWL-0)

| Before | After |
|--------|-------|
|    <img width="784" alt="Screen Shot 2023-03-08 at 16 09 36" src="https://user-images.githubusercontent.com/30609058/223850621-725c6618-2713-4daa-8e25-51582e41b482.png">  |   <img width="807" alt="Screen Shot 2023-03-08 at 16 10 16" src="https://user-images.githubusercontent.com/30609058/223850750-f9a1c5df-475a-47a5-91ec-6877dca2dd02.png">   |

### 2) Optimized hover style on links

- I noticed that our hover styles weren't behaving properly and jumping vertically a bit on `mouseIn` and `mouseOut` and fixed the jumping
- the underline was also being set to 2px instead of 1px in it's default state so I updated it as well
- [Styles can be found in figma](https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=2646-8407&t=ez54izbXzhGHAlWL-0)

| Before | After |
|--------|-------|
| ![link-hover](https://user-images.githubusercontent.com/30609058/223854479-f9ef8a72-ad2e-4c09-a891-a4f3a16891a4.gif) | ![link-hover-new](https://user-images.githubusercontent.com/30609058/223855135-6e9e1284-98f2-4fcf-9b54-5a9119924e1d.gif) |

### 3) Fixed focus style on links 

- I noticed that our focus styles weren't really working on dark backgrounds, so I added a box-shadow with a white fill to account for cases like this and at least ensure that the white fill shows up and acts a bit like an outline
- I also bumped the thickness up to 3px or `gcds-spacing-50`, is this acceptable :S ? I know the others were using nice border tokens

| Before | After |
|--------|-------|
|    <img width="113" alt="Screen Shot 2023-03-08 at 16 18 41" src="https://user-images.githubusercontent.com/30609058/223852648-5957d4f5-c1bf-4852-9d59-d8307b5f8fa3.png"> | <img width="105" alt="Screen Shot 2023-03-08 at 16 19 34" src="https://user-images.githubusercontent.com/30609058/223853509-ee8d9e95-ae85-42fb-b8d0-cb282d582aaf.png"> |

| Before | After |
|--------|-------|
|  <img width="156" alt="Screen Shot 2023-03-08 at 16 25 30" src="https://user-images.githubusercontent.com/30609058/223853773-b10ec6ec-ca19-49ab-a16f-a26bee5914ba.png">  |   <img width="163" alt="Screen Shot 2023-03-08 at 16 21 35" src="https://user-images.githubusercontent.com/30609058/223853018-d61326a7-07cf-45bf-bed5-8f0f05c25e42.png">  |