### PR TITLE
fix: change path to alpha

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -26,5 +26,5 @@ customHeaders:
           img-src 'self' data: https: www.w3.org;
           style-src 'unsafe-inline' https: 'strict-dynamic' 'self' https://fonts.googleapis.com;
           base-uri 'self';
-          form-action 'self' https://design-system.cdssandbox.xyz;
+          form-action 'self';
           object-src 'none'

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -31,7 +31,7 @@ Ask us about GC Design System, make a suggestion, or request a component you'd l
 
 Fill out this form or submit an issue through GitHub for <gcds-link external href="{{ links.githubTokensIssues }}" target="_blank">tokens</gcds-link>, <gcds-link external href="{{ links.githubIssues }}" target="_blank">components</gcds-link>, or <gcds-link external href="{{ links.githubDocsIssues }}" target="_blank">documentation</gcds-link>.
 
-<form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="https://design-system.cdssandbox.xyz/api/submission">
+<form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactEN" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -31,7 +31,7 @@ Renseignez-vous sur Système de design GC, faites une suggestion ou demandez un 
 
 Pour toute demande concernant <gcds-link external href="{{ links.githubTokensIssues }}" target="_blank">les unités de style</gcds-link>, <gcds-link external href="{{ links.githubIssues }}" target="_blank">les composants</gcds-link>, et <gcds-link external href="{{ links.githubDocsIssues }}" target="_blank">la documentation</gcds-link>, remplissez ce formulaire ou envoyez une demande à l'aide de fonction « Issues » dans GitHub.
 
-<form class="my-500 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="https://design-system.cdssandbox.xyz/api/submission">
+<form class="my-500 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactFR" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 


### PR DESCRIPTION
# Summary | Résumé
Step x of hosting migration to AWS

This will be the final state of the contact form submission. The API endpoint that sits on a lambda will be available on `*.alpha.canada.ca/api/submission` which will then be a relative path for `*.alpha.canada.ca/api/submission`. 


---
⚠️ Do not merge until `*.cdssandbox.xyz` is released through terraform apply. Relevant PRs below:
- https://github.com/cds-snc/gcds-terraform/pull/39
- https://github.com/cds-snc/gcds-terraform/pull/40