### PR TITLE
Fix typo in select use case documentation

### DIFF
--- a/src/en/components/select/use-case.md
+++ b/src/en/components/select/use-case.md
@@ -17,7 +17,7 @@ permalink: /en/components/select/
 date: 'git Last Modified'
 ---
 
-## Problems buttons solve
+## Problems select solves
 
 Use select within a form to:
 


### PR DESCRIPTION
# Summary | Résumé

Update select's use case heading to mention the correct component. 
