### PR TITLE
Add correct French names to other names in checkbox

### DIFF
--- a/src/fr/composants/Case-a-cocher/case-dusage.md
+++ b/src/fr/composants/Case-a-cocher/case-dusage.md
@@ -6,7 +6,7 @@ eleventyNavigation:
   title: Case à cocher
   locale: fr
   parent: componentsFR
-  otherNames: checklist.
+  otherNames: liste de contrôle, liste de vérification.
   description: Cases qui permettent la sélection d’une ou plusieurs options.
   thumbnail: /images/common/components/preview-checkbox.svg
   alt: Un aperçu du composant case à cocher avec trois options. La première option a une boîte blanche au contour noir avec une coche à l'intérieur suivi de deux longues boîtes grises rectangulaires qui représentent du texte. Les deux autres options sont représentées d'une boîte blanche au contour noir, vide, suivie de deux longues boites grises représentant du texte.


### PR DESCRIPTION
# Summary | Résumé

French other names for checkbox in component preview didn't have the correct names, added the correct names.
