### PR TITLE
Use consistent "Experimental" tags for components in French

### DIFF
--- a/src/fr/composants/contenu-pour-lecteurs-decran/case-dusage.md
+++ b/src/fr/composants/contenu-pour-lecteurs-decran/case-dusage.md
@@ -10,7 +10,7 @@ eleventyNavigation:
   description: Information accessible par les technologies d'assistance, comme les lecteurs d'écran, mais invisible pour les utilisateur·rice·s voyant·e·s.
   thumbnail: /images/common/components/preview-screenreader-content.svg
   alt: Le composant Contenu pour lecteurs d'écran montre un rectangle avec une bordure en ligne pointillée. À l'intérieur de ce rectangle se trouve une icône barrée de couleur bleu foncé d'un œil, ainsi que 3 rectangles plus petits de couleur gris clair représentant le texte.
-  tag: Experimental
+  tag: À l'essai
   state: coming-soon
 translationKey: "screenreadercontent"
 tags: ['screenreadercontentFR', 'usage']

--- a/src/fr/composants/image/case-dusage.md
+++ b/src/fr/composants/image/case-dusage.md
@@ -10,6 +10,7 @@ eleventyNavigation:
   description: Un élément permettant d'afficher un contenu visuel optimisé et réactif.
   thumbnail: /images/common/components/preview-image.svg
   alt: Le composant Image montre un rectangle gris clair avec, à l'intérieur, un cercle gris foncé représentant le soleil et 2 triangles gris foncé représentant des montagnes.
+  tag: À l'essai
   state: coming-soon
 translationKey: "image"
 tags: ['imageFR', 'usage']


### PR DESCRIPTION
# Decision: Use "À l'essai" consistently in French

<img width="748" alt="Screenshot 2023-09-01 at 10 46 24 AM" src="https://github.com/cds-snc/gcds-docs/assets/38330843/aa9740b7-e9bb-4acd-8b18-478f8805c511">

# Match experimental tags in EN/FR
Image was missing tag in French

<img width="901" alt="Screenshot 2023-09-01 at 10 50 01 AM" src="https://github.com/cds-snc/gcds-docs/assets/38330843/c46a5fae-fdfe-4e80-ae84-e93220db7923">
