### PR TITLE
fix card preview

### DIFF
--- a/src/en/components/card/use-case.md
+++ b/src/en/components/card/use-case.md
@@ -40,38 +40,39 @@ Note: For Canada.ca, avoid using cards in place of the doormats specified in the
 
 </article>
 
-<div>
-  <h2>Component types</h2>
-  <div>
-    <h3 class="mb-400 mt-400">Link card</h3>
-      {% componentPreview "Link card preview" "py-400" %}
+## Component types
+
+### Link card
+
+{% componentPreview "Link card preview" "px-300 py-400" "my-400" %}
 <gcds-card card-title="Card title link" tag="Tag" href="#" description="Description or supporting text relating to the headline. Longer text will be truncated with ...">
-<div slot="footer">Context info • metadata</div>
+
+  <div slot="footer">Context info • metadata</div>
 </gcds-card>
 {% endcomponentPreview %}
-    <p class="mb-400">Use the link card to:</p>
-    <ul class="list-disc mb-400">
-      <li>Structure information on the same topic to progressively offer the reader more details</li>
-      <li>Include a link when there’s further information. Adding a link makes the entire card interactive as a large clickable target.</li>
-      <li>Provide a large, clickable target leading to more information.</li>
-    </ul>
-  </div>
 
-<div>
-<h3 class="mb-400 mt-400">Action card</h3>
-  {% componentPreview "Action card preview" "py-400" "" %}
-  <gcds-card card-title="Card title link" href="#" type="action" tag="Tag" description="Description or supporting text relating to the headline. Longer text will be truncated with ..." img-alt="#">
+<p class="mb-400">Use the link card to:</p>
+<ul class="list-disc mb-400">
+  <li>Structure information on the same topic to progressively offer the reader more details</li>
+  <li>Include a link when there’s further information. Adding a link makes the entire card interactive as a large clickable target.</li>
+  <li>Provide a large, clickable target leading to more information.</li>
+</ul>
+
+### Action card
+
+{% componentPreview "Action card preview" "px-300 py-400" "my-400" %}
+<gcds-card card-title="Card title link" href="#" type="action" tag="Tag" description="Description or supporting text relating to the headline. Longer text will be truncated with ..." img-alt="#">
+
   <div slot="footer">
     <gcds-button>Button label</gcds-button>
   </div>
 </gcds-card>
-  {% endcomponentPreview %}
-    <p class="mb-400">Use the action card to:</p>
-    <ul class="list-disc mb-400">
-      <li>Group information that supports a task. The main action features on a button in the card footer.</li>
-      <li>Highlight an immediate action a person can take using the button.</li>
-      <li>Give a person the choice to learn more by selecting the card title headline link before moving to action.</li>
-    </ul>
-    <p>Note: In the action card, only the card title headline link and the button are interactive. The button is for a specific action</p>
-  </div>
-</div>
+{% endcomponentPreview %}
+
+<p class="mb-400">Use the action card to:</p>
+<ul class="list-disc mb-400">
+  <li>Group information that supports a task. The main action features on a button in the card footer.</li>
+  <li>Highlight an immediate action a person can take using the button.</li>
+  <li>Give a person the choice to learn more by selecting the card title headline link before moving to action.</li>
+</ul>
+<p>Note: In the action card, only the card title headline link and the button are interactive. The button is for a specific action</p>

--- a/src/fr/composants/carte/case-dusage.md
+++ b/src/fr/composants/carte/case-dusage.md
@@ -40,39 +40,39 @@ Remarque : Pour Canada.ca, évitez d'utiliser des cartes au lieu des éléments 
 
 </article>
 
-<div>
-  <h2>Types de composants</h2>
-  <h3 class="mb-400 mt-400">Carte « Lien »</h3>
-  {% componentPreview "Aperçu de carte « Lien »" "py-400" "" %}
-  <gcds-card card-title="Titre de la carte" tag="Balise" href="#" description="Description destinée à accompagner le titre. Les textes plus longs seront tronqués avec ...">
-<div slot="footer">Infos contextuelles • metadonnées</div>
+## Types de composants
+
+### Carte « Lien »
+
+{% componentPreview "Aperçu de carte « Lien »" "px-300 py-400" "my-400" %}
+<gcds-card card-title="Titre de la carte" tag="Balise" href="#" description="Description destinée à accompagner le titre. Les textes plus longs seront tronqués avec ...">
+
+  <div slot="footer">Infos contextuelles • metadonnées</div>
 </gcds-card>
