### PR TITLE
fix live demo display

### DIFF
--- a/examples/component-name/code.md
+++ b/examples/component-name/code.md
@@ -14,7 +14,7 @@ tags: ['{navKey}{locale}', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-{componentNameSlugEN}--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-{componentNameSlugEN}--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/breadcrumbs/code.md
+++ b/src/en/components/breadcrumbs/code.md
@@ -31,9 +31,9 @@ Add a new breadcrumbs link to the breadcrumbs component by using the `<gcds-brea
 
 <iframe
   title="Overview of gcds-breadcrumbs properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&id=components-breadcrumbs--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&id=components-breadcrumbs--events-properties"
   width="1200"
-  height="1050"
+  height="1000"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/button/code.md
+++ b/src/en/components/button/code.md
@@ -28,9 +28,9 @@ Use a button for important actions a person using a product can initiate.
 
 <iframe
   title="Overview of gcds-button properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-button--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-button--events-properties"
   width="1200"
-  height="1920"
+  height="1650"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/card/code.md
+++ b/src/en/components/card/code.md
@@ -22,9 +22,9 @@ When you have more than 1 card on a page:
 
 <iframe
   title="Overview of gcds-card properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-card--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-card--events-properties"
   width="1200"
-  height="1800"
+  height="1750"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/checkbox/code.md
+++ b/src/en/components/checkbox/code.md
@@ -31,9 +31,9 @@ Use a checkbox with a [fieldset]({{ links.fieldset }}) when you are expecting th
 
 <iframe
   title="Overview of gcds-checkbox properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-checkbox--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-checkbox--events-properties"
   width="1200"
-  height="1850"
+  height="1800"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/container/code.md
+++ b/src/en/components/container/code.md
@@ -43,9 +43,9 @@ Containers are not centered automatically. To centre a container on a page, add 
 
 <iframe
   title="Overview of gcds-container properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-container--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-container--events-properties"
   width="1200"
-  height="1400"
+  height="1350"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/data-table/code.md
+++ b/src/en/components/data-table/code.md
@@ -14,7 +14,7 @@ tags: ['datatableEN', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-data-table--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-data-table--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/date-modified/code.md
+++ b/src/en/components/date-modified/code.md
@@ -21,9 +21,9 @@ Use the date modified component to identify the date a web page was last updated
 
 <iframe
   title="Overview of gcds-date-modified properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-date-modified--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-date-modified--events-properties"
   width="1200"
-  height="1000"
+  height="950"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/details/code.md
+++ b/src/en/components/details/code.md
@@ -34,9 +34,9 @@ To help a reader's experience accessing details content:
 
 <iframe
   title="Overview of gcds-details properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-details--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-details--events-properties"
   width="1200"
-  height="950"
+  height="900"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/error-message/code.md
+++ b/src/en/components/error-message/code.md
@@ -40,9 +40,9 @@ A person who receives an error message needs to:
 
 <iframe
   title="Overview of gcds-error-message properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-message--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-message--events-properties"
   width="1200"
-  height="900"
+  height="850"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/error-summary/code.md
+++ b/src/en/components/error-summary/code.md
@@ -36,9 +36,9 @@ Opt to make your error heading more specific by using the `heading` attributes.
 
 <iframe
   title="Overview of gcds-error-summary properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-summary--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-summary--events-properties"
   width="1200"
-  height="1500"
+  height="1450"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/fieldset/code.md
+++ b/src/en/components/fieldset/code.md
@@ -35,9 +35,9 @@ The fieldset will only validate [checkbox]({{ links.checkbox }}) and [radio butt
 
 <iframe
   title="Overview of gcds-fieldset properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-fieldset--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-fieldset--events-properties"
   width="1200"
-  height="2200"
+  height="2150"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/file-uploader/code.md
+++ b/src/en/components/file-uploader/code.md
@@ -26,9 +26,9 @@ Define the file types the file uploader accepts using the `accept` attribute.
 
 <iframe
   title="Overview of gcds-file-uploader properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-file-uploader--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-file-uploader--events-properties"
   width="1200"
-  height="1750"
+  height="1700"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/footer/code.md
+++ b/src/en/components/footer/code.md
@@ -63,9 +63,9 @@ Opt to include the contextual band to add up to three footer links for your prod
 
 <iframe
   title="Overview of gcds-footer properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-footer--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties"
   width="1200"
-  height="2050"
+  height="2000"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/grid/code.md
+++ b/src/en/components/grid/code.md
@@ -133,7 +133,7 @@ Mobile
 
 <iframe
   title="Overview of gcds-grid properties and events."
-  src="https://cds-snc.github.io/gcds-components/staging/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-grid--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-grid--events-properties"
   width="1200"
   height="2100"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/header/code.md
+++ b/src/en/components/header/code.md
@@ -41,9 +41,9 @@ Use this header landmark to communicate a Government of Canada digital service o
 
 <iframe
   title="Overview of gcds-header properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-header--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-header--events-properties"
   width="1200"
-  height="1535"
+  height="1450"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/heading/code.md
+++ b/src/en/components/heading/code.md
@@ -14,7 +14,7 @@ tags: ['headingEN', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-heading--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-heading--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/image/code.md
+++ b/src/en/components/image/code.md
@@ -14,7 +14,7 @@ tags: ['imageEN', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-image--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-image--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/input/code.md
+++ b/src/en/components/input/code.md
@@ -25,9 +25,9 @@ Use an input to ask for information short, one-line response.
 
 <iframe
   title="Overview of gcds-input properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-input--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-input--events-properties"
   width="1200"
-  height="1985"
+  height="1925"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/language-toggle/code.md
+++ b/src/en/components/language-toggle/code.md
@@ -23,9 +23,9 @@ Note: If using the header component, the language toggle can be assigned using t
 
 <iframe
   title="Overview of gcds-footer properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-language-toggle--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-language-toggle--events-properties"
   width="1200"
-  height="1110"
+  height="700"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/pagination/code.md
+++ b/src/en/components/pagination/code.md
@@ -17,7 +17,7 @@ Use pagination to break up content and spread it over numerous pages. This can h
 Use simple pagination for a smaller number of pages.
 
 - Set the `display` attribute to `simple`.
-- Set the previous page’s URL with the `previous-href` attribute.  
+- Set the previous page’s URL with the `previous-href` attribute.
 - Set the previous page’s label with the `previous-label` attribute.
 - Set the next page’s URL with the `next-href` attribute.
 - Set the next page’s label with the `next-label` attribute.
@@ -86,9 +86,9 @@ url={
 
 <iframe
   title="Overview of gcds-pagination properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-pagination--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-pagination--events-properties"
   width="1200"
-  height="1400"
+  height="1350"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/radio/code.md
+++ b/src/en/components/radio/code.md
@@ -24,9 +24,9 @@ The radio helps users to make a choice by limiting their options.
 
 <iframe
   title="Overview of gcds-radio properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-radio--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-radio--events-properties"
   width="1200"
-  height="1670"
+  height="1620"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/screenreader-content/code.md
+++ b/src/en/components/screenreader-content/code.md
@@ -14,7 +14,7 @@ tags: ['screenreadercontentEN', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-screenreader-content--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-screenreader-content--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/search/code.md
+++ b/src/en/components/search/code.md
@@ -14,7 +14,7 @@ tags: ['searchEN', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-search--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-search--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/select/code.md
+++ b/src/en/components/select/code.md
@@ -24,9 +24,9 @@ Use the `default-value` attribute to set the first option in the select list. Th
 
 <iframe
   title="Overview of gcds-select properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-select--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-select--events-properties"
   width="1200"
-  height="2100"
+  height="2050"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/side-navigation/code.md
+++ b/src/en/components/side-navigation/code.md
@@ -24,9 +24,9 @@ If using breadcrumbs, align the content hierarchy in both sets of links, so the 
 
 <iframe
   title="Overview of gcds-side-nav properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-side-navigation--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-side-navigation--events-properties"
   width="1200"
-  height="1700"
+  height="1650"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/signature/code.md
+++ b/src/en/components/signature/code.md
@@ -29,9 +29,9 @@ Use the signature type in the site’s <a href="{{ links.header }}">header</a> a
 
 <iframe
   title="Overview of gcds-side-nav properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-signature--events-properties#events--properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-signature--events-properties#events--properties"
   width="1200"
-  height="1100"
+  height="1050"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/stepper/code.md
+++ b/src/en/components/stepper/code.md
@@ -20,9 +20,9 @@ Use the `current-step` attribute to indicate the step that the user is on and th
 
 <iframe
   title="Overview of gcds-stepper properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-stepper--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-stepper--events-properties"
   width="1200"
-  height="850"
+  height="800"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/en/components/text/code.md
+++ b/src/en/components/text/code.md
@@ -14,7 +14,7 @@ tags: ['textEN', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-text--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-text--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/textarea/code.md
+++ b/src/en/components/textarea/code.md
@@ -29,7 +29,7 @@ The text area gives users the option to provide the information they want to sha
 
 <iframe
   title="Overview of gcds-textarea properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-textarea--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-textarea--events-properties"
   width="1200"
   height="1900"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/top-navigation/code.md
+++ b/src/en/components/top-navigation/code.md
@@ -26,9 +26,9 @@ Use a top navigation to help a person find their way around your web page or sit
 
 <iframe
   title="Overview of gcds-top-nav properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-top-navigation--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-top-navigation--events-properties"
   width="1200"
-  height="1750"
+  height="1700"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/Case-a-cocher/code.md
+++ b/src/fr/composants/Case-a-cocher/code.md
@@ -31,9 +31,9 @@ Utilisez une case à cocher avec un [jeu de champs]({{ links.fieldset }}) lorsqu
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-checkbox."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-checkbox--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-checkbox--events-properties"
   width="1200"
-  height="1850"
+  height="1800"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/Chemin-de-navigation/code.md
+++ b/src/fr/composants/Chemin-de-navigation/code.md
@@ -31,9 +31,9 @@ Ajoutez un nouveau lien au composant Chemin de navigation à l'aide du composant
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-breadcrumbs."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&id=components-breadcrumbs--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&id=components-breadcrumbs--events-properties"
   width="1200"
-  height="1050"
+  height="1000"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/barre-de-navigation-laterale/code.md
+++ b/src/fr/composants/barre-de-navigation-laterale/code.md
@@ -24,9 +24,9 @@ Si vous utilisez un composant Chemin de navigation, uniformisez la hiérarchie d
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-side-nav."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-side-navigation--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-side-navigation--events-properties"
   width="1200"
-  height="1700"
+  height="1650"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/barre-de-navigation-superieure/code.md
+++ b/src/fr/composants/barre-de-navigation-superieure/code.md
@@ -26,9 +26,9 @@ Utilisez une barre de navigation supérieure pour aider une personne à se repé
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-top-nav."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-top-navigation--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-top-navigation--events-properties"
   width="1200"
-  height="1750"
+  height="1700"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/bascule-de-langue/code.md
+++ b/src/fr/composants/bascule-de-langue/code.md
@@ -23,9 +23,9 @@ Remarque : Si vous utilisez le composant En-tête, la bascule de langue peut êt
 
 <iframe
   title="Overview of gcds-footer properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-language-toggle--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-language-toggle--events-properties"
   width="1200"
-  height="1110"
+  height="700"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/boite/code.md
+++ b/src/fr/composants/boite/code.md
@@ -43,9 +43,9 @@ Les boîtes ne sont pas automatiquement centrées. Pour centrer une boîte sur u
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-container."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-container--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-container--events-properties"
   width="1200"
-  height="1400"
+  height="1350"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/bouton-radio/code.md
+++ b/src/fr/composants/bouton-radio/code.md
@@ -24,9 +24,9 @@ Les boutons radio aident les utilisateur·rice·s a faire un choix en limitant l
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-radio."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-radio--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-radio--events-properties"
   width="1200"
-  height="1670"
+  height="1620"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/bouton/code.md
+++ b/src/fr/composants/bouton/code.md
@@ -14,7 +14,7 @@ Utilisez un bouton pour les actions importantes que peut initier une personne ut
 
 ### Rendez vos boutons accessibles
 
-- Vérifiez la visibilité de la bordure du bouton par rapport à la surface où vous le placez. 
+- Vérifiez la visibilité de la bordure du bouton par rapport à la surface où vous le placez.
 - Explicitez clairement l'action correspondant au bouton grâce à un libellé court et spécifique dans un format d'appel à l'action, comme « Démarrer l'application » ou « Enregistrer une copie ».
 - Évitez de réutiliser le texte du libellé sur la même page ou d'utiliser des libellés qui se ressemblent beaucoup. Une personne parcourant les champs à l'aide d'une technologie d'assistance entendra le texte de l'étiquette en succession rapide et n'aura pas d'indication pour associer le bouton à son action.
 
@@ -28,9 +28,9 @@ Utilisez un bouton pour les actions importantes que peut initier une personne ut
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-button."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-button--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-button--events-properties"
   width="1200"
-  height="1920"
+  height="1650"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/carte/code.md
+++ b/src/fr/composants/carte/code.md
@@ -22,9 +22,9 @@ Lorsque votre page comprend plusieurs cartes :
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-card."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-card--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-card--events-properties"
   width="1200"
-  height="1800"
+  height="1750"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/champ-de-saisie/code.md
+++ b/src/fr/composants/champ-de-saisie/code.md
@@ -26,9 +26,9 @@ Utilisez un champ de saisie pour obtenir une réponse courte d'une ligne.
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-input."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-input--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-input--events-properties"
   width="1200"
-  height="1985"
+  height="1925"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/contenu-pour-lecteurs-decran/code.md
+++ b/src/fr/composants/contenu-pour-lecteurs-decran/code.md
@@ -14,7 +14,7 @@ tags: ['screenreadercontentFR', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-screenreader-content--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-screenreader-content--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/date-de-modification/code.md
+++ b/src/fr/composants/date-de-modification/code.md
@@ -21,9 +21,9 @@ Utilisez le composant date de modification pour indiquer la date de la dernière
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-date-modified."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-date-modified--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-date-modified--events-properties"
   width="1200"
-  height="1000"
+  height="950"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/details/code.md
+++ b/src/fr/composants/details/code.md
@@ -34,9 +34,9 @@ Pour aider une personne à accéder au contenu du composant Détails :
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-details."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-details--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-details--events-properties"
   width="1200"
-  height="950"
+  height="900"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/en-tete/code.md
+++ b/src/fr/composants/en-tete/code.md
@@ -41,9 +41,9 @@ Utilisez ce point de repère pour transmettre de l'information sur un service du
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-header."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-header--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-header--events-properties"
   width="1200"
-  height="1535"
+  height="1450"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/grille/code.md
+++ b/src/fr/composants/grille/code.md
@@ -133,7 +133,7 @@ Mobile
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-grid."
-  src="https://cds-snc.github.io/gcds-components/staging/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-grid--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-grid--events-properties"
   width="1200"
   height="2100"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/image/code.md
+++ b/src/fr/composants/image/code.md
@@ -14,7 +14,7 @@ tags: ['imageFR', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-image--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-image--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/indicateur-detape/code.md
+++ b/src/fr/composants/indicateur-detape/code.md
@@ -20,9 +20,9 @@ Utilisez l'attribut `current-step` pour indiquer l'étape à laquelle l'utilisat
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-stepper."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-stepper--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-stepper--events-properties"
   width="1200"
-  height="850"
+  height="800"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/jeu-de-champs/code.md
+++ b/src/fr/composants/jeu-de-champs/code.md
@@ -35,9 +35,9 @@ Le jeu de champs ne validera que les [cases à cocher]({{ links.checkbox }}) et 
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-fieldset."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-fieldset--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-fieldset--events-properties"
   width="1200"
-  height="2200"
+  height="2150"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/message-derreur/code.md
+++ b/src/fr/composants/message-derreur/code.md
@@ -40,9 +40,9 @@ La personne qui reçoit un message d'erreur doit :
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-error-message."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-message--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-message--events-properties"
   width="1200"
-  height="900"
+  height="850"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/pagination/code.md
+++ b/src/fr/composants/pagination/code.md
@@ -17,7 +17,7 @@ Utilisez la pagination pour séparer le contenu et le répartir sur plusieurs pa
 Utilisez la pagination simple lorsque le nombre de pages est peu important.
 
 - Réglez l’attribut `display` sur `simple`.
-- Définissez l’URL de la page précédente à l’aide de l’attribut `previous-href`.  
+- Définissez l’URL de la page précédente à l’aide de l’attribut `previous-href`.
 - Définissez le libellé de la page précédente à l’aide de l’attribut `previous-label`.
 - Définissez l’URL de la page suivante à l’aide de l’attribut `next-href`.
 - Définissez le libellé de la page suivante à l’aide de l’attribut `next-label`.
@@ -86,9 +86,9 @@ url={
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-pagination."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-pagination--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-pagination--events-properties"
   width="1200"
-  height="1400"
+  height="1350"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/pied-de-page/code.md
+++ b/src/fr/composants/pied-de-page/code.md
@@ -69,9 +69,9 @@ Pour la bande de lien du pied de page, réglez l'élément `sub-links` en passan
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-footer."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-footer--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties"
   width="1200"
-  height="2050"
+  height="2000"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/recherche/code.md
+++ b/src/fr/composants/recherche/code.md
@@ -14,7 +14,7 @@ tags: ['searchFR', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-search--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-search--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/resume-de-erreurs/code.md
+++ b/src/fr/composants/resume-de-erreurs/code.md
@@ -36,9 +36,9 @@ Rédigez des en-têtes d'erreur plus précis en utilisant l'attribut `heading`.
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-error-summary."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-error-summary--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-summary--events-properties"
   width="1200"
-  height="1500"
+  height="1450"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/selection/code.md
+++ b/src/fr/composants/selection/code.md
@@ -24,9 +24,9 @@ Utilisez l'attribut `default-value` pour configurer la première option dans la 
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-select."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-select--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-select--events-properties"
   width="1200"
-  height="2100"
+  height="2050"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/signature/code.md
+++ b/src/fr/composants/signature/code.md
@@ -6,7 +6,7 @@ tags: ["signatureFR", "code"]
 date: "git Last Modified"
 ---
 
-## Cas d’utilisation principal
+## Cas d'utilisation principal
 
 Utilisez la signature comme image de marque claire et reconnaissable du gouvernement du Canada pour votre site ou produit.
 
@@ -14,24 +14,24 @@ Utilisez la signature comme image de marque claire et reconnaissable du gouverne
 
 ### Utilisation des types de signature et de mot-symbole
 
-Utilisez la signature dans <a href="{{ links.header }}">l’en-tête</a> du site et le mot-symbole dans <a href="{{ links.footer }}">le pied de page</a> du site.
+Utilisez la signature dans <a href="{{ links.header }}">l'en-tête</a> du site et le mot-symbole dans <a href="{{ links.footer }}">le pied de page</a> du site.
 
-- Utilisez l’attribut `type` pour définir la `signature`.
-- Utilisez l’attribut `type` pour définir le `wordmark`.
+- Utilisez l'attribut `type` pour définir la `signature`.
+- Utilisez l'attribut `type` pour définir le `wordmark`.
 
 ### Définir la langue et la couleur
 
-- Définissez les paramètres de langue de la page en utilisant l’attribut `lang`. L’attribut `Fr` définira le français comme la langue de la page et l’attribut `En` définira l’anglais comme la langue de la page.
-- Utilisez un lien hypertexte dans la signature pour qu’elle puisse mener à la page d’accueil Canada.ca dans la même langue officielle que la page actuelle. Définissez l’attribut `has-link` à `true` pour créer un lien hypertexte vers Canada.ca.
-- Définissez le composant comme `colour` ou `white` en utilisant l’attribut `variant`.
+- Définissez les paramètres de langue de la page en utilisant l'attribut `lang`. L'attribut `Fr` définira le français comme la langue de la page et l'attribut `En` définira l'anglais comme la langue de la page.
+- Utilisez un lien hypertexte dans la signature pour qu'elle puisse mener à la page d'accueil Canada.ca dans la même langue officielle que la page actuelle. Définissez l'attribut `has-link` à `true` pour créer un lien hypertexte vers Canada.ca.
+- Définissez le composant comme `colour` ou `white` en utilisant l'attribut `variant`.
 
 {% include "partials/getcode.njk" %}
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-signature."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-signature--events-properties#events--properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-signature--events-properties#events--properties"
   width="1200"
-  height="1100"
+  height="1050"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/tableau-de-donnees/code.md
+++ b/src/fr/composants/tableau-de-donnees/code.md
@@ -14,7 +14,7 @@ tags: ['datatableFR', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-data-table--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-data-table--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/televerseur-de-fichiers/code.md
+++ b/src/fr/composants/televerseur-de-fichiers/code.md
@@ -26,9 +26,9 @@ Utilisez l'attribut `accept` pour définir les types de fichiers acceptés par l
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-file-uploader."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-file-uploader--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-file-uploader--events-properties"
   width="1200"
-  height="1750"
+  height="1700"
   style="display: block; margin: 0 auto;"
   frameBorder="0"
   allow="clipboard-write"

--- a/src/fr/composants/texte/code.md
+++ b/src/fr/composants/texte/code.md
@@ -14,7 +14,7 @@ tags: ['textFR', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-text--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-text--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/titre/code.md
+++ b/src/fr/composants/titre/code.md
@@ -14,7 +14,7 @@ tags: ['headingFR', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-heading--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-heading--events-properties"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/zone-de-texte/code.md
+++ b/src/fr/composants/zone-de-texte/code.md
@@ -29,7 +29,7 @@ La zone de texte donne aux utilisateur·rice·s la possibilité de fournir les r
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-textarea."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&singleStory=true&id=components-textarea--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-textarea--events-properties"
   width="1200"
   height="1900"
   style="display: block; margin: 0 auto;"


### PR DESCRIPTION
# Summary | Résumé

Adjust live demo display to hide "Events & properties" heading.