### PR TITLE
fix: environment vars not loading, moved getParameters to lambda handler

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,10 +9,5 @@ COPY src ${FUNCTION_DIR}
 
 RUN npm install --omit=dev
 
-RUN apt-get update && apt-get install -y \
-    awscli
-
-COPY bin/entry.sh ./entry.sh
-
-RUN chmod +x ./entry.sh
 CMD exec ./entry.sh
+CMD ["node", "index.js"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,5 +9,4 @@ COPY src ${FUNCTION_DIR}
 
 RUN npm install --omit=dev
 
-CMD exec ./entry.sh
 CMD ["node", "index.js"]

--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-# shellcheck disable=SC2120
-
-echo "INFO Starting lambda handler"
-exec node index.js

--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -1,59 +1,5 @@
 #!/bin/sh
 # shellcheck disable=SC2120
 
-ENV_PATH="/tmp/gcds-api"
-TMP_ENV_FILE="$ENV_PATH/.env"
-
-# Check if a variable exists in the execution environment and is not empty
-var_expand() {
-  if [ -z "${1-}" ] || [ $# -ne 1 ]; then
-    printf 'var_expand: expected one argument\n' >&2;
-    return 1;
-  fi
-  eval printf '%s' "\"\${$1?}\"" 2> /dev/null # Variable double substitution to be able to check for variable
-}
-
-# Export variables from a .env file into the current execution environment
-load_non_existing_envs() {
-  _isComment='^[[:space:]]*#'
-  _isBlank='^[[:space:]]*$'
-  while IFS= read -r line; do
-    if echo "$line" | grep -Eq "$_isComment"; then # Ignore comment line
-      continue
-    fi
-    if echo "$line" | grep -Eq "$_isBlank"; then # Ignore blank line
-      continue
-    fi
-    key=$(echo "$line" | cut -d '=' -f 1)
-    value=$(echo "$line" | cut -d '=' -f 2-)
-
-    if [ -z "$(var_expand "$key")" ]; then # Check if environment variable doesn't exist
-      export "${key}=${value}"
-    fi
-  done < $TMP_ENV_FILE
-}
-
-echo "INFO Retrieving environment parameters"
-if [ ! -f "$ENV_PATH/.env" ]; then
-    if [ ! -d "$ENV_PATH" ]; then
-        mkdir "$ENV_PATH"
-    fi
-    aws ssm get-parameters \
-        --region ca-central-1 \
-        --with-decryption \
-        --names gc-design-system-config \
-        --query 'Parameters[*].Value' \
-        --output text > "$TMP_ENV_FILE"
-
-fi
-
-# Check if environment vars were retrieved
-if [ ! -s "$TMP_ENV_FILE" ]; then
-    echo "ERROR Failed to retrieve env vars during init"
-    rm "$TMP_ENV_FILE"
-    exit 1
-fi
-load_non_existing_envs
-
 echo "INFO Starting lambda handler"
 exec node index.js

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1,5 +1,7 @@
-const express = require('express')
-const axios = require("axios");
+import { getParametersByName } from '@aws-lambda-powertools/parameters/ssm';
+
+import express from 'express';
+import axios from 'axios';
 
 const app = express()
 const port = process.env['PORT'] || 8080
@@ -33,10 +35,13 @@ app.post('/submission', async (req, res) => {
     // Form name is in the format "contactEN" or "contactFR"
     const lang = body["form-name"].slice(-2).toLowerCase()
 
-    const { EMAIL_TARGET, NOTIFY_API_KEY, NOTIFY_TEMPLATE_ID } = process.env;
+    const parameters = await getParametersByName({
+        'gc-design-system-config': { transform: 'json' }
+    }, { decrypt: true });
+
+    const { EMAIL_TARGET, NOTIFY_API_KEY, NOTIFY_TEMPLATE_ID } = parameters['gc-design-system-config'];
 
     const {name, email, message, reasonForContact, honeypot} = body
-
 
     // Honeypot check
     if (honeypot && honeypot.length > 0) {

--- a/api/src/package.json
+++ b/api/src/package.json
@@ -5,7 +5,10 @@
   "main": "../index.js",
   "author": "",
   "license": "ISC",
+  "type": "module",
   "dependencies": {
+    "@aws-lambda-powertools/parameters": "^1.18.0",
+    "@aws-sdk/client-ssm": "^3.504.0",
     "axios": "^1.6.2",
     "express": "^4.18.2"
   }


### PR DESCRIPTION
# Summary | Résumé
The contact us form returned an Internal Server Error last January 30th when a user attempted to submit it. Upon further investigation, it seemed it was due to the environment variables not loading within the entry script. It seems to happen intermittently, or upon cold boot of the lambda. Moving the call to `getParameters` hopefully solves this issue

![Screenshot 2024-02-01 at 12 04 55 PM](https://github.com/cds-snc/gcds-docs/assets/916044/a030fbbb-b0df-4ef1-8772-5a2b979ea192)


**Important** the parameter `gc-design-system-config` config needs to be changed from a key-value env format to a JSON format (located in api_config in the forms terraform repository)
```json
{"EMAIL_TARGET":"assistance+design@cds-snc.ca",
"NOTIFY_API_KEY":"<notify-key>",
"NOTIFY_TEMPLATE_ID":"<notify-template>"}
```