### PR TITLE
fix live demo display

### DIFF
--- a/src/en/components/breadcrumbs/code.md
+++ b/src/en/components/breadcrumbs/code.md
@@ -29,12 +29,14 @@ Add a new breadcrumbs link to the breadcrumbs component by using the `<gcds-brea
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-breadcrumbs properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&id=components-breadcrumbs--events-properties"
-  width="1200"
-  height="1050"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-breadcrumbs properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&id=components-breadcrumbs--events-properties"
+    width="1200"
+    height="1050"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/button/code.md
+++ b/src/en/components/button/code.md
@@ -26,12 +26,14 @@ Use a button for important actions a person using a product can initiate.
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-button properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-button--events-properties"
-  width="1200"
-  height="1920"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-button properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-button--events-properties"
+    width="1200"
+    height="1650"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/checkbox/code.md
+++ b/src/en/components/checkbox/code.md
@@ -29,12 +29,14 @@ Use a checkbox with a [fieldset]({{ links.fieldset }}) when you are expecting th
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-checkbox properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-checkbox--events-properties"
-  width="1200"
-  height="1760"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-checkbox properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-checkbox--events-properties"
+    width="1200"
+    height="1650"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/details/code.md
+++ b/src/en/components/details/code.md
@@ -32,12 +32,14 @@ To help a reader's experience accessing details content:
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-details properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-details--events-properties"
-  width="1200"
-  height="865"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-details properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-details--events-properties"
+    width="1200"
+    height="950"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/error-message/code.md
+++ b/src/en/components/error-message/code.md
@@ -38,12 +38,14 @@ A person who receives an error message needs to:
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-error-message properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-message--events-properties"
-  width="1200"
-  height="675"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-error-message properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-message--events-properties"
+    width="1200"
+    height="900"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/error-summary/code.md
+++ b/src/en/components/error-summary/code.md
@@ -34,12 +34,14 @@ Opt to make your error heading more specific by using the `heading` attributes.
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-error-summary properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-summary--events-properties"
-  width="1200"
-  height="1400"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-error-summary properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-summary--events-properties"
+    width="1200"
+    height="1500"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/fieldset/code.md
+++ b/src/en/components/fieldset/code.md
@@ -33,12 +33,14 @@ The fieldset will only validate [checkbox]({{ links.checkbox }}) and [radio butt
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-fieldset properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-fieldset--events-properties"
-  width="1200"
-  height="1540"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-fieldset properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-fieldset--events-properties"
+    width="1200"
+    height="1600"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/footer/code.md
+++ b/src/en/components/footer/code.md
@@ -61,12 +61,14 @@ Opt to include the contextual band to add up to three footer links for your prod
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-footer properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-footer--events-properties"
-  width="1200"
-  height="1110"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-footer properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-footer--events-properties"
+    width="1200"
+    height="1100"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/header/code.md
+++ b/src/en/components/header/code.md
@@ -39,12 +39,14 @@ Use this header landmark to communicate a Government of Canada digital service o
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-header properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-header--events-properties"
-  width="1200"
-  height="1535"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-header properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-header--events-properties"
+    width="1200"
+    height="1535"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/input/code.md
+++ b/src/en/components/input/code.md
@@ -23,12 +23,14 @@ Use an input to ask for information short, one-line response.
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-input properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-input--events-properties"
-  width="1200"
-  height="1985"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-input properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-input--events-properties"
+    width="1200"
+    height="1900"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/language-toggle/code.md
+++ b/src/en/components/language-toggle/code.md
@@ -21,12 +21,14 @@ Note: If using the header component, the language toggle can be assigned using t
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-footer properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-language-toggle--events-properties"
-  width="1200"
-  height="1110"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-footer properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-language-toggle--events-properties"
+    width="1200"
+    height="800"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/radio/code.md
+++ b/src/en/components/radio/code.md
@@ -22,12 +22,14 @@ The radio helps users to make a choice by limiting their options.
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-radio properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-radio--events-properties"
-  width="1200"
-  height="1670"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-radio properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-radio--events-properties"
+    width="1200"
+    height="1600"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/side-navigation/code.md
+++ b/src/en/components/side-navigation/code.md
@@ -18,16 +18,18 @@ Implement the side navigation in the product layout so that it’s present on al
 
 ### Use the side navigation with other components
 
-If using breadcrumbs, align the content hierarchy in both sets of links, so the components reflect a similar path through the site.  
+If using breadcrumbs, align the content hierarchy in both sets of links, so the components reflect a similar path through the site.
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-side-nav properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-side-navigation--events-properties"
-  width="1200"
-  height="1670"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-side-nav properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-side-navigation--events-properties"
+    width="1200"
+    height="1750"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/stepper/code.md
+++ b/src/en/components/stepper/code.md
@@ -18,12 +18,14 @@ Use the `current-step` attribute to indicate the step that the user is on and th
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-stepper properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-stepper--events-properties"
-  width="1200"
-  height="800"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-stepper properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-stepper--events-properties"
+    width="1200"
+    height="850"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/textarea/code.md
+++ b/src/en/components/textarea/code.md
@@ -27,12 +27,14 @@ The text area gives users the option to provide the information they want to sha
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-textarea properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-textarea--events-properties"
-  width="1200"
-  height="1825"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-textarea properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-textarea--events-properties"
+    width="1200"
+    height="1800"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/en/components/top-navigation/code.md
+++ b/src/en/components/top-navigation/code.md
@@ -24,12 +24,14 @@ Use a top navigation to help a person find their way around your web page or sit
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-top-nav properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-top-navigation--events-properties"
-  width="1200"
-  height="1650"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-top-nav properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-top-navigation--events-properties"
+    width="1200"
+    height="1650"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/Case-a-cocher/code.md
+++ b/src/fr/composants/Case-a-cocher/code.md
@@ -14,7 +14,7 @@ Utilisez une case à cocher avec un [jeu de champs]({{ links.fieldset }}) lorsqu
 
 ### Utilisez un jeu de champs et l’attribut obligatoire
 
-- Regroupez les options de cases à cocher et nommer le groupe en utilisant la [composante de jeu de champs]({{ links.fieldset }}).  
+- Regroupez les options de cases à cocher et nommer le groupe en utilisant la [composante de jeu de champs]({{ links.fieldset }}).
 - Utilisez le jeu de champs `legend` et l’attribut `hint` pour le nom du groupe et ses instructions.
 - Pour les groupes obligatoires, sélectionnez l’attribut `required` dans le jeu de champs. La sélection de l’attribut `required` permet la validation et la gestion des erreurs pour le groupe de cases à cocher.
 
@@ -29,12 +29,14 @@ Utilisez une case à cocher avec un [jeu de champs]({{ links.fieldset }}) lorsqu
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-checkbox."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-checkbox--events-properties"
-  width="1200"
-  height="1760"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-checkbox."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-checkbox--events-properties"
+    width="1200"
+    height="1650"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/Chemin-de-navigation/code.md
+++ b/src/fr/composants/Chemin-de-navigation/code.md
@@ -29,12 +29,14 @@ Ajoutez un nouveau lien au composant Chemin de navigation à l'aide du composant
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-breadcrumbs."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&id=components-breadcrumbs--events-properties"
-  width="1200"
-  height="1050"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-breadcrumbs."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&id=components-breadcrumbs--events-properties"
+    width="1200"
+    height="1050"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/barre-de-navigation-laterale/code.md
+++ b/src/fr/composants/barre-de-navigation-laterale/code.md
@@ -22,12 +22,14 @@ Si vous utilisez un composant Chemin de navigation, uniformisez la hiérarchie d
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-side-nav."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-side-navigation--events-properties"
-  width="1200"
-  height="1670"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-side-nav."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-side-navigation--events-properties"
+    width="1200"
+    height="1750"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/barre-de-navigation-superieure/code.md
+++ b/src/fr/composants/barre-de-navigation-superieure/code.md
@@ -24,12 +24,14 @@ Utilisez une barre de navigation supérieure pour aider une personne à se repé
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-top-nav."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-top-navigation--events-properties"
-  width="1200"
-  height="1650"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-top-nav."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-top-navigation--events-properties"
+    width="1200"
+    height="1650"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/bascule-de-langue/code.md
+++ b/src/fr/composants/bascule-de-langue/code.md
@@ -21,12 +21,14 @@ Remarque : Si vous utilisez le composant En-tête, la bascule de langue peut êt
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Overview of gcds-footer properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-language-toggle--events-properties"
-  width="1200"
-  height="1110"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Overview of gcds-footer properties and events."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-language-toggle--events-properties"
+    width="1200"
+    height="800"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/bouton-radio/code.md
+++ b/src/fr/composants/bouton-radio/code.md
@@ -22,12 +22,14 @@ Les boutons radio aident les utilisateur·rice·s a faire un choix en limitant l
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-radio."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-radio--events-properties"
-  width="1200"
-  height="1670"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-radio."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-radio--events-properties"
+    width="1200"
+    height="1600"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/bouton/code.md
+++ b/src/fr/composants/bouton/code.md
@@ -14,7 +14,7 @@ Utilisez un bouton pour les actions importantes que peut initier une personne ut
 
 ### Rendez vos boutons accessibles
 
-- Vérifiez la visibilité de la bordure du bouton par rapport à la surface où vous le placez. 
+- Vérifiez la visibilité de la bordure du bouton par rapport à la surface où vous le placez.
 - Explicitez clairement l'action correspondant au bouton grâce à un libellé court et spécifique dans un format d'appel à l'action, comme « Démarrer l'application » ou « Enregistrer une copie ».
 - Évitez de réutiliser le texte du libellé sur la même page ou d'utiliser des libellés qui se ressemblent beaucoup. Une personne parcourant les champs à l'aide d'une technologie d'assistance entendra le texte de l'étiquette en succession rapide et n'aura pas d'indication pour associer le bouton à son action.
 
@@ -26,12 +26,14 @@ Utilisez un bouton pour les actions importantes que peut initier une personne ut
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-button."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-button--events-properties"
-  width="1200"
-  height="1920"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-button."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-button--events-properties"
+    width="1200"
+    height="1650"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/champ-de-saisie/code.md
+++ b/src/fr/composants/champ-de-saisie/code.md
@@ -24,12 +24,14 @@ Utilisez un champ de saisie pour obtenir une réponse courte d'une ligne.
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-input."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-input--events-properties"
-  width="1200"
-  height="1985"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-input."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-input--events-properties"
+    width="1200"
+    height="1900"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/details/code.md
+++ b/src/fr/composants/details/code.md
@@ -32,12 +32,14 @@ Pour aider une personne à accéder au contenu du composant Détails :
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-details."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-details--events-properties"
-  width="1200"
-  height="865"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-details."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-details--events-properties"
+    width="1200"
+    height="950"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/en-tete/code.md
+++ b/src/fr/composants/en-tete/code.md
@@ -14,14 +14,14 @@ Utilisez ce point de repère pour transmettre de l'information sur un service du
 
 ### Régler l'élément signature dans l'en-tête
 
-- Maintenez toujours l'intégrité de la signature du gouvernement du Canada. Évitez à tout prix de modifier la signature. Évitez surtout d'étirer le texte ou de changer les couleurs. 
-- Faites passer le mode d'affichage de la signature du gouvernement du Canada en couleur ou en blanc à l'aide de l'attribut `signature-variant`. Choisissez l'affichage `color` pour un fond blanc.  
+- Maintenez toujours l'intégrité de la signature du gouvernement du Canada. Évitez à tout prix de modifier la signature. Évitez surtout d'étirer le texte ou de changer les couleurs.
+- Faites passer le mode d'affichage de la signature du gouvernement du Canada en couleur ou en blanc à l'aide de l'attribut `signature-variant`. Choisissez l'affichage `color` pour un fond blanc.
 - Facultativement, définissez la signature du gouvernement du Canada comme lien vers Canada.ca en réglant l'attribut `signature-has-link` à `true`.
 
 ### Configurer la bascule de langue
 
 - Ajoutez la bascule de langue en définissant l'attribut `lang-href`. L'attribut `lang-href` définit également l'élément « href » de la bascule de langue.
-- Utilisez l'attribut `lang` pour définir la langue du site; le bouton à bascule proposera l'autre langue officielle.  
+- Utilisez l'attribut `lang` pour définir la langue du site; le bouton à bascule proposera l'autre langue officielle.
 - Si votre site est multilingue : Créez une option pour sélectionner d'autres langues en utilisant cet emplacement d'en-tête pour un modèle d'internationalisation. Pour ce faire, passez un élément avec l'attribut `slot=”toggle”` afin de remplacer l'élément de la bascule de langue dans l'en-tête.
 
 ### Inclure le bouton « Passer au contenu »
@@ -34,17 +34,19 @@ Utilisez ce point de repère pour transmettre de l'information sur un service du
 
 - Ajoutez un menu en passant un élément enfant à l'aide de l'attribut `slot=”menu”`. Cela placera l'élément dans l'en-tête, sous le bouton de bascule de langue, la signature et la barre de recherche.
 - Ajoutez un champ de recherche en faisant passer un élément enfant avec l'attribut `slot=”search”`. Cela placera l'élément sous la bascule de langue, à côté de la signature dans l'en-tête.
-- Ajoutez un composant chemin de navigation en faisant passer un élément enfant avec l'attribut `slot=”breadcrumb”`. Cela placera le chemin de navigation dans l'en-tête, sous le bouton de bascule de langue, la signature et la barre de recherche. 
+- Ajoutez un composant chemin de navigation en faisant passer un élément enfant avec l'attribut `slot=”breadcrumb”`. Cela placera le chemin de navigation dans l'en-tête, sous le bouton de bascule de langue, la signature et la barre de recherche.
 - Ajoutez une bannière en faisant passer un élément enfant avec l'attribut `slot=”banner”`. Cela placera l'élément en haut de l'en-tête sous l'élément `topnav`.
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-header."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-header--events-properties"
-  width="1200"
-  height="1535"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-header."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-header--events-properties"
+    width="1200"
+    height="1535"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/indicateur-detape/code.md
+++ b/src/fr/composants/indicateur-detape/code.md
@@ -18,12 +18,14 @@ Utilisez l'attribut `current-step` pour indiquer l'étape à laquelle l'utilisat
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-stepper."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-stepper--events-properties"
-  width="1200"
-  height="800"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-stepper."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-stepper--events-properties"
+    width="1200"
+    height="850"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/jeu-de-champs/code.md
+++ b/src/fr/composants/jeu-de-champs/code.md
@@ -21,7 +21,7 @@ Ajoutez du texte explicatif par défaut pour fournir du contexte supplémentaire
 ### Prendre en charge les messages d'erreur et le texte explicatif pour les boutons radio et les cases à cocher
 
 - Les attributs `required` et `error-message` fonctionnent mieux avec un groupe de [cases à cocher]({{ links.checkbox }}) ou de [boutons radio]({{ links.radio }}).
-- Conservez le texte explicatif, les validateurs et les messages d'erreur par défaut dans le jeu de champs pour les boutons radio et les cases à cocher.  
+- Conservez le texte explicatif, les validateurs et les messages d'erreur par défaut dans le jeu de champs pour les boutons radio et les cases à cocher.
 - Pour les boutons radio et les [cases à cocher]({{ links.input }}), insérez la question dans la légende afin d'aider les utilisateur·rice·s de lecteurs d'écran à comprendre que les entrées sont toutes liées.
 
 ### Validateurs
@@ -33,12 +33,14 @@ Le jeu de champs ne validera que les [cases à cocher]({{ links.checkbox }}) et 
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-fieldset."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-fieldset--events-properties"
-  width="1200"
-  height="1540"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-fieldset."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-fieldset--events-properties"
+    width="1200"
+    height="1600"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/message-derreur/code.md
+++ b/src/fr/composants/message-derreur/code.md
@@ -17,7 +17,7 @@ Tous les composants du système de conception GC sont déjà livrés avec une ge
 ### Rédigez des messages d'erreur pour faciliter l'accomplissement des tâches.
 
 - Assurez-vous que l'on puisse accéder immédiatement aux contrôles du formulaire associés au libellé auquel le message d'erreur est attaché.
-- Rédigez un message d'erreur spécifique pour éviter qu'il s'affiche à nouveau alors que l'utilisateur·rice pensait l'avoir corrigé.  
+- Rédigez un message d'erreur spécifique pour éviter qu'il s'affiche à nouveau alors que l'utilisateur·rice pensait l'avoir corrigé.
 - Ne proposez pas d'étapes supplémentaires. Précisez ce qu'il faut faire pour corriger l'erreur pour que l'on puisse prendre des mesures et soumettre de nouveau — voire revalider — les modifications sans devoir suivre des étapes supplémentaires.
 - Fournissez une ou deux solutions pour corriger l'erreur, plutôt qu'une démarche en plusieurs étapes.
 
@@ -38,12 +38,14 @@ La personne qui reçoit un message d'erreur doit :
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-error-message."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-message--events-properties"
-  width="1200"
-  height="675"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-error-message."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-message--events-properties"
+    width="1200"
+    height="900"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/pied-de-page/code.md
+++ b/src/fr/composants/pied-de-page/code.md
@@ -66,13 +66,14 @@ Pour la bande de lien du pied de page, réglez l'élément `sub-links` en passan
 
 {% include "partials/getcode.njk" %}
 
-
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-footer."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-footer--events-properties"
-  width="1200"
-  height="1110"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-footer."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-footer--events-properties"
+    width="1200"
+    height="1110"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/resume-de-erreurs/code.md
+++ b/src/fr/composants/resume-de-erreurs/code.md
@@ -34,12 +34,14 @@ Rédigez des en-têtes d'erreur plus précis en utilisant l'attribut `heading`.
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-error-summary."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-summary--events-properties"
-  width="1200"
-  height="1400"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-error-summary."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-summary--events-properties"
+    width="1200"
+    height="1500"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/fr/composants/zone-de-texte/code.md
+++ b/src/fr/composants/zone-de-texte/code.md
@@ -27,12 +27,14 @@ La zone de texte donne aux utilisateur·rice·s la possibilité de fournir les r
 
 {% include "partials/getcode.njk" %}
 
-<iframe
-  title="Survol des propriétés et des évènements relatifs à gcds-textarea."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-textarea--events-properties"
-  width="1200"
-  height="1825"
-  style="display: block; margin: 0 auto;"
-  frameBorder="0"
-  allow="clipboard-write"
-></iframe>
+<div class="iframe-container">
+  <iframe
+    title="Survol des propriétés et des évènements relatifs à gcds-textarea."
+    src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-textarea--events-properties"
+    width="1200"
+    height="1800"
+    style="display: block; margin: 0 auto;"
+    frameBorder="0"
+    allow="clipboard-write"
+  ></iframe>
+</div>

--- a/src/styles/_general.scss
+++ b/src/styles/_general.scss
@@ -21,4 +21,10 @@ body {
 
 iframe {
   max-width: 100%;
+  margin-block-start: -7.35rem !important;
+}
+
+.iframe-container {
+  overflow-y: hidden;
+  margin-block-start: var(--gcds-spacing-550);
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -95,7 +95,12 @@ body {
   display: none; }
 
 iframe {
-  max-width: 100%; }
+  max-width: 100%;
+  margin-block-start: -7.35rem !important; }
+
+.iframe-container {
+  overflow-y: hidden;
+  margin-block-start: var(--gcds-spacing-550); }
 
 .anatomy-list {
   counter-reset: item;


### PR DESCRIPTION
# Summary | Résumé

Due to the recent structure changes we made to our Storybook, the live demo iframe now loads in the heading "Events & properties". This adds an iframe-container around each live demo iframe to hide the heading.