### PR TITLE
Update create-component-page script

### DIFF
--- a/examples/component-name/base.md
+++ b/examples/component-name/base.md
@@ -2,18 +2,18 @@
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-enter-component-name
 figma: insert figma url
 permalink: false
-tags: ['navKey{locale}', 'header']
+tags: ['{navKey}{locale}', 'header']
 ---
 
-# componentName <br>`<gcds-component-name>`
+# {componentName} <br>`<gcds-component-name>`
 
-_alsoCalled: ._
+_{alsoCalled}: ._
 
 This element will have the content below it
 
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "componentPreview" %}
+{% componentPreview "{componentPreview}" %}
   Insert component here
 {% endcomponentPreview %}

--- a/examples/component-name/base.md
+++ b/examples/component-name/base.md
@@ -1,13 +1,19 @@
 ---
-github: https://github.com/cds-snc/gcds-components/tree/main/src/components/gcds-globalComponentName
-figma: https://www.figma.com/community/file/1128687821123298228
+github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-enter-component-name
+figma: insert figma url
 permalink: false
 tags: ['navKey{locale}', 'header']
 ---
 
-# componentName
+# componentName <br>`<gcds-component-name>`
+
+_alsoCalled: ._
 
 This element will have the content below it
 
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
+
+{% componentPreview "componentPreview" %}
+  Insert component here
+{% endcomponentPreview %}

--- a/examples/component-name/code.md
+++ b/examples/component-name/code.md
@@ -1,14 +1,14 @@
 ---
-title: componentName
+title: {componentName}
 layout: "layouts/component-documentation.njk"
-translationKey: "navKeyCode"
-tags: ['navKey{locale}', 'code']
+translationKey: "{navKey}Code"
+tags: ['{navKey}{locale}', 'code']
 # date: "git Last Modified"
 ---
 
-## buildComponent
+## {buildComponent}
 
-## codeA11y
+## {codeA11y}
 
 {% include "partials/getcode.njk" %}
 

--- a/examples/component-name/code.md
+++ b/examples/component-name/code.md
@@ -1,9 +1,23 @@
 ---
-title: componentName - {Components}
+title: componentName
 layout: "layouts/component-documentation.njk"
 translationKey: "navKeyCode"
 tags: ['navKey{locale}', 'code']
-date: "git Last Modified"
+# date: "git Last Modified"
 ---
 
-## Code
+## buildComponent
+
+## codeA11y
+
+{% include "partials/getcode.njk" %}
+
+<iframe
+  title="iframeTitle"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-{componentNameSlugEN}--events-properties"
+  width="1200"
+  height="1650"
+  style="display: block; margin: 0 auto;"
+  frameBorder="0"
+  allow="clipboard-write"
+></iframe>

--- a/examples/component-name/design.md
+++ b/examples/component-name/design.md
@@ -1,17 +1,17 @@
 ---
-title: componentName
+title: {componentName}
 layout: "layouts/component-documentation.njk"
-translationKey: "navKeyDesign"
-tags: ['navKey{locale}', 'design']
+translationKey: "{navKey}Design"
+tags: ['{navKey}{locale}', 'design']
 # date: "git Last Modified"
 ---
 
-## anatomy
+## {anatomy}
 
 <ol class="anatomy-list">
   <li><strong>list</strong></li>
 </ol>
 
-<img class="b-sm b-default p-400" src="/images/{localLower}/components/anatomy/gcds-{componentNameSlugEN}-anatomy.svg" alt="An image of the anatomy." />
+<img class="b-sm b-default p-400" src="/images/{local}/components/anatomy/gcds-{componentNameSlugEN}-anatomy.svg" alt="An image of the anatomy." />
 
-## designA11y
+## {designA11y}

--- a/examples/component-name/design.md
+++ b/examples/component-name/design.md
@@ -1,9 +1,17 @@
 ---
-title: componentName - {Components}
+title: componentName
 layout: "layouts/component-documentation.njk"
 translationKey: "navKeyDesign"
 tags: ['navKey{locale}', 'design']
-date: "git Last Modified"
+# date: "git Last Modified"
 ---
 
-## Design
+## anatomy
+
+<ol class="anatomy-list">
+  <li><strong>list</strong></li>
+</ol>
+
+<img class="b-sm b-default p-400" src="/images/{localLower}/components/anatomy/gcds-{componentNameSlugEN}-anatomy.svg" alt="An image of the anatomy." />
+
+## designA11y

--- a/examples/component-name/use-case.md
+++ b/examples/component-name/use-case.md
@@ -1,19 +1,30 @@
 ---
-title: componentName - {Components}
+title: componentName
 layout: "layouts/component-documentation.njk"
 eleventyNavigation:
   key: navKey{locale}
   title: componentName
   locale: {localeLower}
   parent: components{locale}
