### PR TITLE
Fix copy button in component code sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@11ty/eleventy-plugin-syntaxhighlight": "^4.0.0",
-    "@cdssnc/gcds-components": "^0.9.1",
+    "@cdssnc/gcds-components": "^0.9.3",
     "@cdssnc/gcds-tokens": "^1.0.3",
     "@cdssnc/gcds-utility": "^1.0.0",
     "@quasibit/eleventy-plugin-sitemap": "^2.1.4",

--- a/src/en/components/button/code.md
+++ b/src/en/components/button/code.md
@@ -33,4 +33,5 @@ Use a button for important actions a person using a product can initiate.
   height="1920"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/en/components/checkbox/code.md
+++ b/src/en/components/checkbox/code.md
@@ -36,4 +36,5 @@ Use a checkbox with a [fieldset]({{ links.fieldset }}) when you are expecting th
   height="1760"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/en/components/details/code.md
+++ b/src/en/components/details/code.md
@@ -39,4 +39,5 @@ To help a reader's experience accessing details content:
   height="865"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/en/components/error-message/code.md
+++ b/src/en/components/error-message/code.md
@@ -45,4 +45,5 @@ A person who receives an error message needs to:
   height="675"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/en/components/fieldset/code.md
+++ b/src/en/components/fieldset/code.md
@@ -40,4 +40,5 @@ The fieldset will only validate [checkbox]({{ links.checkbox }}) and [radio butt
   height="1540"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/en/components/footer/code.md
+++ b/src/en/components/footer/code.md
@@ -68,4 +68,5 @@ Opt to include the contextual band to add up to three footer links for your prod
   height="1110"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/en/components/header/code.md
+++ b/src/en/components/header/code.md
@@ -46,4 +46,5 @@ Use this header landmark to communicate a Government of Canada digital service o
   height="1535"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/en/components/input/code.md
+++ b/src/en/components/input/code.md
@@ -30,4 +30,5 @@ Use an input to ask for information short, one-line response.
   height="1985"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/en/components/radio/code.md
+++ b/src/en/components/radio/code.md
@@ -29,4 +29,5 @@ The radio helps users to make a choice by limiting their options.
   height="1670"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/en/components/stepper/code.md
+++ b/src/en/components/stepper/code.md
@@ -25,4 +25,5 @@ Use the `current-step` attribute to indicate the step that the user is on and th
   height="800"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/en/components/textarea/code.md
+++ b/src/en/components/textarea/code.md
@@ -34,4 +34,5 @@ The text area gives users the option to provide the information they want to sha
   height="1825"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/Case-a-cocher/code.md
+++ b/src/fr/composants/Case-a-cocher/code.md
@@ -36,4 +36,5 @@ Utilisez une case à cocher avec un [jeu de champs]({{ links.fieldset }}) lorsqu
   height="1760"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/bouton/code.md
+++ b/src/fr/composants/bouton/code.md
@@ -33,4 +33,5 @@ Utilisez un bouton pour les actions importantes que peut initier une personne ut
   height="1920"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/champ-de-saisie/code.md
+++ b/src/fr/composants/champ-de-saisie/code.md
@@ -31,4 +31,5 @@ Utilisez un champ de saisie pour obtenir une réponse courte d'une ligne.
   height="1985"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/details/code.md
+++ b/src/fr/composants/details/code.md
@@ -39,4 +39,5 @@ Pour aider une personne à accéder au contenu du composant Détails :
   height="865"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/en-tete/code.md
+++ b/src/fr/composants/en-tete/code.md
@@ -46,4 +46,5 @@ Utilisez ce point de repère pour transmettre de l'information sur un service du
   height="1535"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/indicateur-detape/code.md
+++ b/src/fr/composants/indicateur-detape/code.md
@@ -25,4 +25,5 @@ Utilisez l'attribut `current-step` pour indiquer l'étape à laquelle l'utilisat
   height="800"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/jeu-de-champs/code.md
+++ b/src/fr/composants/jeu-de-champs/code.md
@@ -40,4 +40,5 @@ Le jeu de champs ne validera que les [cases à cocher]({{ links.checkbox }}) et 
   height="1540"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/message-derreur/code.md
+++ b/src/fr/composants/message-derreur/code.md
@@ -45,4 +45,5 @@ La personne qui reçoit un message d'erreur doit :
   height="675"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/pied-de-page/code.md
+++ b/src/fr/composants/pied-de-page/code.md
@@ -74,4 +74,5 @@ Pour la bande de lien du pied de page, réglez l'élément `sub-links` en passan
   height="1110"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/radio/code.md
+++ b/src/fr/composants/radio/code.md
@@ -29,4 +29,5 @@ Les boutons radio aident les utilisateur·rice·s a faire un choix en limitant l
   height="1670"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>

--- a/src/fr/composants/zone-de-texte/code.md
+++ b/src/fr/composants/zone-de-texte/code.md
@@ -34,4 +34,5 @@ La zone de texte donne aux utilisateur·rice·s la possibilité de fournir les r
   height="1825"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
+  allow="clipboard-write"
 ></iframe>


### PR DESCRIPTION
# Summary | Résumé

Add `allow="clipboard-write"` to the iframes in the component code sections.

Resolves #134 
