### PR TITLE
fix: Remove repeated line in language toggle documentation

### DIFF
--- a/src/en/components/language-toggle/use-case.md
+++ b/src/en/components/language-toggle/use-case.md
@@ -27,9 +27,6 @@ Use the language toggle to:
 - Make sure people are able to switch between languages without losing track of where they were before switching.
 - Support Official Languages by offering equitable access in French and English.
 
-Related components
-Header for placing the Government of Canada
-
 <article class="bg-full-width bg-primary text-light pt-500 pb-400 my-500">
   <h2 class="mt-0 mb-400">Related components</h2>
 


### PR DESCRIPTION
# Summary | Résumé

Remove repeated "related components" line in language toggle use case documentation.