### PR TITLE
Up the size of email field to 50 on contact form

### DIFF
--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -34,7 +34,7 @@ Fill out this form or submit an issue through GitHub for <a href="{{ links.githu
 <form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;">
   <input type="hidden" name="form-name" value="contactEN" />
   <gcds-input type="text" input-id="name" label="Full name" size="30" required></gcds-input>
-  <gcds-input type="email" input-id="email" label="Email address" size="30" required></gcds-input>
+  <gcds-input type="email" input-id="email" label="Email address" size="50" required></gcds-input>
   <gcds-textarea label="Message" textarea-id="message" hint="Write your question or comment." required></gcds-textarea>
   <div hidden>
     <gcds-input type="text" input-id="bot-field" label="bot"></gcds-input>

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -34,7 +34,7 @@ Pour toute demande concernant <a href="{{ links.githubTokensIssues }}" target="_
 <form class="my-500 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;">
   <input type="hidden" name="form-name" value="contactFR" />
   <gcds-input type="text" input-id="name" label="Nom complet" size="30" required></gcds-input>
-  <gcds-input type="email" input-id="email" label="Adresse courriel" size="30" required></gcds-input>
+  <gcds-input type="email" input-id="email" label="Adresse courriel" size="50" required></gcds-input>
   <gcds-textarea label="Message" textarea-id="message" hint="Écrivez votre question ou commentaire." required></gcds-textarea>
   <div hidden>
     <gcds-input type="text" input-id="bot-field" label="bot"></gcds-input>


### PR DESCRIPTION
# Summary | Résumé

Up the size of email field to 50 on contact form to accommodate departmental email addresses.
