### PR TITLE
fix: add more checks for originating host url

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -25,6 +25,10 @@ process.on('SIGTERM', async () => {
 app.post('/submission', async (req, res) => {
     let origin = req.get('origin');
     const body = req.body
+    const forwardedHost = req.get('x-forwarded-host')
+    const forwardedProto = req.get('x-forwarded-proto')
+
+    const forwardedOrigin = forwardedHost && forwardedProto ? `${forwardedProto}://${forwardedHost}` : null
 
     // Form name is in the format "contactEN" or "contactFR"
     const lang = body["form-name"].slice(-2).toLowerCase()
@@ -72,9 +76,12 @@ app.post('/submission', async (req, res) => {
         });
 
     // Attempt to get origin URL from request. If origin is null, use the default domains
+    origin = origin && origin !== 'null' ? origin : forwardedOrigin
     origin = origin && origin !== 'null' ? origin : lang === 'en' ? DOMAIN_EN : DOMAIN_FR
+
     const contactPath = lang == 'en' ? '/en/contact/thanks' : '/fr/contactez/merci'
     const redirectTo = origin + contactPath
+    console.log(`Redirecting to ${redirectTo}`)
     res.redirect(303, redirectTo)
 })
 

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -71,7 +71,8 @@ app.post('/submission', async (req, res) => {
             console.log('AXIOS ERROR: ', err);
         });
 
-    origin = origin ? origin : lang === 'en' ? DOMAIN_EN : DOMAIN_FR
+    // Attempt to get origin URL from request. If origin is null, use the default domains
+    origin = origin && origin !== 'null' ? origin : lang === 'en' ? DOMAIN_EN : DOMAIN_FR
     const contactPath = lang == 'en' ? '/en/contact/thanks' : '/fr/contactez/merci'
     const redirectTo = origin + contactPath
     res.redirect(303, redirectTo)

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -26,5 +26,5 @@ customHeaders:
           img-src 'self' data: https: www.w3.org;
           style-src 'unsafe-inline' https: 'strict-dynamic' 'self' https://fonts.googleapis.com;
           base-uri 'self';
-          form-action 'self' https://qao6j5zrqcys7evf2azwko4ju40xvfjy.lambda-url.ca-central-1.on.aws;
+          form-action 'self';
           object-src 'none'

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -31,7 +31,7 @@ Ask us about GC Design System, make a suggestion, or request a component you'd l
 
 Fill out this form or submit an issue through GitHub for <gcds-link external href="{{ links.githubTokensIssues }}" target="_blank">tokens</gcds-link>, <gcds-link external href="{{ links.githubIssues }}" target="_blank">components</gcds-link>, or <gcds-link external href="{{ links.githubDocsIssues }}" target="_blank">documentation</gcds-link>.
 
-<form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="https://qao6j5zrqcys7evf2azwko4ju40xvfjy.lambda-url.ca-central-1.on.aws/submission">
+<form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactEN" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -31,7 +31,7 @@ Renseignez-vous sur Système de design GC, faites une suggestion ou demandez un 
 
 Pour toute demande concernant <gcds-link external href="{{ links.githubTokensIssues }}" target="_blank">les unités de style</gcds-link>, <gcds-link external href="{{ links.githubIssues }}" target="_blank">les composants</gcds-link>, et <gcds-link external href="{{ links.githubDocsIssues }}" target="_blank">la documentation</gcds-link>, remplissez ce formulaire ou envoyez une demande à l'aide de fonction « Issues » dans GitHub.
 
-<form class="my-500 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="https://qao6j5zrqcys7evf2azwko4ju40xvfjy.lambda-url.ca-central-1.on.aws/submission">
+<form class="my-500 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactFR" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 


### PR DESCRIPTION
# Summary | Résumé
I did a bunch of testing with attempts to get the originating host URL. This change introduces the following logic:

- Origin could be an actual host, or null, or `null` (string)
- If `origin` is invalid, try and check if headers contain `x-forwarded-host`
- If none of the options above are valid, default to using the production domains depending on language

I also found a nice way to have a custom URL for the lambda function URL ([PR here](https://github.com/cds-snc/gcds-terraform/pull/37)).

⚠️ I won't merge this PR until the reverse proxy path exists. The path will exist as soon as the [PR](https://github.com/cds-snc/gcds-terraform/pull/37) has been merged & changes have been applied by terraform.
Update: I just tested the path via curl and it works now, so this should be safe to merge.