### PR TITLE
Remove padding in pagination preview on smaller screen sizes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -225,7 +225,7 @@ module.exports = function (eleventyConfig) {
       </ul>`;
   });
 
-  eleventyConfig.addPairedShortcode('componentPreview', (children, title, padding = "py-400", margin = "my-500") => {
+  eleventyConfig.addPairedShortcode('componentPreview', (children, title, padding = "px-300 py-400", margin = "my-500") => {
     const content = children;
 
     return `
@@ -233,7 +233,7 @@ module.exports = function (eleventyConfig) {
         <p class="container-full font-semibold px-300 py-200 bb-sm b-default bg-light">
           ${title}
         </p>
-        <div class="px-300 ${padding}">
+        <div class="${padding}">
           ${content}
         </div>
       </div>

--- a/src/en/components/checkbox/base.md
+++ b/src/en/components/checkbox/base.md
@@ -15,7 +15,7 @@ A checkbox is a set of options for one or multiple selections.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Checkbox component preview" "pt-400" %}
+{% componentPreview "Checkbox component preview" "px-300 pt-400" %}
 <gcds-fieldset
   fieldset-id="fieldset"
   legend="Legend"

--- a/src/en/components/error-message/base.md
+++ b/src/en/components/error-message/base.md
@@ -15,6 +15,6 @@ An error message is a description of a problem blocking a user goal.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Error message component preview" "pt-400 pb-100" %}
+{% componentPreview "Error message component preview" "px-300 pt-400 pb-100" %}
 <gcds-error-message message="Error message or validation message."></gcds-error-message>
 {% endcomponentPreview %}

--- a/src/en/components/fieldset/base.md
+++ b/src/en/components/fieldset/base.md
@@ -15,7 +15,7 @@ A fieldset is a group of multiple form components or elements.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Fieldset component preview" "pt-400" %}
+{% componentPreview "Fieldset component preview" "px-300 pt-400" %}
 <gcds-fieldset
   fieldset-id="fieldset"
   legend="Legend"

--- a/src/en/components/header/base.md
+++ b/src/en/components/header/base.md
@@ -15,7 +15,7 @@ The header is the responsive Government of Canada branded header landmark.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Header component preview" "pt-400 pb-200" %}
+{% componentPreview "Header component preview" "px-300 pt-400 pb-200" %}
 <gcds-header lang-href="#" skip-to-href="#">
 </gcds-header>
 {% endcomponentPreview %}

--- a/src/en/components/input/base.md
+++ b/src/en/components/input/base.md
@@ -15,7 +15,7 @@ An input is a space to enter short-form information in response to a question or
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Input component preview" "pt-400" %}
+{% componentPreview "Input component preview" "px-300 pt-400" %}
 <gcds-input
   input-id="input-example"
   label="Label"

--- a/src/en/components/pagination/base.md
+++ b/src/en/components/pagination/base.md
@@ -15,7 +15,7 @@ Pagination is a division of content into multiple linked pages.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Pagination component preview" %}
+{% componentPreview "Pagination component preview" "xs:px-0 sm:px-0 md:px-0" %}
 <gcds-pagination
   label="Simple pagination example"
   display="simple"

--- a/src/en/components/pagination/base.md
+++ b/src/en/components/pagination/base.md
@@ -15,7 +15,7 @@ Pagination is a division of content into multiple linked pages.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Pagination component preview" "xs:px-0 sm:px-0 md:px-0" %}
+{% componentPreview "Pagination component preview" "px-0 lg:px-300 xl:px-300 py-400" %}
 <gcds-pagination
   label="Simple pagination example"
   display="simple"

--- a/src/en/components/radio/base.md
+++ b/src/en/components/radio/base.md
@@ -15,7 +15,7 @@ A radio is a set of options for a single selection.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Radio component preview" "pt-400 pb-200" %}
+{% componentPreview "Radio component preview" "px-300 pt-400 pb-200" %}
 <gcds-fieldset
   fieldset-id="fieldset"
   legend="Legend"

--- a/src/en/components/side-navigation/base.md
+++ b/src/en/components/side-navigation/base.md
@@ -14,7 +14,7 @@ A side navigation is a vertical list of page links on the left side of the scree
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Side navigation component preview" "pt-400 pb-200" %}
+{% componentPreview "Side navigation component preview" "px-300 pt-400 pb-200" %}
 <gcds-side-nav label="Side navigation component preview">
   <gcds-nav-link href="#">Nav link 1</gcds-nav-link>
   <gcds-nav-link href="#">Nav link 2</gcds-nav-link>

--- a/src/en/components/stepper/base.md
+++ b/src/en/components/stepper/base.md
@@ -15,6 +15,6 @@ A stepper is a progress tracker for a multi-step process.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Stepper component preview" "pt-400 pb-100" %}
+{% componentPreview "Stepper component preview" "px-300 pt-400 pb-100" %}
 <gcds-stepper current-step="1" total-steps="4"></gcds-stepper>
 {% endcomponentPreview %}

--- a/src/en/components/textarea/base.md
+++ b/src/en/components/textarea/base.md
@@ -15,7 +15,7 @@ A text area is a space to enter long-form information in response to a question 
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Text area component preview" "pt-400" %}
+{% componentPreview "Text area component preview" "px-300 pt-400" %}
 <gcds-textarea
   textarea-id="textarea-example"
   label="Label"

--- a/src/fr/composants/Case-a-cocher/base.md
+++ b/src/fr/composants/Case-a-cocher/base.md
@@ -15,7 +15,7 @@ La case à cocher permet de proposer un ensemble d'options en vue d'une sélecti
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant de case à cocher" "pt-400" %}
+{% componentPreview "Aperçu du composant de case à cocher" "px-300 pt-400" %}
 <gcds-fieldset
   fieldset-id="fieldset"
   legend="Légende"

--- a/src/fr/composants/barre-de-navigation-laterale/base.md
+++ b/src/fr/composants/barre-de-navigation-laterale/base.md
@@ -14,7 +14,7 @@ Une barre de navigation latérale consiste en une liste de liens de navigation s
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant barre de navigation latérale" "pt-400 pb-200" %}
+{% componentPreview "Aperçu du composant barre de navigation latérale" "px-300 pt-400 pb-200" %}
 <gcds-side-nav label="Aperçu du composant barre de navigation latérale" lang="fr">
   <gcds-nav-link href="#">Lien de navigation 1</gcds-nav-link>
   <gcds-nav-link href="#">Lien de navigation 2</gcds-nav-link>

--- a/src/fr/composants/bouton-radio/base.md
+++ b/src/fr/composants/bouton-radio/base.md
@@ -15,7 +15,7 @@ Un bouton radio permet de proposer plusieurs options de réponse pour un choix u
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant de radio" "pt-400 pb-200" %}
+{% componentPreview "Aperçu du composant de radio" "px-300 pt-400 pb-200" %}
 <gcds-fieldset
   fieldset-id="fieldset"
   legend="Légende"

--- a/src/fr/composants/champ-de-saisie/base.md
+++ b/src/fr/composants/champ-de-saisie/base.md
@@ -15,7 +15,7 @@ Un champ de saisie est un espace permettant de saisir une courte réponse à une
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant de champ de saisie" "pt-400" %}
+{% componentPreview "Aperçu du composant de champ de saisie" "px-300 pt-400" %}
 <gcds-input
   input-id="input-example"
   label="Étiquette de champ"

--- a/src/fr/composants/en-tete/base.md
+++ b/src/fr/composants/en-tete/base.md
@@ -15,7 +15,7 @@ L'en-tête porte l'image de marque réactive du gouvernement du Canada.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant de l'en-tête" "pt-400 pb-200" %}
+{% componentPreview "Aperçu du composant de l'en-tête" "px-300 pt-400 pb-200" %}
 <gcds-header lang-href="#" skip-to-href="#">
 </gcds-header>
 {% endcomponentPreview %}

--- a/src/fr/composants/indicateur-detape/base.md
+++ b/src/fr/composants/indicateur-detape/base.md
@@ -15,6 +15,6 @@ Un indicateur d'étape offre un suivi de l'avancement d'un processus comportant 
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant indicateur d'étape" "pt-400 pb-100" %}
+{% componentPreview "Aperçu du composant indicateur d'étape" "px-300 pt-400 pb-100" %}
 <gcds-stepper current-step="1" total-steps="4"></gcds-stepper>
 {% endcomponentPreview %}

--- a/src/fr/composants/jeu-de-champs/base.md
+++ b/src/fr/composants/jeu-de-champs/base.md
@@ -15,7 +15,7 @@ Un jeu de champs est un groupe de plusieurs composants ou éléments d’un form
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant de jeu de champs" "pt-400" %}
+{% componentPreview "Aperçu du composant de jeu de champs" "px-300 pt-400" %}
 <gcds-fieldset
   fieldset-id="fieldset"
   legend="Légende"

--- a/src/fr/composants/message-derreur/base.md
+++ b/src/fr/composants/message-derreur/base.md
@@ -15,6 +15,6 @@ Un message d’erreur est une description d’un problème représentant un obst
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant de message d'erreur" "pt-400 pb-100" %}
+{% componentPreview "Aperçu du composant de message d'erreur" "px-300 pt-400 pb-100" %}
 <gcds-error-message message="Message d'erreur ou message de validation."></gcds-error-message>
 {% endcomponentPreview %}

--- a/src/fr/composants/pagination/base.md
+++ b/src/fr/composants/pagination/base.md
@@ -15,7 +15,7 @@ La pagination est une division du contenu entre plusieurs pages liées.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant de la pagination" %}
+{% componentPreview "Aperçu du composant de la pagination" "xs:px-0 sm:px-0 md:px-0" %}
 <gcds-pagination
   label="pagination simple"
   display="simple"

--- a/src/fr/composants/pagination/base.md
+++ b/src/fr/composants/pagination/base.md
@@ -15,7 +15,7 @@ La pagination est une division du contenu entre plusieurs pages liées.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant de la pagination" "xs:px-0 sm:px-0 md:px-0" %}
+{% componentPreview "Aperçu du composant de la pagination" "px-0 lg:px-300 xl:px-300 py-400" %}
 <gcds-pagination
   label="pagination simple"
   display="simple"

--- a/src/fr/composants/zone-de-texte/base.md
+++ b/src/fr/composants/zone-de-texte/base.md
@@ -15,7 +15,7 @@ Une zone de texte est un espace permettant de saisir une réponse détaillée à
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% componentPreview "Aperçu du composant de zone de texte" "pt-400" %}
+{% componentPreview "Aperçu du composant de zone de texte" "px-300 pt-400" %}
 <gcds-textarea
   textarea-id="textarea-example"
   label="Libellé de champ"


### PR DESCRIPTION
# Summary | Résumé

Update component preview padding on pagination pages to not overlap on smaller screens.

Mid-size overlap change will need to happen in `gcds-pagination`
