### PR TITLE
ci: fix function name in workflow

### DIFF
--- a/.github/workflows/docker-build-push-production.yml
+++ b/.github/workflows/docker-build-push-production.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  FUNCTION_PREFIX: gcds-api 
+  FUNCTION_PREFIX: gc-design-system
   GITHUB_SHA: ${{ github.sha }}
   REGISTRY: 307395567143.dkr.ecr.ca-central-1.amazonaws.com/gc-design-system
 


### PR DESCRIPTION
# Summary | Résumé
Workflow to update the function is failing due to the function name being incorrect:
<img width="447" alt="Screenshot 2023-12-07 at 10 17 42 AM" src="https://github.com/cds-snc/gcds-docs/assets/916044/6efbc622-7bb2-4692-84d0-adb6d704b6b2">

Function name should be `gc-design-system-api`
