### PR TITLE
integrate gcds-link component

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -191,14 +191,12 @@ module.exports = function (eleventyConfig) {
           stage: 'stage',
           figma: 'Figma',
           github: 'GitHub',
-          newtab: '(Opens in a new tab)',
           comingsoon: 'coming soon',
         },
         fr: {
           stage: 'phase',
           figma: 'Figma',
           github: 'GitHub',
-          newtab: "(S'ouvre dans un nouvel onglet)",
           comingsoon: 'à venir',
         },
       };
@@ -210,7 +208,7 @@ module.exports = function (eleventyConfig) {
       if (figma) {
         figmaLink = `
         <li class="figma-link">
-          <a href="${figma}" target="_blank" rel="nofollow" aria-label="${langStrings[locale].figma} ${langStrings[locale].newtab}">${langStrings[locale].figma}<gcds-icon name="external-link" margin-left="100" /></a>
+          <gcds-link external href="${figma}">${langStrings[locale].figma}</gcds-link>
         </li>`;
       } else {
         figmaLink = `
@@ -226,7 +224,7 @@ module.exports = function (eleventyConfig) {
       return `
       <ul class="d-flex flex-wrap gap-400">
         ${stageChip} <li class="github-link">
-          <a href="${githubLink}" target="_blank" rel="nofollow" aria-label="${langStrings[locale].github} ${langStrings[locale].newtab}">${langStrings[locale].github}<gcds-icon name="external-link" margin-left="100" /></a>
+          <gcds-link external href="${githubLink}">${langStrings[locale].github}</gcds-link>
         </li> ${figmaLink}
       </ul>`;
     },

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
-    "@cdssnc/gcds-components": "^0.15.0",
-    "@cdssnc/gcds-tokens": "^1.9.2",
+    "@cdssnc/gcds-components": "^0.17.0",
+    "@cdssnc/gcds-tokens": "^1.10.1",
     "@cdssnc/gcds-utility": "^1.0.7",
     "@quasibit/eleventy-plugin-sitemap": "^2.1.4",
     "chroma-js": "^2.4.2",

--- a/src/_data/lookingfor.js
+++ b/src/_data/lookingfor.js
@@ -2,7 +2,7 @@ module.exports = {
   en: {
     heading: 'Looking for another component?',
     coparagraph:
-      'Check out our <a href="/en/components/">components page</a>. If the component\'s not there, send us feedback on what you\'d like us to work on next.',
+      'Check out our <gcds-link href="/en/components/">components page</gcds-link>. If the component\'s not there, send us feedback on what you\'d like us to work on next.',
     csparagraph:
       "Share your feedback with us to help improve GC Design System or you can check out what's coming soon.",
     feedback: 'Give feedback',
@@ -15,7 +15,7 @@ module.exports = {
   fr: {
     heading: "À la recherche d'un autre composant?",
     coparagraph:
-      'Rendez vous sur notre <a href="/fr/composants/">page de composants</a>. S\'il y manque un composant, écrivez nous pour nous faire savoir les composants que vous souhaitez voir dans le futur.',
+      'Rendez vous sur notre <gcds-link href="/fr/composants/">page de composants</gcds-link>. S\'il y manque un composant, écrivez nous pour nous faire savoir les composants que vous souhaitez voir dans le futur.',
     csparagraph:
       "Faites-nous part de vos commentaires pour l'amélioration de Système de design GC ou découvrez nos futures fonctionnalités.",
     feedback: 'Fournir des commentaires',

--- a/src/_includes/partials/onthispage.njk
+++ b/src/_includes/partials/onthispage.njk
@@ -5,7 +5,7 @@
         <ul>
             {% for key, item in onthispage %}
                 <li>
-                    <a href="#{{ item }}">{{ key }}</a>
+                    <gcds-link href="#{{ item }}">{{ key }}</gcds-link>
                 </li>
             {% endfor %}
         </ul>

--- a/src/en/components/breadcrumbs/code.md
+++ b/src/en/components/breadcrumbs/code.md
@@ -21,7 +21,7 @@ Tip: For a process that does not have a traditional landing page, link to the st
 
 ### Place breadcrumbs before the `<main>` element
 
-Place breadcrumbs at the top of a page, before the `<main>` element. This way the <a href="{{ links.button }}">skip-to-content button</a> can work to let a person skip all navigation links, including breadcrumbs.
+Place breadcrumbs at the top of a page, before the `<main>` element. This way the <gcds-link href="{{ links.button }}">skip-to-content button</gcds-link> can work to let a person skip all navigation links, including breadcrumbs.
 
 ### Use breadcrumb items for breadcrumbs links
 

--- a/src/en/components/breadcrumbs/design.md
+++ b/src/en/components/breadcrumbs/design.md
@@ -20,7 +20,7 @@ date: 'git Last Modified'
 ### Breadcrumbs anatomy – with header and H1 title
 
 <ol class="anatomy-list">
-  <li>The <a href="{{ links.header }}"><strong>header</strong></a> is part of a trusted brand — for apps, forms, or other transactional digital services.</li>
+  <li>The <gcds-link href="{{ links.header }}"><strong>header</strong></gcds-link> is part of a trusted brand — for apps, forms, or other transactional digital services.</li>
   <li>The <strong>home page link</strong> navigates back to the home page of the current webpage or site.</li>
   <li>The <strong>parent page link</strong> navigates to the parent page of the current page. You can have up to three parent page links in addition to the homepage and the Canada.ca home or 5 in total.</li>
   <li>The <strong>H1 title</strong> is a separate element from the breadcrumbs component. It tells readers what the page or site is about and acts a signpost, giving them a sense of place.</li>
@@ -44,7 +44,7 @@ Breadcrumbs represent the location of the current page in relation to the site's
 - Avoid using the breadcrumbs component to show progress through the user journey.
 - Limit breadcrumbs to 5 levels. Displaying too many levels of breadcrumbs items can be overwhelming.
 
-Tip: If using with other navigation components, like the <a href="{{ links.topNav }}">top navigation</a> and <a href="{{ links.sideNav }}">side navigation</a>, align both sets of links, so elements reflect a similar path through the site. This provides a consistent navigation experience and helps visitors understand their current location.
+Tip: If using with other navigation components, like the <gcds-link href="{{ links.topNav }}">top navigation</gcds-link> and <gcds-link href="{{ links.sideNav }}">side navigation</gcds-link>, align both sets of links, so elements reflect a similar path through the site. This provides a consistent navigation experience and helps visitors understand their current location.
 
 ### Write specific parent page link text
 
@@ -54,4 +54,4 @@ Tip: If using with other navigation components, like the <a href="{{ links.topNa
 
 ### Place breadcrumbs before the main element
 
-Place breadcrumbs at the top of a page, before the main content. This way the <a href="{{ links.button }}">skip-to-content button</a> can work to let a person skip all navigation links, including breadcrumbs.
+Place breadcrumbs at the top of a page, before the main content. This way the <gcds-link href="{{ links.button }}">skip-to-content button</gcds-link> can work to let a person skip all navigation links, including breadcrumbs.

--- a/src/en/components/date-modified/use-case.md
+++ b/src/en/components/date-modified/use-case.md
@@ -36,7 +36,7 @@ Use date modified to:
 
 <div class="remove-empty-p">
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Date type preview" "py-400" "" %}
+  {% componentPreview "Date type preview" "px-300 py-400" "" %}
   <gcds-date-modified>2023-08-22</gcds-date-modified>
   {% endcomponentPreview %}
   <div>
@@ -49,7 +49,7 @@ Use date modified to:
 </gcds-grid>
 <br/>
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Version type preview" "py-400" "" %}
+  {% componentPreview "Version type preview" "px-300 py-400" "" %}
   <gcds-date-modified type="version">1.0.0</gcds-date-modified>
   {% endcomponentPreview %}
   <div>

--- a/src/en/components/error-summary/code.md
+++ b/src/en/components/error-summary/code.md
@@ -18,7 +18,7 @@ All GC Design System components come with default error handling for required fo
 The GC Design System error summary uses the `listen` attribute to collect errors. The error summary will list errors from GC Design System components `onSubmit`. Errors are listed in the same order as they appear on the page.
 
 - Enable any controls the person will need to access to recover from any of the errors.
-- Consider replacing any generic default <a href="{{ links.errorMessage }}">error message</a> with text that defines the specific problem and how a person can fix it.
+- Consider replacing any generic default <gcds-link href="{{ links.errorMessage }}">error message</gcds-link> with text that defines the specific problem and how a person can fix it.
 
 ### Opt to use the error summary with your own component instances
 

--- a/src/en/components/error-summary/design.md
+++ b/src/en/components/error-summary/design.md
@@ -22,7 +22,7 @@ tags: ['errorsummaryEN', 'design']
 Keep in mind that errors interrupt the flow of a person's action in your product. This can be jarring and uncomfortable.
 
 - Provide a clear path to fixing the error. Errors elicit an emotional response that is heightened when the problem is difficult or impossible to resolve.
-- Make the <a href="{{ links.errorMessage }}">error message</a> and recovery obvious to get a person back on task and regain momentum.
+- Make the <gcds-link href="{{ links.errorMessage }}">error message</gcds-link> and recovery obvious to get a person back on task and regain momentum.
 - Keep the error summary list readable with short and specific error messages.
 - Limit the number of form components on a page that require a response.
 

--- a/src/en/components/error-summary/use-case.md
+++ b/src/en/components/error-summary/use-case.md
@@ -25,7 +25,7 @@ GC Design System form components come with default error handling. When a person
 Use an error summary to interrupt a person who's submitting a form when there is a problem or a series of problems to:
 
 - Make errors obvious so a person knows about them and how to address them.
-- List <a href="{{ links.errorMessage }}">error messages</a> when a person needs to add information or make a correction to two or more components before they can submit a form.
+- List <gcds-link href="{{ links.errorMessage }}">error messages</gcds-link> when a person needs to add information or make a correction to two or more components before they can submit a form.
 
 <article class="bg-full-width bg-primary text-light pt-500 pb-400 my-500">
   <h2 class="mt-0 mb-400">Related components</h2>

--- a/src/en/components/grid/code.md
+++ b/src/en/components/grid/code.md
@@ -30,7 +30,7 @@ Tip: Keep layouts simple. Consider optimizing each layout for mobile, tablet, an
 - Add space between columns to reduce the cognitive load of reading content too densely packed together.
 - Whenever possible, align objects both vertically and horizontally.
 - Use the `gap` property to add spacing between your `columns` in the grid.
-- Use GC Design System <a href="{{ links.designTokens }}">design tokens</a> as a reference for the size of the `gap` in the grid. The tokens measurements match up with the spacing values for the `gap` attribute.
+- Use GC Design System <gcds-link href="{{ links.designTokens }}">design tokens</gcds-link> as a reference for the size of the `gap` in the grid. The tokens measurements match up with the spacing values for the `gap` attribute.
 
 ### Choose an option for equal width columns
 

--- a/src/en/components/grid/design.md
+++ b/src/en/components/grid/design.md
@@ -38,7 +38,7 @@ Tip: Keep grid layouts simple by designing for mobile, tablet, and desktop exper
 
 - Add space between columns to reduce the cognitive load of reading content too densely packed together.
 - Whenever possible, align objects both vertically and horizontally.
-- Select the gap size, or space between columns, by choosing a measurement option from our <a href="{{ links.spacing }}">spacing tokens</a>.
+- Select the gap size, or space between columns, by choosing a measurement option from our <gcds-link href="{{ links.spacing }}">spacing tokens</gcds-link>.
 
 ### Communicate meaning by adjusting spacing
 

--- a/src/en/components/search/code.md
+++ b/src/en/components/search/code.md
@@ -10,7 +10,7 @@ date: 'git Last Modified'
 
 Use the search component so people can find information based on keywords.
 
-- Place the search component in the <a href="{{ links.header }}">header</a> below the language toggle and in line with the <a href="{{ links.signature }}">Government of Canada signature</a>.
+- Place the search component in the <gcds-link href="{{ links.header }}">header</gcds-link> below the language toggle and in line with the <gcds-link href="{{ links.signature }}">Government of Canada signature</gcds-link>.
 - Ensure the header is responsive so that the search appears below both the signature and the language toggle on mobile devices.
 
 ## Coding and accessibility for search

--- a/src/en/components/search/design.md
+++ b/src/en/components/search/design.md
@@ -3,7 +3,7 @@ title: Search
 layout: 'layouts/component-documentation.njk'
 translationKey: 'searchDesign'
 tags: ['searchEN', 'design']
-date: "git Last Modified"
+date: 'git Last Modified'
 ---
 
 ## Search anatomy
@@ -21,5 +21,5 @@ date: "git Last Modified"
 
 ### Place the search in a predictable location in the header
 
-- Place the search component in the <a href="{{ links.header }}">header</a> below the language toggle and in line with the <a href="{{ links.signature }}">Government of Canada signature</a>.
+- Place the search component in the <gcds-link href="{{ links.header }}">header</gcds-link> below the language toggle and in line with the <gcds-link href="{{ links.signature }}">Government of Canada signature</gcds-link>.
 - Ensure the header is responsive so that the search appears below both the signature and the language toggle on mobile devices.

--- a/src/en/components/select/design.md
+++ b/src/en/components/select/design.md
@@ -35,4 +35,4 @@ date: 'git Last Modified'
 ### Use other questions to reduce select option size
 
 - Try asking the users other questions before using the select in order to reduce the amount of options.
-- If the list of items is smaller (6-7 items or less), consider using <a href="{{ links.radio }}">radio buttons</a> instead.
+- If the list of items is smaller (6-7 items or less), consider using <gcds-link href="{{ links.radio }}">radio buttons</gcds-link> instead.

--- a/src/en/components/signature/code.md
+++ b/src/en/components/signature/code.md
@@ -14,14 +14,14 @@ Use the signature component for a clear and identifiable Government of Canada la
 
 ### Apply the signature or wordmark types
 
-Use the signature type in the site’s <a href="{{ links.header }}">header</a> and the wordmark type in the site’s <a href="{{ links.footer }}">footer</a>.
+Use the signature type in the site's <gcds-link href="{{ links.header }}">header</gcds-link> and the wordmark type in the site's <gcds-link href="{{ links.footer }}">footer</gcds-link>.
 
 - Set the `type` attribute to `signature`.
 - Set the `type` attribute to `wordmark`.
 
 ### Set the language and colour
 
-- Set the page’s language settings using the `lang` attribute. `En` will render the English version for an English page and `Fr` will render the French version for a French page.
+- Set the page's language settings using the `lang` attribute. `En` will render the English version for an English page and `Fr` will render the French version for a French page.
 - Link the signature to the Canada.ca homepage in the same Official Language as the current page. Set `has-link` attribute to `true` to link to Canada.ca.
 - Set the component to either `colour` or `white` using the `variant` attribute.
 

--- a/src/en/components/signature/design.md
+++ b/src/en/components/signature/design.md
@@ -9,8 +9,8 @@ date: 'git Last Modified'
 ## Signature anatomy
 
 <ol class="anatomy-list">
-  <li>The <strong>Government of Canada Signature</strong> is a brand identifier found in the site’s <a href="{{ links.header }}">header</a>. The signature is used as a global link to the site’s homepage.</li>
-  <li>The <strong>Canada Wordmark</strong> is a brand identifier found in the site’s <a href="{{ links.footer }}">footer</a>. It reinforces the brand by communicating to a site visitor that they’re reading content from the Government of Canada.</li>
+  <li>The <strong>Government of Canada Signature</strong> is a brand identifier found in the site's <gcds-link href="{{ links.header }}">header</gcds-link>. The signature is used as a global link to the site's homepage.</li>
+  <li>The <strong>Canada Wordmark</strong> is a brand identifier found in the site's <gcds-link href="{{ links.footer }}">footer</gcds-link>. It reinforces the brand by communicating to a site visitor that they're reading content from the Government of Canada.</li>
 </ol>
 
 <img class="b-sm b-default p-400" src="/images/en/components/anatomy/gcds-signature-anatomy-en.svg" alt="Signature anatomy showing the labels 1 (Government of Canada Signature) and 2 (Canada Wordmark)" />

--- a/src/en/components/theme-and-topic-menu/code.md
+++ b/src/en/components/theme-and-topic-menu/code.md
@@ -14,7 +14,7 @@ Use the theme and topic menu to provide global navigation to Government of Canad
 
 ### Use the theme and topic menu with other components
 
-Add the theme and topic menu directly to the <a href="{{ links.header }}">header</a> component by passing a child element with the `slot="menu"` attribute in the header. This will place the theme and topic menu in the header after the language toggle, signature, and search slots.
+Add the theme and topic menu directly to the <gcds-link href="{{ links.header }}">header</gcds-link> component by passing a child element with the `slot="menu"` attribute in the header. This will place the theme and topic menu in the header after the language toggle, signature, and search slots.
 
 **Note**: If applying the theme and topic menu to the front page of Canada.ca, use the `home` attribute to render with the correct styling.
 

--- a/src/en/components/top-navigation/code.md
+++ b/src/en/components/top-navigation/code.md
@@ -19,8 +19,8 @@ Use a top navigation to help a person find their way around your web page or sit
 
 ### Use the top navigation with other components
 
-- If using <a href="{{ links.breadcrumbs }}">breadcrumbs</a>, align the content hierarchy in both set of links, so both components reflect a similar path through the site.
-- If you're using the <a href="{{ links.header }}">header</a> component, add the top navigation directly to the header by passing a child element with the `slot="menu"` attribute into the header. This will place the top nav in the header after the language toggle, signature, and search slots.
+- If using <gcds-link href="{{ links.breadcrumbs }}">breadcrumbs</gcds-link>, align the content hierarchy in both set of links, so both components reflect a similar path through the site.
+- If you're using the <gcds-link href="{{ links.header }}">header</gcds-link> component, add the top navigation directly to the header by passing a child element with the `slot="menu"` attribute into the header. This will place the top nav in the header after the language toggle, signature, and search slots.
 
 {% include "partials/getcode.njk" %}
 

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -29,7 +29,7 @@ Have questions? Something you'd change or you'd like to see? Share your feedback
 
 Ask us about GC Design System, make a suggestion, or request a component you'd like to see.
 
-Fill out this form or submit an issue through GitHub for <a href="{{ links.githubTokensIssues }}" target="_blank">tokens <gcds-icon name="external-link" label="Opens in a new tab." margin-left="50" /></a>, <a href="{{ links.githubIssues }}" target="_blank">components <gcds-icon name="external-link" label="Opens in a new tab." margin-left="50" /></a>, or <a href="{{ links.githubDocsIssues }}" target="_blank">documentation <gcds-icon name="external-link" label="Opens in a new tab." margin-left="50" /></a>.
+Fill out this form or submit an issue through GitHub for <gcds-link external href="{{ links.githubTokensIssues }}" target="_blank">tokens</gcds-link>, <gcds-link external href="{{ links.githubIssues }}" target="_blank">components</gcds-link>, or <gcds-link external href="{{ links.githubDocsIssues }}" target="_blank">documentation</gcds-link>.
 
 <form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;">
   <input type="hidden" name="form-name" value="contactEN" />

--- a/src/en/foundations/colour/colour.md
+++ b/src/en/foundations/colour/colour.md
@@ -45,9 +45,9 @@ Colour tokens define colour for components and global styles.
 
 ## Colour tokens and accessibility
 
-GC Design System components meet level AA of the <a href="{{ links.wcag }}" target="_blank">Web Content Accessibility Guidelines (WCAG 2.1) <gcds-icon name="external-link" label="Opens in a new tab." margin-left="50" /></a> colour contrast standards for text and interactive elements.
+GC Design System components meet level AA of the <gcds-link external href="{{ links.wcag }}" target="_blank">Web Content Accessibility Guidelines (WCAG 2.1)</gcds-link> colour contrast standards for text and interactive elements.
 
-When you use global tokens, check if your colour combinations meet standards for accessible colour contrast using <a href="{{ links.webaim }}" target="_blank">WebAIM Contrast Checker <gcds-icon name="external-link" label="Opens in a new tab." margin-left="50" /></a>.
+When you use global tokens, check if your colour combinations meet standards for accessible colour contrast using <gcds-link external href="{{ links.webaim }}" target="_blank">WebAIM Contrast Checker</gcds-link>.
 
 ## Select colour tokens purposefully
 

--- a/src/en/foundations/spacing/spacing.md
+++ b/src/en/foundations/spacing/spacing.md
@@ -28,7 +28,7 @@ Spacing tokens help position elements onscreen and in components.
 
 ## Spacing tokens and accessibility
 
-GC Design System components meet level AAA of the <a href="{{ links.wcagTargetSize }}" target="_blank">Web Content Accessibility Guidelines (WCAG 2.1) <gcds-icon name="external-link" label="Opens in a new tab." margin-left="50" /></a> for both tap targets and visual presentation.
+GC Design System components meet level AAA of the <gcds-link external href="{{ links.wcagTargetSize }}" target="_blank">Web Content Accessibility Guidelines (WCAG 2.1)</gcds-link> for both tap targets and visual presentation.
 
 Spacing establishes visual hierarchy for content and guides focus to certain elements. Information that's too densely packed is difficult to read and increases cognitive load.
 

--- a/src/en/foundations/typography/typography.md
+++ b/src/en/foundations/typography/typography.md
@@ -47,7 +47,7 @@ Typography tokens include the style, arrangement, and appearance of letters, num
 
 ## Typography and and accessibility
 
-GC Design System components meet <a href="{{ links.wcagTextSpacing }}" target="_blank">level AA of the Web Content Accessibility Guidelines (WCAG 2.1) <gcds-icon name="external-link" label="Opens in a new tab." margin-left="50" /></a> for text spacing and AAA for visual presentation.
+GC Design System components meet <gcds-link external href="{{ links.wcagTextSpacing }}" target="_blank">level AA of the Web Content Accessibility Guidelines (WCAG 2.1)</gcds-link> for text spacing and AAA for visual presentation.
 
 ## Vertical rhythm and rem spacing sizes
 

--- a/src/en/pages/index.md
+++ b/src/en/pages/index.md
@@ -31,14 +31,14 @@ date: 'git Last Modified'
 
 <article class="py-450">
   <h2 class="mb-400">A design system just for you</h2>
-  <p class="mb-500">Take a look around. <a class="link-default" href="{{ links.about }}">Tell us what you think</a>.</p>
+  <p class="mb-500">Take a look around. <gcds-link href="{{ links.about }}">Tell us what you think</gcds-link>.</p>
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" gap="450">
     <li class="list-none">
       <img class="mb-200" src="../../images/common/home/icon-components.svg" alt="" />
       <h3 class="mb-400">Components</h3>
       <p class="mb-400">User interface building blocks address different user objectives.</p>
       <p class="mb-400">Select reusable code for common components, paired with best practice advice, for the framework you're using.</p>
-      <a class="link-default" href="{{ links.components }}">View components</a>
+      <gcds-link href="{{ links.components }}">View components</gcds-link>
     </li>
     <li class="list-none">
       <img class="mb-200" src="../../images/common/home/icon-patterns.svg" alt="" />
@@ -52,7 +52,7 @@ date: 'git Last Modified'
       <h3 class="mb-400">Design tokens</h3>
       <p class="mb-400">Brand and design decisions built into code.</p>
       <p class="mb-400">Learn how encoded decisions shape the design of government services for a consistent visual experience.</p>
-      <a class="link-default" href="{{ links.foundations }}">View tokens</a>
+      <gcds-link href="{{ links.foundations }}">View tokens</gcds-link>
     </li>
   </gcds-grid>
 </article>
@@ -61,11 +61,15 @@ date: 'git Last Modified'
   <h2 class="mb-400">What's new</h2>
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" gap="450">
     <li class="list-none bg-white px-250 py-450 b-radius-md">
-      <h3 class="mb-400"><a class="link-inherit" href="{{ links.releaseNotes }}" target="_blank">Release notes <gcds-icon name="external-link" label="Opens in a new tab." margin-left="50" /></a></h3>
+      <h3 class="mb-400">
+        <gcds-link external href="{{ links.releaseNotes }}">Release notes</gcds-link>
+      </h3>
       <p>The latest additions.</p>
     </li>
     <li class="list-none bg-white px-250 py-450 b-radius-md">
-      <h3 class="mb-400"><a class="link-inherit" href="{{ links.comingSoon }}">Coming soon</a></h3>
+      <h3 class="mb-400">
+        <gcds-link href="{{ links.comingSoon }}">Coming soon</gcds-link>
+      </h3>
       <p>What we're working on.</p>
     </li>
   </gcds-grid>
@@ -76,5 +80,5 @@ date: 'git Last Modified'
   <h3 class="mb-400">Top navigation</h3>
   <p class="mb-450">A top navigation is a horizontal list of page links. Use a top navigation to help a person find their way around your web page or site.</p>
   <img class="d-block mb-450" src="../../images/common/components/preview-top-nav.svg" alt="Top navigation shows site navigation with a dark blue box followed by two greyed boxes, the last having a dark blue line underneath to show selection." />
-  <a href="{{ links.topNav }}">Read more about top navigation</a>
+  <gcds-link href="{{ links.topNav }}">Read more about top navigation</gcds-link>
 </article>

--- a/src/fr/composants/Chemin-de-navigation/code.md
+++ b/src/fr/composants/Chemin-de-navigation/code.md
@@ -21,7 +21,7 @@ Conseil : Lorsqu'un processus n'a pas de page d'accueil traditionnelle, insére
 
 ### Placez le chemin de navigation avant l'élément `<main>`
 
-Placez le chemin de navigation en haut d'une page, avant l'élément `<main>`. De cette façon, le <a href="{{ links.button }}">bouton « Passer au contenu principal »</a> permettra à l'utilisateur·rice d'ignorer tous les liens de navigation, y compris les chemins de navigation.
+Placez le chemin de navigation en haut d'une page, avant l'élément `<main>`. De cette façon, le <gcds-link href="{{ links.button }}">bouton « Passer au contenu principal »</gcds-link> permettra à l'utilisateur·rice d'ignorer tous les liens de navigation, y compris les chemins de navigation.
 
 ### Utiliser les éléments du chemin de navigation pour les liens du chemin de navigation
 

--- a/src/fr/composants/Chemin-de-navigation/design.md
+++ b/src/fr/composants/Chemin-de-navigation/design.md
@@ -20,7 +20,7 @@ date: 'git Last Modified'
 ### Structure du chemin de navigation — avec en-tête et titre H1
 
 <ol class="anatomy-list">
-  <li>L'<a href="{{ links.header }}"><strong>en-tête</strong></a> constitue un élément d'une image de marque fiable — pour les applications, les formulaires ou d'autres services numériques transactionnels.</li>
+  <li>L'<gcds-link href="{{ links.header }}"><strong>en-tête</strong></gcds-link> constitue un élément d'une image de marque fiable — pour les applications, les formulaires ou d'autres services numériques transactionnels.</li>
   <li>Le <strong>lien vers la page d'accueil</strong> ramène à la page d'accueil de la page Web ou du site actuel.</li>
   <li>Le <strong>lien de la page parent</strong> conduit vers la page parent de la page actuelle. Vous pouvez avoir jusqu'à trois liens vers des pages parents en plus de ceux vers la page d'accueil et la page d'accueil Canada.ca.</li>
   <li>Le  <strong>titre H1</strong> est un élément distinct du composant Chemin de navigation. Il indique aux lecteur·rice·s la nature de la page ou du site et sert de repère.</li>
@@ -44,7 +44,7 @@ Le chemin de navigation représente l'emplacement de la page courante par rappor
 - Évitez d'utiliser le composant Chemin de navigation pour illustrer l'évolution du parcours de l'utilisateur·rice.
 - Limitez le chemin de navigation à cinq niveaux. Un trop grand nombre de niveaux dans le chemin de navigation peut être accablant pour certaines personnes.
 
-Conseil : Si vous utilisez également d'autres composants de navigation, comme la <a href="{{ links.topNav }}">barre de navigation supérieure</a> et la <a href="{{ links.sideNav }}">barre de navigation latérale</a>, harmonisez-les de façon à ce que les éléments reflètent le parcours d'une personne sur le site. Cela offre une expérience de navigation uniforme et aide les utilisateur·rice·s à comprendre leur emplacement actuel.
+Conseil : Si vous utilisez également d'autres composants de navigation, comme la <gcds-link href="{{ links.topNav }}">barre de navigation supérieure</gcds-link> et la <gcds-link href="{{ links.sideNav }}">barre de navigation latérale</gcds-link>, harmonisez-les de façon à ce que les éléments reflètent le parcours d'une personne sur le site. Cela offre une expérience de navigation uniforme et aide les utilisateur·rice·s à comprendre leur emplacement actuel.
 
 ### Écrivez du texte spécifique pour le lien vers la page parent
 
@@ -54,4 +54,4 @@ Conseil : Si vous utilisez également d'autres composants de navigation, comme 
 
 ### Placez le chemin de navigation avant le contenu principal
 
-Placez le chemin de navigation en haut d'une page, avant le contenu principal. De cette façon, <a href="{{ links.button }}">le bouton « Passer au contenu principal »</a> permettra à l'utilisateur·rice d'ignorer tous les liens de navigation, y compris les chemins de navigation.
+Placez le chemin de navigation en haut d'une page, avant le contenu principal. De cette façon, <gcds-link href="{{ links.button }}">le bouton « Passer au contenu principal »</gcds-link> permettra à l'utilisateur·rice d'ignorer tous les liens de navigation, y compris les chemins de navigation.

--- a/src/fr/composants/barre-de-navigation-superieure/code.md
+++ b/src/fr/composants/barre-de-navigation-superieure/code.md
@@ -19,8 +19,8 @@ Utilisez une barre de navigation supérieure pour aider une personne à se repé
 
 ### Utilisez la barre de navigation supérieure avec d'autres composants.
 
-- Si vous utilisez un composant <a href="{{ links.breadcrumbs }}">chemin de navigation</a>, uniformisez la hiérarchie dans les deux ensembles sur le site.
-- Si vous utilisez le composant <a href="{{ links.header }}">en-tête</a>, ajoutez la barre de navigation supérieure directement dans l'en-tête en insérant un élément enfant à l'aide de l'attribut `slot="menu"` dans l'en-tête. Cela placera la barre de navigation supérieure dans l'en-tête, après la bascule de langue, la signature et la barre de recherche.
+- Si vous utilisez un composant <gcds-link href="{{ links.breadcrumbs }}">chemin de navigation</gcds-link>, uniformisez la hiérarchie dans les deux ensembles sur le site.
+- Si vous utilisez le composant <gcds-link href="{{ links.header }}">en-tête</gcds-link>, ajoutez la barre de navigation supérieure directement dans l'en-tête en insérant un élément enfant à l'aide de l'attribut `slot="menu"` dans l'en-tête. Cela placera la barre de navigation supérieure dans l'en-tête, après la bascule de langue, la signature et la barre de recherche.
 
 {% include "partials/getcode.njk" %}
 

--- a/src/fr/composants/date-de-modification/case-dusage.md
+++ b/src/fr/composants/date-de-modification/case-dusage.md
@@ -38,7 +38,7 @@ Utilisez la date de modification pour :
 
 <div class="remove-empty-p">
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Aperçu du le type date" "py-400" "" %}
+  {% componentPreview "Aperçu du le type date" "px-300 py-400" "" %}
   <gcds-date-modified>2023-08-22</gcds-date-modified>
   {% endcomponentPreview %}
   <div>
@@ -51,7 +51,7 @@ Utilisez la date de modification pour :
 </gcds-grid>
 <br/>
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Aperçu du le type version" "py-400" "" %}
+  {% componentPreview "Aperçu du le type version" "px-300 py-400" "" %}
   <gcds-date-modified type="version">1.0.0</gcds-date-modified>
   {% endcomponentPreview %}
   <div>

--- a/src/fr/composants/grille/code.md
+++ b/src/fr/composants/grille/code.md
@@ -30,7 +30,7 @@ Conseil : Visez la simplicité pour vos mises en page. Envisagez d'optimiser ch
 - Ajoutez de l'espace entre les colonnes pour réduire la charge cognitive liée à la lecture d'un contenu trop dense.
 - Dans la mesure du possible, alignez les objets verticalement et horizontalement.
 - Utilisez la propriété `gap` pour ajouter de l'espacement entre vos `columns` dans la grille.
-- Utilisez les <a href="{{ links.designTokens }}">unités de style</a> de Système de design GC comme référence pour la taille de votre `gap` dans la grille. Les mesures des unités correspondent aux valeurs d'espacement de l'attribut `gap`.
+- Utilisez les <gcds-link href="{{ links.designTokens }}">unités de style</gcds-link> de Système de design GC comme référence pour la taille de votre `gap` dans la grille. Les mesures des unités correspondent aux valeurs d'espacement de l'attribut `gap`.
 
 ### Choisissez une option pour des colonnes de largeur égale
 

--- a/src/fr/composants/grille/design.md
+++ b/src/fr/composants/grille/design.md
@@ -38,7 +38,7 @@ Conseil : Visez la simplicité pour la disposition des grilles en concevant des
 
 - Ajoutez de l'espace entre les colonnes pour réduire la charge cognitive liée à la lecture d'un contenu trop dense.
 - Dans la mesure du possible, alignez les objets verticalement et horizontalement.
-- Sélectionnez la taille de l'écart, ou l'espacement entre les colonnes, en choisissant une option de mesure parmi nos <a href="{{ links.spacing }}">unités d'espacement</a>.
+- Sélectionnez la taille de l'écart, ou l'espacement entre les colonnes, en choisissant une option de mesure parmi nos <gcds-link href="{{ links.spacing }}">unités d'espacement</gcds-link>.
 
 ### Utilisez l'espacement pour véhiculer un sens particulier
 

--- a/src/fr/composants/menu-des-themes-et-sujets/code.md
+++ b/src/fr/composants/menu-des-themes-et-sujets/code.md
@@ -6,17 +6,17 @@ tags: ['themeand-topic-menuFR', 'code']
 date: 'git Last Modified'
 ---
 
-## Création d’un menu des thèmes et sujets
+## Création d'un menu des thèmes et sujets
 
-Utilisez le menu des thèmes et sujets pour permettre aux utilisateur·rice·s de naviguer à travers l’ensemble des sites du gouvernement du Canada.
+Utilisez le menu des thèmes et sujets pour permettre aux utilisateur·rice·s de naviguer à travers l'ensemble des sites du gouvernement du Canada.
 
 ## Codage et accessibilité du menu des thèmes et sujets
 
-### Utilisation du menu des thèmes et sujets avec d’autres composants
+### Utilisation du menu des thèmes et sujets avec d'autres composants
 
-Ajoutez directement le menu des thèmes et sujets à l’<a href="{{ links.header }}">en-tête</a> en passant un élément secondaire avec l’attribut `slot="menu"` dans l’en-tête. Cela placera le menu des thèmes et sujets dans l’en-tête, à la suite de la bascule de la langue, la signature et la barre de recherche.
+Ajoutez directement le menu des thèmes et sujets à l'<gcds-link href="{{ links.header }}">en-tête</gcds-link> en passant un élément secondaire avec l'attribut `slot="menu"` dans l'en-tête. Cela placera le menu des thèmes et sujets dans l'en-tête, à la suite de la bascule de la langue, la signature et la barre de recherche.
 
-Remarque : Si vous souhaitez ajouter un menu de thèmes et sujets à la page d’accueil de Canada.ca, utilisez l’attribut `home` pour utiliser le style approprié.
+Remarque : Si vous souhaitez ajouter un menu de thèmes et sujets à la page d'accueil de Canada.ca, utilisez l'attribut `home` pour utiliser le style approprié.
 
 {% include "partials/getcode.njk" %}
 

--- a/src/fr/composants/recherche/code.md
+++ b/src/fr/composants/recherche/code.md
@@ -8,10 +8,10 @@ date: 'git Last Modified'
 
 ## Créer un composant recherche
 
-Utilisez le composant recherche pour aider les gens à trouver des renseignements à l’aide de mots-clés.
+Utilisez le composant recherche pour aider les gens à trouver des renseignements à l'aide de mots-clés.
 
-- Placez le composant recherche dans l’<a href="{{ links.header }}">en-tête</a> sous la bascule de langue et alignez-le sur la <a href="{{ links.signature }}">signature du gouvernement du Canada</a>.
-- Assurez-vous que l’en-tête est réactif afin que le composant recherche apparaisse sous la signature et la bascule de langue sur les appareils mobiles.
+- Placez le composant recherche dans l'<gcds-link href="{{ links.header }}">en-tête</gcds-link> sous la bascule de langue et alignez-le sur la <gcds-link href="{{ links.signature }}">signature du gouvernement du Canada</gcds-link>.
+- Assurez-vous que l'en-tête est réactif afin que le composant recherche apparaisse sous la signature et la bascule de langue sur les appareils mobiles.
 
 ## Codage et accessibilité du composant recherche
 
@@ -22,9 +22,9 @@ Utilisez le composant recherche pour aider les gens à trouver des renseignement
 
 ### Optez pour la modification du point de terminaison de la recherche pour les applications ou sites transactionnels
 
-- Optez pour la modification du point de terminaison de la recherche pour une application ou un site transactionnel lorsque le fait de quitter le site interromprait la tâche ou le flux de travail d’une personne.
-- Utilisez la méthode de requête HTTP par défaut `GET` du composant, ou bien utilisez `POST` au besoin en définissant l’attribut `method`.
-- Définissez l’attribut `action` sur un point de terminaison de votre choix et définissez l’attribut placeholder (message-guide) pour refléter l’étendue de la recherche. Le message-guide du champ de recherche remplira également le texte de l’étiquette.
+- Optez pour la modification du point de terminaison de la recherche pour une application ou un site transactionnel lorsque le fait de quitter le site interromprait la tâche ou le flux de travail d'une personne.
+- Utilisez la méthode de requête HTTP par défaut `GET` du composant, ou bien utilisez `POST` au besoin en définissant l'attribut `method`.
+- Définissez l'attribut `action` sur un point de terminaison de votre choix et définissez l'attribut placeholder (message-guide) pour refléter l'étendue de la recherche. Le message-guide du champ de recherche remplira également le texte de l'étiquette.
 
 {% include "partials/getcode.njk" %}
 

--- a/src/fr/composants/recherche/design.md
+++ b/src/fr/composants/recherche/design.md
@@ -3,14 +3,14 @@ title: Recherche
 layout: 'layouts/component-documentation.njk'
 translationKey: 'searchDesign'
 tags: ['searchFR', 'design']
-date: "git Last Modified"
+date: 'git Last Modified'
 ---
 
 ## Structure du composant recherche
 
 <ol class="anatomy-list">
-  <li>Le <strong>champ de saisie</strong> est un espace permettant d’entrer des mots-clés de recherche.</li>
-  <li>Le <strong>message-guide du champ de recherche</strong> indique l’action attendue.</li>
+  <li>Le <strong>champ de saisie</strong> est un espace permettant d'entrer des mots-clés de recherche.</li>
+  <li>Le <strong>message-guide du champ de recherche</strong> indique l'action attendue.</li>
   <li>Le <strong>bouton</strong> lance la recherche pour obtenir des résultats.</li>
   <li>L'<strong>icône</strong> est une aide visuelle sur le bouton.</li>
 </ol>
@@ -19,7 +19,7 @@ date: "git Last Modified"
 
 ## Accessibilité et design des recherche
 
-### Placez le composant recherche à un endroit prévisible dans l’en-tête
+### Placez le composant recherche à un endroit prévisible dans l'en-tête
 
-- Placez le composant recherche dans l’<a href="{{ links.header }}">en-tête</a> sous la bascule de langue et alignez-le sur la <a href="{{ links.signature }}">signature du gouvernement du Canada</a>.
-- Assurez-vous que l’en-tête est réactif afin que le composant recherche apparaisse sous la signature et la bascule de langue sur les appareils mobiles.
+- Placez le composant recherche dans l'<gcds-link href="{{ links.header }}">en-tête</gcds-link> sous la bascule de langue et alignez-le sur la <gcds-link href="{{ links.signature }}">signature du gouvernement du Canada</gcds-link>.
+- Assurez-vous que l'en-tête est réactif afin que le composant recherche apparaisse sous la signature et la bascule de langue sur les appareils mobiles.

--- a/src/fr/composants/resume-de-erreurs/case-dusage.md
+++ b/src/fr/composants/resume-de-erreurs/case-dusage.md
@@ -25,7 +25,7 @@ Les composants de Système de design GC sont livrés avec une gestion des erreur
 Utilisez le résumé des erreurs pour interrompre l'envoi d'un formulaire lorsqu'on constate le besoin de :
 
 - Rendre les erreurs évidentes pour que l'on sache les reconnaître et y remédier;
-- Dresser une liste <a href="{{ links.errorMessage }}">des messages d'erreur</a> lorsqu'une personne doit ajouter des renseignements ou apporter des modifications à deux ou plusieurs éléments avant de pouvoir soumettre un formulaire.
+- Dresser une liste <gcds-link href="{{ links.errorMessage }}">des messages d'erreur</gcds-link> lorsqu'une personne doit ajouter des renseignements ou apporter des modifications à deux ou plusieurs éléments avant de pouvoir soumettre un formulaire.
 
 <article class="bg-full-width bg-primary text-light pt-500 pb-400 my-500">
 

--- a/src/fr/composants/resume-de-erreurs/code.md
+++ b/src/fr/composants/resume-de-erreurs/code.md
@@ -18,7 +18,7 @@ Tous les composants de Système de design GC sont livrés avec une gestion des e
 Le résumé des erreurs de Système de design GC utilise l'attribut `listen` pour recueillir les erreurs. Lors de l'exécution de l'opération `onSubmit`, le résumé des erreurs dressera la liste des erreurs provenant des composants de Système de design GC. Les erreurs seront répertoriées dans le même ordre qu'elles apparaissent sur la page.
 
 - Activez tous les contrôles nécessaires pour résoudre l'une ou l'autre des erreurs.
-- Envisagez de remplacer tout <a href="{{ links.errorMessage }}">message d'erreur</a> générique par défaut par un texte qui définit le problème concret et la façon de le résoudre.
+- Envisagez de remplacer tout <gcds-link href="{{ links.errorMessage }}">message d'erreur</gcds-link> générique par défaut par un texte qui définit le problème concret et la façon de le résoudre.
 
 ### Utiliser le résumé des erreurs avec vos propres composants
 

--- a/src/fr/composants/resume-de-erreurs/design.md
+++ b/src/fr/composants/resume-de-erreurs/design.md
@@ -22,7 +22,7 @@ tags: ['errorsummaryFR', 'design']
 N'oubliez pas que les erreurs interrompent le déroulement d'une action. Cette situation peut s'avérer dérangeante et désagréable pour vos utilisateur·rice·s.
 
 - Clarifiez la démarche à suivre pour corriger l'erreur. Les erreurs suscitent une réaction émotionnelle d'autant plus forte que le problème est difficile ou impossible à résoudre.
-- Rédigez un <a href="{{ links.errorMessage }}">message d'erreur</a> clair et expliquez comment y remédier pour permettre à la personne de se remettre à la tâche.
+- Rédigez un <gcds-link href="{{ links.errorMessage }}">message d'erreur</gcds-link> clair et expliquez comment y remédier pour permettre à la personne de se remettre à la tâche.
 - Assurez-vous de rédiger des messages d'erreur courts et précis afin de rendre la liste des erreurs lisible.
 - Limitez le nombre de composants de formulaire par page nécessitant une réponse.
 

--- a/src/fr/composants/selection/design.md
+++ b/src/fr/composants/selection/design.md
@@ -35,4 +35,4 @@ date: 'git Last Modified'
 ### Utilisez d'autres questions pour réduire le nombre d'options de sélection
 
 - Essayez de poser des questions aux utilisateur·rice·s avant d'utiliser la sélection afin de réduire le nombre d'options.
-- Si une liste d'éléments contient moins d'options (6-7 éléments ou moins), envisagez plutôt l'utilisation de <a href="{{ links.radio }}">boutons radio</a>.
+- Si une liste d'éléments contient moins d'options (6-7 éléments ou moins), envisagez plutôt l'utilisation de <gcds-link href="{{ links.radio }}">boutons radio</gcds-link>.

--- a/src/fr/composants/signature/code.md
+++ b/src/fr/composants/signature/code.md
@@ -14,7 +14,7 @@ Utilisez la signature comme image de marque claire et reconnaissable du gouverne
 
 ### Utilisation des types de signature et de mot-symbole
 
-Utilisez la signature dans <a href="{{ links.header }}">l'en-tête</a> du site et le mot-symbole dans <a href="{{ links.footer }}">le pied de page</a> du site.
+Utilisez la signature dans <gcds-link href="{{ links.header }}">l'en-tête</gcds-link> du site et le mot-symbole dans <gcds-link href="{{ links.footer }}">le pied de page</gcds-link> du site.
 
 - Utilisez l'attribut `type` pour définir la `signature`.
 - Utilisez l'attribut `type` pour définir le `wordmark`.

--- a/src/fr/composants/signature/design.md
+++ b/src/fr/composants/signature/design.md
@@ -9,27 +9,27 @@ date: 'git Last Modified'
 ## Structure de la signature
 
 <ol class="anatomy-list">
-  <li>La <strong>signature du gouvernement du Canada</strong> est l’identificateur de l’image de marque placée dans l’<a href="{{ links.header }}">en-tête</a> du site. La signature sert de lien général vers la page d’accueil du site.</li>
-  <li>Le <strong>mot-symbole « Canada »</strong> est l’identificateur de l’image de marque placé dans le <a href="{{ links.footer }}">pied de page</a> du site. Il renforce l’image de marque en informant les visiteur·rice·s du site que le contenu qui leur est présenté provient du gouvernement du Canada.</li>
+  <li>La <strong>signature du gouvernement du Canada</strong> est l'identificateur de l'image de marque placée dans l'<gcds-link href="{{ links.header }}">en-tête</gcds-link> du site. La signature sert de lien général vers la page d'accueil du site.</li>
+  <li>Le <strong>mot-symbole « Canada »</strong> est l'identificateur de l'image de marque placé dans le <gcds-link href="{{ links.footer }}">pied de page</gcds-link> du site. Il renforce l'image de marque en informant les visiteur·rice·s du site que le contenu qui leur est présenté provient du gouvernement du Canada.</li>
 </ol>
 
 <img class="b-sm b-default p-400" src="/images/fr/components/anatomy/gcds-signature-anatomy-fr.svg" alt="structure de la signature montrant les étiquettes 1 (signature du gouvernement du Canada) et 2 (mot-symbole « Canada »)" />
 
 ## Design et accessibilité de la signature
 
-### Établir l’ordre des langues dans la signature
+### Établir l'ordre des langues dans la signature
 
-Affichez d’abord la signature en français sur les pages en français. De même, insérez d’abord la signature en anglais sur les pages en anglais.
+Affichez d'abord la signature en français sur les pages en français. De même, insérez d'abord la signature en anglais sur les pages en anglais.
 
-**Remarque :** L’image contient un lien hypertexte qui mène à la page d’accueil Canada.ca dans la même langue officielle que la page actuelle.
+**Remarque :** L'image contient un lien hypertexte qui mène à la page d'accueil Canada.ca dans la même langue officielle que la page actuelle.
 
 ### Utilisez des couleurs non standard de manière accessible
 
-- Choisissez d’utiliser des couleurs non standard lorsqu’un niveau de contraste plus élevé avec l’arrière-plan est nécessaire, comme pour le mode sombre;
-- Optez pour l’utilisation de couleurs non standard lorsqu’un produit affiche une couleur unique, comme le noir et le blanc;
+- Choisissez d'utiliser des couleurs non standard lorsqu'un niveau de contraste plus élevé avec l'arrière-plan est nécessaire, comme pour le mode sombre;
+- Optez pour l'utilisation de couleurs non standard lorsqu'un produit affiche une couleur unique, comme le noir et le blanc;
 - Lorsque la couleur du drapeau est modifiée, assurez-vous de toujours utiliser cette même couleur pour le symbole du drapeau dans la signature et le mot-symbole;
-- Utilisez toujours la même combinaison de couleurs dans la signature et le mot-symbole. Par exemple, si la signature est en noir et blanc, alors le mot-symbole doit également l’être;
-- Lorsqu’une seule couleur est utilisée, vérifiez le rapport de contraste entre les éléments de la signature pour vous assurer que le ratio est à tout le moins conforme à la norme WCAG, niveau AA.
+- Utilisez toujours la même combinaison de couleurs dans la signature et le mot-symbole. Par exemple, si la signature est en noir et blanc, alors le mot-symbole doit également l'être;
+- Lorsqu'une seule couleur est utilisée, vérifiez le rapport de contraste entre les éléments de la signature pour vous assurer que le ratio est à tout le moins conforme à la norme WCAG, niveau AA.
 
 <img class="b-sm b-default p-400 mt-400 mb-400" src="/images/fr/components/example/example-signature-side-by-side-fr.svg" alt="Une image représentant les deux versions de la signature. La signature se trouve à gauche et le mot-symbole est placé à droite." />
 
@@ -39,10 +39,10 @@ Le style de couleur standard utilise un texte noir et un drapeau rouge sur fond 
 
 Le style de couleur inversé utilise un texte blanc et un drapeau rouge sur fond noir.
 
-<img class="b-sm b-default p-400 mt-500 mb-400" src="/images/fr/components/example/example-signature-bw-fr.svg" alt="Une image présentant deux combinaisons de signature et de mot-symbole. Dans un cas, la signature et le mot-symbole sont noirs sur fond blanc. Dans l’autre cas, la signature et le mot-symbole sont blancs sur fond noir." />
+<img class="b-sm b-default p-400 mt-500 mb-400" src="/images/fr/components/example/example-signature-bw-fr.svg" alt="Une image présentant deux combinaisons de signature et de mot-symbole. Dans un cas, la signature et le mot-symbole sont noirs sur fond blanc. Dans l'autre cas, la signature et le mot-symbole sont blancs sur fond noir." />
 
 Le style noir et blanc utilise un fond soit entièrement noir, soit entièrement blanc. Le style entièrement noir est le plus fréquemment employé.
 
-<img class="b-sm b-default p-400 mt-500 mb-400" src="/images/fr/components/example/example-signature-single-colour-style-fr.svg" alt="Une image montrant la signature et le mot-symbole en violet foncé sur un fond violet pâle. Des barres et des cases simulent du texte et des images sur une page web fictive. Les cases de texte et d’images sont également violet foncé." />
+<img class="b-sm b-default p-400 mt-500 mb-400" src="/images/fr/components/example/example-signature-single-colour-style-fr.svg" alt="Une image montrant la signature et le mot-symbole en violet foncé sur un fond violet pâle. Des barres et des cases simulent du texte et des images sur une page web fictive. Les cases de texte et d'images sont également violet foncé." />
 
 Le style couleur unique utilise une couleur autre que le noir ou le blanc si uniquement cette couleur est utilisée pour le produit.

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -29,7 +29,7 @@ Avez-vous des questions? Vous avez un changement à suggérer ou une fonctionnal
 
 Renseignez-vous sur Système de design GC, faites une suggestion ou demandez un composant que vous aimeriez voir.
 
-Pour toute demande concernant <a href="{{ links.githubTokensIssues }}" target="_blank">les unités de style <gcds-icon name="external-link" label="S'ouvre dans un nouvel onglet." margin-left="50" /></a>, <a href="{{ links.githubIssues }}" target="_blank">les composants <gcds-icon name="external-link" label="S'ouvre dans un nouvel onglet." margin-left="50" /></a>, et <a href="{{ links.githubDocsIssues }}" target="_blank">la documentation <gcds-icon name="external-link" label="S'ouvre dans un nouvel onglet." margin-left="50" /></a>, remplissez ce formulaire ou envoyez une demande à l'aide de fonction « Issues » dans GitHub.
+Pour toute demande concernant <gcds-link external href="{{ links.githubTokensIssues }}" target="_blank">les unités de style</gcds-link>, <gcds-link external href="{{ links.githubIssues }}" target="_blank">les composants</gcds-link>, et <gcds-link external href="{{ links.githubDocsIssues }}" target="_blank">la documentation</gcds-link>, remplissez ce formulaire ou envoyez une demande à l'aide de fonction « Issues » dans GitHub.
 
 <form class="my-500 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;">
   <input type="hidden" name="form-name" value="contactFR" />

--- a/src/fr/fondements/couleur/couleur.md
+++ b/src/fr/fondements/couleur/couleur.md
@@ -45,9 +45,9 @@ Les unités de style de couleur définissent les couleurs pour les composants et
 
 ## Unités de style de couleur et accessibilité
 
-Les composants de Système de design GC sont conformes <a href="{{ links.wcag }}" target="_blank">au niveau AA des Règles pour l'accessibilité des contenus Web 2.1 (WCAG 2.1) <gcds-icon name="external-link" label="S'ouvre dans un nouvel onglet." margin-left="50" /></a> (site anglais) en matière de contraste des couleurs des éléments texte et des éléments interactifs.
+Les composants de Système de design GC sont conformes <gcds-link external href="{{ links.wcag }}" target="_blank">au niveau AA des Règles pour l'accessibilité des contenus Web 2.1 (WCAG 2.1)</gcds-link> (site anglais) en matière de contraste des couleurs des éléments texte et des éléments interactifs.
 
-Lorsque vous utilisez des unités de style de couleur, vérifiez si vos combinaisons de couleurs satisfont aux normes en matière d'accessibilité du contraste des couleurs à l'aide de l'outil <a href="{{ links.wcag }}" target="_blank">Web Aim Contrast Checker <gcds-icon name="external-link" label="S'ouvre dans un nouvel onglet." margin-left="50" /></a> (site anglais).
+Lorsque vous utilisez des unités de style de couleur, vérifiez si vos combinaisons de couleurs satisfont aux normes en matière d'accessibilité du contraste des couleurs à l'aide de l'outil <gcds-link external href="{{ links.wcag }}" target="_blank">Web Aim Contrast Checker</gcds-link> (site anglais).
 
 ## Soyez judicieux dans votre choix d'unités de style de couleur
 

--- a/src/fr/fondements/espacement/espacement.md
+++ b/src/fr/fondements/espacement/espacement.md
@@ -28,7 +28,7 @@ Les unités de style d'espacement aident à disposer les éléments à l'écran 
 
 ## Unités de style d'espacement et accessibilité
 
-Les composants de Système de design GC sont conformes au niveau AAA des <a href="{{ links.wcagTargetSize }}" target="_blank">Règles pour l'accessibilité des contenus Web 2.1 (WCAG 2.1)<gcds-icon name="external-link" label="S'ouvre dans un nouvel onglet." margin-left="50" /></a> (site Web anglais) en matière de cibles pour les pointeurs d'entrée et de présentation visuelle.
+Les composants de Système de design GC sont conformes au niveau AAA des <gcds-link external href="{{ links.wcagTargetSize }}" target="_blank">Règles pour l'accessibilité des contenus Web 2.1 (WCAG 2.1)</gcds-link> (site Web anglais) en matière de cibles pour les pointeurs d'entrée et de présentation visuelle.
 
 L'espacement permet d'établir une hiérarchie visuelle dans le contenu et d'attirer l'attention vers certains éléments. Un contenu trop dense est plus difficile à lire et augmente la charge cognitive du lecteur.
 

--- a/src/fr/fondements/typographie/typographie.md
+++ b/src/fr/fondements/typographie/typographie.md
@@ -48,7 +48,7 @@ Les unités de style typographiques comprennent le style, la disposition et l'ap
 
 ## Typographie et accessibilité
 
-Les composants de Système de design GC <a href="{{ links.wcagTextSpacing }}" target="_blank">sont conformes au niveau AA des Règles pour l'accessibilité des contenus Web 2.1 (WCAG 2.1) <gcds-icon name="external-link" label="S'ouvre dans un nouvel onglet." margin-left="50" /></a> (site Web anglais) en matière d'espacement du texte et au niveau AAA en matière de présentation visuelle.
+Les composants de Système de design GC <gcds-link external href="{{ links.wcagTextSpacing }}" target="_blank">sont conformes au niveau AA des Règles pour l'accessibilité des contenus Web 2.1 (WCAG 2.1)</gcds-link> (site Web anglais) en matière d'espacement du texte et au niveau AAA en matière de présentation visuelle.
 
 ## Rythme vertical et tailles d'espacement en rem
 

--- a/src/fr/pages/index.md
+++ b/src/fr/pages/index.md
@@ -30,14 +30,14 @@ date: 'git Last Modified'
 
 <article class="py-450">
   <h2 class="mb-400">Un système de design rien que pour vous</h2>
-  <p class="mb-500">Explorez notre outil de conception. <a class="link-default" href="/fr/contactez/">Donnez-nous votre avis</a>.</p>
+  <p class="mb-500">Explorez notre outil de conception. <gcds-link href="/fr/contactez/">Donnez-nous votre avis</gcds-link>.</p>
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" gap="450">
     <li class="list-none">
       <img class="mb-200" src="../../images/common/home/icon-components.svg" alt="" />
       <h3 class="mb-400">Composants</h3>
       <p class="mb-400">Les blocs de construction de l'interface utilisateur servent différents objectifs.</p>
       <p class="mb-400">Sélectionnez du code réutilisable pour les composants courants et obtenez des conseils relatifs aux meilleures pratiques pour l'infrastructure que vous utilisez.</p>
-      <a class="link-default" href="{{ links.components }}">Découvrez les composants</a>
+      <gcds-link href="{{ links.components }}">Découvrez les composants</gcds-link>
     </li>
     <li class="list-none">
       <img class="mb-200" src="../../images/common/home/icon-patterns.svg" alt="" />
@@ -51,7 +51,7 @@ date: 'git Last Modified'
       <h3 class="mb-400">Unités de style</h3>
       <p class="mb-400">Des décisions en matière d'image de marque et de conception directement intégrées dans le code.</p>
       <p class="mb-400">Découvrez comment les décisions encodées façonnent la conception des services offerts par le gouvernement du Canada et permettent d'offrir une expérience visuelle uniforme.</p>
-      <a class="link-default" href="{{ links.foundations }}">Découvrez les unités de style</a>
+      <gcds-link href="{{ links.foundations }}">Découvrez les unités de style</gcds-link>
     </li>
   </gcds-grid>
 </article>
@@ -60,11 +60,15 @@ date: 'git Last Modified'
   <h2 class="mb-400">Nouveautés</h2>
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" gap="450">
     <li class="list-none bg-white px-250 py-450 b-radius-md">
-      <h3 class="mb-400"><a class="link-inherit" href="{{ links.releaseNotes }}" target="_blank">Notes de publication <gcds-icon name="external-link" label="Opens in a new tab." margin-left="50" /></a></h3></a></h3>
+      <h3 class="mb-400">
+        <gcds-link external href="{{ links.releaseNotes }}">Notes de publication</gcds-link>
+      </h3>
       <p>Les derniers ajouts.</p>
     </li>
     <li class="list-none bg-white px-250 py-450 b-radius-md">
-      <h3 class="mb-400"><a class="link-inherit" href="{{ links.comingSoon }}">Prochainement</a></h3>
+      <h3 class="mb-400">
+        <gcds-link href="{{ links.comingSoon }}">Prochainement</gcds-link>
+      </h3>
       <p>Ce sur quoi nous travaillons.</p>
     </li>
   </gcds-grid>
@@ -75,5 +79,5 @@ date: 'git Last Modified'
   <h3 class="mb-400">Barre de navigation supérieure</h3>
   <p class="mb-450">Une barre de navigation supérieure est une liste horizontale de liens de page. Utilisez une barre de navigation supérieure pour aider une personne à se repérer sur votre page Web ou site Web.</p>
   <img class="d-block mb-450" src="../../images/common/components/preview-top-nav.svg" alt="Un aperçu du composant barre de navigation supérieure qui montre la navigation du site représentée par des boîtes grises alignés horizontalement. Une boîte bleue suivi de deux boîtes grises représentent les liens où la dernière boîte est surlignée afin de représenter le lien actif." />
-  <a href="{{ links.topNav }}">En savoir plus sur la barre de navigation supérieure</a>
+  <gcds-link href="{{ links.topNav }}">En savoir plus sur la barre de navigation supérieure</gcds-link>
 </article>


### PR DESCRIPTION
# Summary | Résumé

Integrate `gcds-link` component into the documentation site. Replace all links with `gcds-link` that use the default link styling.