-  otherNames: Component
+  otherNames:
   description: This is the componentName
-  thumbnail: /images/{localeLower}/{components}/componentName.png
+  thumbnail: /images/common
   alt: This is an image of the component
+  state: coming-soon
 translationKey: "navKey"
 tags: ['navKey{locale}', 'usage']
-permalink: /{localeLower}/{components}/componentName/
-date: "git Last Modified"
+permalink: /{localeLower}/{components}/{componentNameSlug}/
+# date: "git Last Modified"
 ---
 
-## Use case
+## Problems component solves
+
+Use a componentName
+
+- 
+
+<article class="bg-full-width bg-primary text-light pt-500 pb-400 my-500">
+  <h2 class="mt-0 mb-400">related</h2>
+
+  <a href="" class="link-light">component</a>
+</article>

--- a/examples/component-name/use-case.md
+++ b/examples/component-name/use-case.md
@@ -1,30 +1,30 @@
 ---
-title: componentName
+title: {componentName}
 layout: "layouts/component-documentation.njk"
 eleventyNavigation:
-  key: navKey{locale}
-  title: componentName
+  key: {navKey}{locale}
+  title: {componentName}
   locale: {localeLower}
   parent: components{locale}
   otherNames:
-  description: This is the componentName
+  description: This is the {componentName}
   thumbnail: /images/common
   alt: This is an image of the component
   state: coming-soon
-translationKey: "navKey"
-tags: ['navKey{locale}', 'usage']
+translationKey: "{navKey}"
+tags: ['{navKey}{locale}', 'usage']
 permalink: /{localeLower}/{components}/{componentNameSlug}/
 # date: "git Last Modified"
 ---
 
 ## Problems component solves
 
-Use a componentName
+Use a {componentName}
 
 - 
 
 <article class="bg-full-width bg-primary text-light pt-500 pb-400 my-500">
-  <h2 class="mt-0 mb-400">related</h2>
+  <h2 class="mt-0 mb-400">{relatedComponents}</h2>
 
   <a href="" class="link-light">component</a>
 </article>

--- a/scripts/gen-component-page.js
+++ b/scripts/gen-component-page.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const replace = require('replace-in-file');
 const prompt = require('prompt-sync')();
-const slugify = require("./utils/slugify");
+const slugify = require("../utils/slugify");
 
 let englishName = prompt('English name: ');
 let frenchName = prompt('French name: ');
