### PR TITLE
add h2 heading to component overview to improve structure of page

### DIFF
--- a/src/en/components/components.md
+++ b/src/en/components/components.md
@@ -24,3 +24,5 @@ We're sharing components as we build them.
 Core components help you meet federal identity standards for the Government of Canada in any product.
 
 Experimental components point out new features we're trying out and think you might like to use.
+
+## Browse components

--- a/src/fr/composants/composants.md
+++ b/src/fr/composants/composants.md
@@ -24,3 +24,5 @@ Nous proposons de nouveaux composants au fur et à mesure que nous les construis
 Les composants « De base » vous aident à respecter les normes du gouvernement fédéral canadien en matière d'identité, quel que soit votre produit.
 
 Les composants « À l'essai » indiquent de nouvelles fonctionnalités que nous testons ou qui devraient vous plaire.
+
+## Parcourir les composants


### PR DESCRIPTION
# Summary | Résumé

I noticed that our current structure on the component overview page was missing an H2 heading between the `Component tags` text and the component cards. I talked to Amy and got the English + French copy from her for the new H2 heading.

This should improve the structure of the page as we now have an H2 heading to summarize/introduce the component cards.