### PR TITLE
update unpkg links to use new cdn links in CDN instructions

### DIFF
--- a/src/_includes/partials/installation/step-2-cdn.njk
+++ b/src/_includes/partials/installation/step-2-cdn.njk
@@ -10,9 +10,9 @@
 <script src="{{ links.fontAwesome }}" crossorigin="anonymous"></script>
 
 <!-- GC Design System -->
-<link rel="stylesheet" href="https://unpkg.com/@cdssnc/gcds-components/dist/gcds/gcds.css">
-<script type="module" src="https://unpkg.com/@cdssnc/gcds-components/dist/gcds/gcds.esm.js"></script>
-<script nomodule src="https://unpkg.com/@cdssnc/gcds-components/dist/gcds/gcds.js"></script>
+<link rel="stylesheet" href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@latest/dist/gcds/gcds.css">
+<script type="module" src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@latest/dist/gcds/gcds.esm.js"></script>
+<script nomodule src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@latest/dist/gcds/gcds.js"></script>
 {% endhighlight %}
   <small>{{ installation[locale].step2.cdn.note }}</small>
 </div>


### PR DESCRIPTION
# Summary | Résumé

Replace unpkg links with our new CDN links for the CDN installation instructions.