-  {% endcomponentPreview %}
+{% endcomponentPreview %}
 
-  <div class="mt-400">
-    <p class="mb-400">Utilisez la carte « Lien » aux fins suivantes :</p>
-    <ul class="list-disc mb-400">
-      <li>Structurer des renseignements relatifs à un même thème pour offrir au lectorat davantage de détails de manière progressive.</li>
-      <li>Inclure un lien permettant d'accéder à davantage d'informations. Ajouter un lien rendant l'ensemble de la carte interactive et cliquable.</li>
-      <li>Offrir une large cible cliquable permettant d'accéder à d'autres renseignements.</li>
-    </ul>
-  </div>
+<p class="mb-400">Utilisez la carte « Lien » aux fins suivantes :</p>
+<ul class="list-disc mb-400">
+  <li>Structurer des renseignements relatifs à un même thème pour offrir au lectorat davantage de détails de manière progressive.</li>
+  <li>Inclure un lien permettant d'accéder à davantage d'informations. Ajouter un lien rendant l'ensemble de la carte interactive et cliquable.</li>
+  <li>Offrir une large cible cliquable permettant d'accéder à d'autres renseignements.</li>
+</ul>
 
-<div>
-    <h3 class="mb-400 mt-400">Carte « Action »</h3>
-  {% componentPreview "Aperçu de carte « Action »" "py-400" "" %}
-  <gcds-card card-title="Titre de la carte" href="#" type="action" tag="Balise" description="Description destinée à accompagner le titre. Les textes plus longs seront tronqués avec ..." img-alt="#">
+### Carte « Action »
+
+{% componentPreview "Aperçu de carte « Action »" "px-300 py-400" "my-400" %}
+<gcds-card card-title="Titre de la carte" href="#" type="action" tag="Balise" description="Description destinée à accompagner le titre. Les textes plus longs seront tronqués avec ..." img-alt="#">
+
   <div slot="footer">
     <gcds-button>Libellé du bouton</gcds-button>
   </div>
 </gcds-card>
-  {% endcomponentPreview %}
-    <p class="mb-400">Utilisez la carte « Action » aux fins suivantes :</p>
-    <ul class="list-disc mb-400">
-      <li>Regrouper des renseignements permettant d'accomplir une tâche. La carte action compte un bouton dans le pied de page. </li>
-      <li>Souligner une action immédiate que peut entreprendre la personne à l'aide du bouton.</li>
-      <li>Offrir à une personne la possibilité d'en savoir plus en sélectionnant le titre avant de passer à l'action.</li>
-    </ul>
-    <p>Remarque : Dans la carte « Action », seuls le lien du titre et le bouton sont interactifs. Le bouton est consacré à une action spécifique.</p>
-  </div>
-</div>
+{% endcomponentPreview %}
+
+<p class="mb-400">Utilisez la carte « Action » aux fins suivantes :</p>
+<ul class="list-disc mb-400">
+  <li>Regrouper des renseignements permettant d'accomplir une tâche. La carte action compte un bouton dans le pied de page. </li>
+  <li>Souligner une action immédiate que peut entreprendre la personne à l'aide du bouton.</li>
+  <li>Offrir à une personne la possibilité d'en savoir plus en sélectionnant le titre avant de passer à l'action.</li>
+</ul>
+<p>Remarque : Dans la carte « Action », seuls le lien du titre et le bouton sont interactifs. Le bouton est consacré à une action spécifique.</p>


### PR DESCRIPTION
# Summary | Résumé

The card preview in the use case section was missing some inline padding that I added in.

Before:

![Screenshot 2023-11-01 at 9 41 59 AM](https://github.com/cds-snc/gcds-docs/assets/8675814/315ea72e-d0c9-43a7-869e-566b98eec7b5)

After:

![Screenshot 2023-11-01 at 10 15 17 AM](https://github.com/cds-snc/gcds-docs/assets/8675814/9c665cd8-ed20-481d-b67c-1242f34120f9)



