### PR TITLE
fix button previews

### DIFF
--- a/src/en/components/button/use-case.md
+++ b/src/en/components/button/use-case.md
@@ -79,7 +79,7 @@ A role is a button sub-type that has a specific use on a page.
 
 <div class="remove-empty-p">
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Primary button preview" "py-400" "" %}
+  {% componentPreview "Primary button preview" "px-300 py-400" "" %}
   <gcds-button button-role="primary">Primary</gcds-button>
   {% endcomponentPreview %}
   <div>
@@ -94,7 +94,7 @@ A role is a button sub-type that has a specific use on a page.
 </gcds-grid>
 <br/>
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Secondary button preview" "py-400" "" %}
+  {% componentPreview "Secondary button preview" "px-300 py-400" "" %}
   <gcds-button button-role="secondary">Secondary</gcds-button>
   {% endcomponentPreview %}
   <div>
@@ -108,7 +108,7 @@ A role is a button sub-type that has a specific use on a page.
 </gcds-grid>
 <br/>
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Danger button preview" "py-400" "" %}
+  {% componentPreview "Danger button preview" "px-300 py-400" "" %}
   <gcds-button button-role="danger">Danger</gcds-button>
   {% endcomponentPreview %}
   <div>
@@ -122,7 +122,7 @@ A role is a button sub-type that has a specific use on a page.
 </gcds-grid>
 <br/>
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Skip-to-content button preview" "py-400" "" %}
+  {% componentPreview "Skip-to-content button preview" "px-300 py-400" "" %}
   <gcds-button button-role="skip-to-content">Skip-to-content</gcds-button>
   <p><small>Hidden by default</small></p>
   {% endcomponentPreview %}

--- a/src/fr/composants/bouton/case-dusage.md
+++ b/src/fr/composants/bouton/case-dusage.md
@@ -79,7 +79,7 @@ Un rôle est un sous-type de bouton à usage spécifique sur une page.
 
 <div class="remove-empty-p">
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Aperçu du bouton principal" "py-400" "" %}
+  {% componentPreview "Aperçu du bouton principal" "px-300 py-400" "" %}
   <gcds-button button-role="primary">Principal</gcds-button>
   {% endcomponentPreview %}
   <div>
@@ -94,7 +94,7 @@ Un rôle est un sous-type de bouton à usage spécifique sur une page.
 </gcds-grid>
 <br/>
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Aperçu du bouton secondaire" "py-400" "" %}
+  {% componentPreview "Aperçu du bouton secondaire" "px-300 py-400" "" %}
   <gcds-button button-role="secondary">Secondaire</gcds-button>
   {% endcomponentPreview %}
   <div>
@@ -108,7 +108,7 @@ Un rôle est un sous-type de bouton à usage spécifique sur une page.
 </gcds-grid>
 <br/>
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Aperçu du bouton « Danger »" "py-400" "" %}
+  {% componentPreview "Aperçu du bouton « Danger »" "px-300 py-400" "" %}
   <gcds-button button-role="danger">Danger</gcds-button>
   {% endcomponentPreview %}
   <div>
@@ -122,7 +122,7 @@ Un rôle est un sous-type de bouton à usage spécifique sur une page.
 </gcds-grid>
 <br/>
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Aperçu du bouton « Aller au contenu »" "py-400" "" %}
+  {% componentPreview "Aperçu du bouton « Aller au contenu »" "px-300 py-400" "" %}
   <gcds-button button-role="skip-to-content">Aller au contenu</gcds-button>
   <p><small>Masqué par défaut</small></p>
   {% endcomponentPreview %}


### PR DESCRIPTION
# Summary | Résumé

The button previews in the use case section were missing some inline padding that I added in.

Before:

![Screenshot 2023-11-02 at 8 56 51 AM](https://github.com/cds-snc/gcds-docs/assets/8675814/b669cef7-ef89-47c4-b00d-fcb6ccf6ce6f)

After:

![Screenshot 2023-11-02 at 9 19 04 AM](https://github.com/cds-snc/gcds-docs/assets/8675814/41a21dfe-7a23-4ffc-941b-db8b937214a1)

