### PR TITLE
ci: add workflow for building and pushing docker images for api

### DIFF
--- a/.github/workflows/docker-build-push-production.yml
+++ b/.github/workflows/docker-build-push-production.yml
@@ -9,15 +9,11 @@ env:
   AWS_REGION: ca-central-1
   FUNCTION_PREFIX: gcds-api 
   GITHUB_SHA: ${{ github.sha }}
-  REGISTRY: 307395567143.dkr.ecr.ca-central-1.amazonaws.com/gc-design-system/api 
+  REGISTRY: 307395567143.dkr.ecr.ca-central-1.amazonaws.com/gc-design-system
 
 permissions:
   id-token: write
   contents: write
-  pull-requests: write
-  actions: write
-  checks: write
-  statuses: write
   security-events: write
 
 jobs:
@@ -51,7 +47,7 @@ jobs:
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
-          role-to-assume: arn:aws:iam::307395567143:role/gcds-terraform-apply
+          role-to-assume: arn:aws:iam::307395567143:role/gcds-docs-apply
           role-session-name: ECRPush
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/docker-build-push-production.yml
+++ b/.github/workflows/docker-build-push-production.yml
@@ -1,0 +1,90 @@
+name: Docker build and push
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  AWS_REGION: ca-central-1
+  FUNCTION_PREFIX: gcds-api 
+  GITHUB_SHA: ${{ github.sha }}
+  REGISTRY: 307395567143.dkr.ecr.ca-central-1.amazonaws.com/gc-design-system/api 
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+  actions: write
+  checks: write
+  statuses: write
+  security-events: write
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # tag=v2.11.1
+        id: filter
+        with:
+          filters: |
+            api: 'api/**'
+
+  build-push:
+    if: needs.changes.outputs.images != '[]'
+    runs-on: ubuntu-latest
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.changes.outputs.images) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
+        with:
+          role-to-assume: arn:aws:iam::307395567143:role/gcds-terraform-apply
+          role-session-name: ECRPush
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Build image
+        working-directory: ./${{ matrix.image }}
+        run: |
+          docker build \
+          --build-arg GIT_SHA=$GITHUB_SHA \
+          -t $REGISTRY/${{ matrix.image }}:$GITHUB_SHA \
+          -t $REGISTRY/${{ matrix.image }}:latest .
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1.7.1
+
+      - name: Push image to ECR
+        run: |
+          docker push $REGISTRY/${{ matrix.image }}:$GITHUB_SHA
+          docker push $REGISTRY/${{ matrix.image }}:latest
+
+      - name: Deploy new image
+        run: |
+          aws lambda update-function-code \
+            --function-name ${{ env.FUNCTION_PREFIX }}-${{ matrix.image }} \
+            --image-uri $REGISTRY/${{ matrix.image }}:$GITHUB_SHA  > /dev/null 2>&1
+
+      - name: Docker generate SBOM
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@d6bb182e15f0cad80e7625887ae88e5830728aab # v3.0.0
+        with:
+          docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.GITHUB_SHA }}"
+          dockerfile_path: "${{ matrix.image }}/Dockerfile"
+          sbom_name: "${{ matrix.image }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Logout of Amazon ECR
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,41 @@
+name: Docker build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.filter.outputs.changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # tag=v2.11.1
+        id: filter
+        with:
+          filters: |
+            api: 'api/**'
+
+  build:
+    if: needs.changes.outputs.images != '[]'
+    runs-on: ubuntu-latest
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJSON(needs.changes.outputs.images) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Build image
+        working-directory: ./${{ matrix.image }}
+        run: |
+          docker build \
+          --build-arg GIT_SHA=${{ github.sha }} \
+          -t ${{ matrix.image }}:latest .


### PR DESCRIPTION
# Summary | Résumé
Adds github workflows to build the image when changes are made to the API, as well as a build & push upon merge