### PR TITLE
Change text-only link to a button type

### DIFF
--- a/src/en/components/button/base.md
+++ b/src/en/components/button/base.md
@@ -20,5 +20,5 @@ A button is an interactive object that highlights an important or common action.
 <gcds-button button-role="secondary">Secondary label</gcds-button>
 <gcds-button button-role="danger">Danger label</gcds-button>
 <gcds-button button-role="skip-to-content">Skip-to-content label</gcds-button>
-<gcds-button type="link" button-style="text-only" href="#">Text-only label</gcds-button>
+<gcds-button button-style="text-only">Text-only label</gcds-button>
 {% endcomponentPreview %}

--- a/src/fr/composants/bouton/base.md
+++ b/src/fr/composants/bouton/base.md
@@ -20,5 +20,5 @@ Un bouton est un composant interactif qui met en évidence une action importante
 <gcds-button button-role="secondary">Secondaire</gcds-button>
 <gcds-button button-role="danger">Danger</gcds-button>
 <gcds-button button-role="skip-to-content">Aller au contenu</gcds-button>
-<gcds-button type="link" button-style="text-only" href="#">Text-only label</gcds-button>
+<gcds-button button-style="text-only">Text-only label</gcds-button>
 {% endcomponentPreview %}


### PR DESCRIPTION
# Summary | Résumé

Change `type` on the `text-only` button in the Button component preview to avoid jumping to the top of the page when clicking it.
