### PR TITLE
Add security headers to site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "no-referrer"
+    X-Content-Type-Options = "nosniff"  
+    Permissions-Policy = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()"


### PR DESCRIPTION
# Summary | Résumé

Add the headers `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `X-Content-Type-Options`, and `Permissions-Policy` to design system website.