@@ -21,19 +21,19 @@ fs.rename(`${frenchDirectory}${frenchNameSlug}/use-case.md`, `${frenchDirectory}
 });
 
 let templateKeys = [
-  /componentName/g,
+  /{componentName}/g,
   /{componentNameSlug}/g,
-  /navKey/g,
+  /{navKey}/g,
   /{locale}/g,
-  /alsoCalled/g,
-  /componentPreview/g,
+  /{alsoCalled}/g,
+  /{componentPreview}/g,
   /{components}/g,
   /{localeLower}/g,
-  /related/g,
-  /anatomy/g,
-  /designA11y/g,
-  /buildComponent/g,
-  /codeA11y/g,
+  /{relatedComponents}/g,
+  /{anatomy}/g,
+  /{designA11y}/g,
+  /{buildComponent}/g,
+  /{codeA11y}/g,
   /{componentNameSlugEN}/g
 ];
 
@@ -54,8 +54,7 @@ let engOptions = {
     `${englishName} component preview`,
     "components",
     "en",
-    englishNameSlug,
-    "Related components"
+    "Related components",
     `${englishName} anatomy`,
     `Design and accessibility for ${englishName}`,
     `Build a ${englishName}`,
@@ -80,7 +79,6 @@ let frOptions = {
     `Aperçu du composant de ${frenchName}`,
     "composants",
     "fr",
-    frenchNameSlug,
     "Composants connexes",
     `Structure de la ${frenchName}`,
     `Accessibilité et design des ${frenchName}`,

--- a/scripts/gen-component-page.js
+++ b/scripts/gen-component-page.js
@@ -2,39 +2,92 @@ const fs = require('fs');
 const path = require('path');
 const replace = require('replace-in-file');
 const prompt = require('prompt-sync')();
+const slugify = require("./utils/slugify");
 
-const englishName = prompt('English name: ');
-const frenchName = prompt('French name: ');
+let englishName = prompt('English name: ');
+let frenchName = prompt('French name: ');
+
+let englishNameSlug =slugify(englishName);
+let frenchNameSlug =slugify(frenchName);
 
 let englishDirectory = './src/en/components/';
 let frenchDirectory = './src/fr/composants/';
 
-copyFolderSync('./examples/component-name', `${englishDirectory}${englishName}`);
-copyFolderSync('./examples/component-name', `${frenchDirectory}${frenchName}`);
+copyFolderSync('./examples/component-name', `${englishDirectory}${englishNameSlug}`);
+copyFolderSync('./examples/component-name', `${frenchDirectory}${frenchNameSlug}`);
 
-fs.rename(`${frenchDirectory}${frenchName}/use-case.md`, `${frenchDirectory}${frenchName}/case-dusage.md`, function(err) {
+fs.rename(`${frenchDirectory}${frenchNameSlug}/use-case.md`, `${frenchDirectory}${frenchNameSlug}/case-dusage.md`, function(err) {
   if ( err ) console.log('ERROR: ' + err);
 });
 
+let templateKeys = [
+  /componentName/g,
+  /{componentNameSlug}/g,
+  /navKey/g,
+  /{locale}/g,
+  /alsoCalled/g,
+  /componentPreview/g,
+  /{components}/g,
+  /{localeLower}/g,
+  /related/g,
+  /anatomy/g,
+  /designA11y/g,
+  /buildComponent/g,
+  /codeA11y/g,
+  /{componentNameSlugEN}/g
+];
+
 let engOptions = {
   files: [
-    `${englishDirectory}${englishName}/base.md`,
-    `${englishDirectory}${englishName}/use-case.md`,
-    `${englishDirectory}${englishName}/design.md`,
-    `${englishDirectory}${englishName}/code.md`
+    `${englishDirectory}${englishNameSlug}/base.md`,
+    `${englishDirectory}${englishNameSlug}/use-case.md`,
+    `${englishDirectory}${englishNameSlug}/design.md`,
+    `${englishDirectory}${englishNameSlug}/code.md`
   ],
-  from: [/componentName/g, /globalComponentName/g, /navKey/g, /{locale}/g, /{Components}/g, /{components}/g, /{localeLower}/g],
-  to: [englishName, englishName, englishName.replace('-', ''), "EN", "Components", "components", "en"]
+  from: templateKeys,
+  to: [
+    englishName,
+    englishNameSlug,
+    englishNameSlug.replace('-', ''),
+    "EN",
+    "Also called",
+    `${englishName} component preview`,
+    "components",
+    "en",
+    englishNameSlug,
+    "Related components"
+    `${englishName} anatomy`,
+    `Design and accessibility for ${englishName}`,
+    `Build a ${englishName}`,
+    `Coding and accessibility for ${englishName}`,
+    englishNameSlug
+  ]
 };
 let frOptions = {
   files: [
-    `${frenchDirectory}${frenchName}/base.md`,
-    `${frenchDirectory}${frenchName}/case-dusage.md`,
-    `${frenchDirectory}${frenchName}/design.md`,
-    `${frenchDirectory}${frenchName}/code.md`
+    `${frenchDirectory}${frenchNameSlug}/base.md`,
+    `${frenchDirectory}${frenchNameSlug}/case-dusage.md`,
+    `${frenchDirectory}${frenchNameSlug}/design.md`,
+    `${frenchDirectory}${frenchNameSlug}/code.md`
   ],
-  from: [/componentName/g, /globalComponentName/g, /navKey/g, /{locale}/g, /{Components}/g, /{components}/g, /{localeLower}/g],
-  to: [frenchName, englishName, englishName.replace('-', ''), "FR", "Composants", "composants", "fr"]
+  from: templateKeys,
+  to: [
+    frenchName,
+    frenchNameSlug,
+    englishNameSlug.replace('-', ''),
+    "FR",
+    "Autres noms ",
+    `Aperçu du composant de ${frenchName}`,
+    "composants",
+    "fr",
+    frenchNameSlug,
+    "Composants connexes",
+    `Structure de la ${frenchName}`,
+    `Accessibilité et design des ${frenchName}`,
+    `Créer une case à ${frenchName}`,
+    `Accessibilité et codage des cases à ${frenchName}`,
+    englishNameSlug
+  ]
 };
 
 try {


### PR DESCRIPTION
# Summary | Résumé

Update the `create-component-page` script to create pages that are closer to the final documentation pages. New pages will have all shortcodes and more complex sections, like the anatomy list, already on the page. The publisher will just need to fill in the relevant information after. Pages will appear under the coming-soon section until `state` has been updated.

## Usage

To use the `create-component-page` script, run `npm run create-component-page`. A prompt for `English name:` and `French name:` will appear, continue by entering the name of the component in both languages. After entering that information, English and French component pages will be created.

### Example

```
npm run create-component-page
English Name: File uploader
French name: Téléverseur de fichiers
```

This will generate the directories `/src/en/components/file-uploader/` and `/src/fr/composants/televerseur-de-fichiers/` with `base.md`, `use-case.md`, `design.md` and `code.md` files in them.