### PR TITLE
fix: Add lang query string to storybook iframe

### DIFF
--- a/src/en/components/breadcrumbs/code.md
+++ b/src/en/components/breadcrumbs/code.md
@@ -31,7 +31,7 @@ Add a new breadcrumbs link to the breadcrumbs component by using the `<gcds-brea
 
 <iframe
   title="Overview of gcds-breadcrumbs properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&id=components-breadcrumbs--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&id=components-breadcrumbs--events-properties&lang=en"
   width="1200"
   height="1150"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/button/code.md
+++ b/src/en/components/button/code.md
@@ -22,7 +22,7 @@ Use a button for important actions a person using a product can initiate.
 
 <iframe
   title="Overview of gcds-button properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-button--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-button--events-properties&lang=en"
   width="1200"
   height="1800"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/card/code.md
+++ b/src/en/components/card/code.md
@@ -22,7 +22,7 @@ When you have more than 1 card on a page:
 
 <iframe
   title="Overview of gcds-card properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-card--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-card--events-properties&lang=en"
   width="1200"
   height="1900"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/checkbox/code.md
+++ b/src/en/components/checkbox/code.md
@@ -31,7 +31,7 @@ Use a checkbox with a [fieldset]({{ links.fieldset }}) when you are expecting th
 
 <iframe
   title="Overview of gcds-checkbox properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-checkbox--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-checkbox--events-properties&lang=en"
   width="1200"
   height="1950"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/container/code.md
+++ b/src/en/components/container/code.md
@@ -43,7 +43,7 @@ Containers are not centered automatically. To centre a container on a page, add 
 
 <iframe
   title="Overview of gcds-container properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-container--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-container--events-properties&lang=en"
   width="1200"
   height="1500"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/data-table/code.md
+++ b/src/en/components/data-table/code.md
@@ -14,7 +14,7 @@ tags: ['datatableEN', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-data-table--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-data-table--events-properties&lang=en"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/date-modified/code.md
+++ b/src/en/components/date-modified/code.md
@@ -21,7 +21,7 @@ Use the date modified component to identify the date a web page was last updated
 
 <iframe
   title="Overview of gcds-date-modified properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-date-modified--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-date-modified--events-properties&lang=en"
   width="1200"
   height="1100"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/details/code.md
+++ b/src/en/components/details/code.md
@@ -34,7 +34,7 @@ To help a reader's experience accessing details content:
 
 <iframe
   title="Overview of gcds-details properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-details--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-details--events-properties&lang=en"
   width="1200"
   height="1050"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/error-message/code.md
+++ b/src/en/components/error-message/code.md
@@ -40,7 +40,7 @@ A person who receives an error message needs to:
 
 <iframe
   title="Overview of gcds-error-message properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-message--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-message--events-properties&lang=en"
   width="1200"
   height="1000"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/error-summary/code.md
+++ b/src/en/components/error-summary/code.md
@@ -36,7 +36,7 @@ Opt to make your error heading more specific by using the `heading` attributes.
 
 <iframe
   title="Overview of gcds-error-summary properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-summary--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-summary--events-properties&lang=en"
   width="1200"
   height="1600"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/fieldset/code.md
+++ b/src/en/components/fieldset/code.md
@@ -35,7 +35,7 @@ The fieldset will only validate [checkbox]({{ links.checkbox }}) and [radio butt
 
 <iframe
   title="Overview of gcds-fieldset properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-fieldset--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-fieldset--events-properties&lang=en"
   width="1200"
   height="2300"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/file-uploader/code.md
+++ b/src/en/components/file-uploader/code.md
@@ -26,7 +26,7 @@ Define the file types the file uploader accepts using the `accept` attribute.
 
 <iframe
   title="Overview of gcds-file-uploader properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-file-uploader--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-file-uploader--events-properties&lang=en"
   width="1200"
   height="1850"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/footer/code.md
+++ b/src/en/components/footer/code.md
@@ -68,7 +68,7 @@ Opt to include the contextual band to add up to three footer links for your prod
 
 <iframe
   title="Overview of gcds-footer properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties&lang=en"
   width="1200"
   height="2150"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/grid/code.md
+++ b/src/en/components/grid/code.md
@@ -137,7 +137,7 @@ Mobile
 
 <iframe
   title="Overview of gcds-grid properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-grid--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-grid--events-properties&lang=en"
   width="1200"
   height="2250"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/header/code.md
+++ b/src/en/components/header/code.md
@@ -41,7 +41,7 @@ Use this header landmark to communicate a Government of Canada digital service o
 
 <iframe
   title="Overview of gcds-header properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-header--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-header--events-properties&lang=en"
   width="1200"
   height="1600"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/heading/code.md
+++ b/src/en/components/heading/code.md
@@ -45,7 +45,7 @@ Heading levels follow a sequential, hierarchical order: higher levels have large
 
 <iframe
   title="Overview of gcds-heading properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-heading--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-heading--events-properties&lang=en"
   width="1200"
   height="1300"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/image/code.md
+++ b/src/en/components/image/code.md
@@ -14,7 +14,7 @@ tags: ['imageEN', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-image--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-image--events-properties&lang=en"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/input/code.md
+++ b/src/en/components/input/code.md
@@ -25,7 +25,7 @@ Use an input to ask for information short, one-line response.
 
 <iframe
   title="Overview of gcds-input properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-input--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-input--events-properties&lang=en"
   width="1200"
   height="2075"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/language-toggle/code.md
+++ b/src/en/components/language-toggle/code.md
@@ -23,7 +23,7 @@ Note: If using the header component, the language toggle can be assigned using t
 
 <iframe
   title="Overview of gcds-footer properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-language-toggle--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-language-toggle--events-properties&lang=en"
   width="1200"
   height="850"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/link/code.md
+++ b/src/en/components/link/code.md
@@ -40,7 +40,7 @@ Note: Only files with URLs of the same origin as the website will be downloaded 
 
 <iframe
   title="Overview of gcds-link properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-link--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-link--events-properties&lang=en"
   width="1200"
   height="1300"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/pagination/code.md
+++ b/src/en/components/pagination/code.md
@@ -86,7 +86,7 @@ url = {
 
 <iframe
   title="Overview of gcds-pagination properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-pagination--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-pagination--events-properties&lang=en"
   width="1200"
   height="1500"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/radio/code.md
+++ b/src/en/components/radio/code.md
@@ -24,7 +24,7 @@ The radio helps users to make a choice by limiting their options.
 
 <iframe
   title="Overview of gcds-radio properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-radio--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-radio--events-properties&lang=en"
   width="1200"
   height="1770"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/screenreader-content/code.md
+++ b/src/en/components/screenreader-content/code.md
@@ -14,7 +14,7 @@ tags: ['screenreadercontentEN', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-screenreader-content--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-screenreader-content--events-properties&lang=en"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/search/code.md
+++ b/src/en/components/search/code.md
@@ -30,7 +30,7 @@ Use the search component so people can find information based on keywords.
 
 <iframe
   title="Overview of gcds-search properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-search--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-search--events-properties&lang=en"
   width="1200"
   height="1150"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/select/code.md
+++ b/src/en/components/select/code.md
@@ -24,7 +24,7 @@ Use the `default-value` attribute to set the first option in the select list. Th
 
 <iframe
   title="Overview of gcds-select properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-select--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-select--events-properties&lang=en"
   width="1200"
   height="2200"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/side-navigation/code.md
+++ b/src/en/components/side-navigation/code.md
@@ -24,7 +24,7 @@ If using breadcrumbs, align the content hierarchy in both sets of links, so the 
 
 <iframe
   title="Overview of gcds-side-nav properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-side-navigation--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-side-navigation--events-properties&lang=en"
   width="1200"
   height="1800"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/signature/code.md
+++ b/src/en/components/signature/code.md
@@ -29,7 +29,7 @@ Use the signature type in the site's <gcds-link href="{{ links.header }}">header
 
 <iframe
   title="Overview of gcds-side-nav properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-signature--events-properties#events--properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-signature--events-properties#events--properties&lang=en"
   width="1200"
   height="1100"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/stepper/code.md
+++ b/src/en/components/stepper/code.md
@@ -20,7 +20,7 @@ Use the `current-step` attribute to indicate the step that the user is on and th
 
 <iframe
   title="Overview of gcds-stepper properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-stepper--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-stepper--events-properties&lang=en"
   width="1200"
   height="950"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/text/code.md
+++ b/src/en/components/text/code.md
@@ -40,7 +40,7 @@ Text displays non-heading content with matching GC Design System styles to provi
 
 <iframe
   title="Overview of gcds-text properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-text--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-text--events-properties&lang=en"
   width="1200"
   height="1350"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/textarea/code.md
+++ b/src/en/components/textarea/code.md
@@ -29,7 +29,7 @@ The text area gives users the option to provide the information they want to sha
 
 <iframe
   title="Overview of gcds-textarea properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-textarea--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-textarea--events-properties&lang=en"
   width="1200"
   height="2050"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/theme-and-topic-menu/code.md
+++ b/src/en/components/theme-and-topic-menu/code.md
@@ -22,7 +22,7 @@ Add the theme and topic menu directly to the <gcds-link href="{{ links.header }}
 
 <iframe
   title="Overview of gcds-topic-menu properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-theme-and-topic-menu--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-theme-and-topic-menu--events-properties&lang=en"
   width="1200"
   height="1850"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/top-navigation/code.md
+++ b/src/en/components/top-navigation/code.md
@@ -26,7 +26,7 @@ Use a top navigation to help a person find their way around your web page or sit
 
 <iframe
   title="Overview of gcds-top-nav properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-top-navigation--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-top-navigation--events-properties&lang=en"
   width="1200"
   height="1850"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/Case-a-cocher/code.md
+++ b/src/fr/composants/Case-a-cocher/code.md
@@ -31,7 +31,7 @@ Utilisez une case à cocher avec un [jeu de champs]({{ links.fieldset }}) lorsqu
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-checkbox."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-checkbox--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-checkbox--events-properties&lang=fr"
   width="1200"
   height="1950"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/Chemin-de-navigation/code.md
+++ b/src/fr/composants/Chemin-de-navigation/code.md
@@ -31,7 +31,7 @@ Ajoutez un nouveau lien au composant Chemin de navigation à l'aide du composant
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-breadcrumbs."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&id=components-breadcrumbs--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&id=components-breadcrumbs--events-properties&lang=fr"
   width="1200"
   height="1150"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/barre-de-navigation-laterale/code.md
+++ b/src/fr/composants/barre-de-navigation-laterale/code.md
@@ -24,7 +24,7 @@ Si vous utilisez un composant Chemin de navigation, uniformisez la hiérarchie d
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-side-nav."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-side-navigation--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-side-navigation--events-properties&lang=fr"
   width="1200"
   height="1800"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/barre-de-navigation-superieure/code.md
+++ b/src/fr/composants/barre-de-navigation-superieure/code.md
@@ -26,7 +26,7 @@ Utilisez une barre de navigation supérieure pour aider une personne à se repé
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-top-nav."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-top-navigation--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-top-navigation--events-properties&lang=fr"
   width="1200"
   height="1850"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/bascule-de-langue/code.md
+++ b/src/fr/composants/bascule-de-langue/code.md
@@ -23,7 +23,7 @@ Remarque : Si vous utilisez le composant En-tête, la bascule de langue peut êt
 
 <iframe
   title="Overview of gcds-lang-toggle properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-language-toggle--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-language-toggle--events-properties&lang=fr"
   width="1200"
   height="850"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/boite/code.md
+++ b/src/fr/composants/boite/code.md
@@ -43,7 +43,7 @@ Les boîtes ne sont pas automatiquement centrées. Pour centrer une boîte sur u
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-container."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-container--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-container--events-properties&lang=fr"
   width="1200"
   height="1500"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/bouton-radio/code.md
+++ b/src/fr/composants/bouton-radio/code.md
@@ -24,7 +24,7 @@ Les boutons radio aident les utilisateur·rice·s a faire un choix en limitant l
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-radio."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-radio--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-radio--events-properties&lang=fr"
   width="1200"
   height="1770"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/bouton/code.md
+++ b/src/fr/composants/bouton/code.md
@@ -22,7 +22,7 @@ Utilisez un bouton pour les actions importantes que peut initier une personne ut
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-button."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-button--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-button--events-properties&lang=fr"
   width="1200"
   height="1800"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/carte/code.md
+++ b/src/fr/composants/carte/code.md
@@ -22,7 +22,7 @@ Lorsque votre page comprend plusieurs cartes :
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-card."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-card--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-card--events-properties&lang=fr"
   width="1200"
   height="1900"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/champ-de-saisie/code.md
+++ b/src/fr/composants/champ-de-saisie/code.md
@@ -26,7 +26,7 @@ Utilisez un champ de saisie pour obtenir une réponse courte d'une ligne.
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-input."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-input--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-input--events-properties&lang=fr"
   width="1200"
   height="2075"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/contenu-pour-lecteurs-decran/code.md
+++ b/src/fr/composants/contenu-pour-lecteurs-decran/code.md
@@ -14,7 +14,7 @@ tags: ['screenreadercontentFR', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-screenreader-content--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-screenreader-content--events-properties&lang=fr"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/date-de-modification/code.md
+++ b/src/fr/composants/date-de-modification/code.md
@@ -21,7 +21,7 @@ Utilisez le composant date de modification pour indiquer la date de la dernière
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-date-modified."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-date-modified--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-date-modified--events-properties&lang=fr"
   width="1200"
   height="1100"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/details/code.md
+++ b/src/fr/composants/details/code.md
@@ -34,7 +34,7 @@ Pour aider une personne à accéder au contenu du composant Détails :
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-details."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-details--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-details--events-properties&lang=fr"
   width="1200"
   height="1050"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/en-tete/code.md
+++ b/src/fr/composants/en-tete/code.md
@@ -41,7 +41,7 @@ Utilisez ce point de repère pour transmettre de l'information sur un service du
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-header."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-header--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-header--events-properties&lang=fr"
   width="1200"
   height="1600"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/grille/code.md
+++ b/src/fr/composants/grille/code.md
@@ -137,7 +137,7 @@ Mobile
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-grid."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-grid--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-grid--events-properties&lang=fr"
   width="1200"
   height="2250"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/image/code.md
+++ b/src/fr/composants/image/code.md
@@ -14,7 +14,7 @@ tags: ['imageFR', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-image--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-image--events-properties&lang=fr"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/indicateur-detape/code.md
+++ b/src/fr/composants/indicateur-detape/code.md
@@ -20,7 +20,7 @@ Utilisez l'attribut `current-step` pour indiquer l'étape à laquelle l'utilisat
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-stepper."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-stepper--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-stepper--events-properties&lang=fr"
   width="1200"
   height="950"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/jeu-de-champs/code.md
+++ b/src/fr/composants/jeu-de-champs/code.md
@@ -35,7 +35,7 @@ Le jeu de champs ne validera que les [cases à cocher]({{ links.checkbox }}) et 
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-fieldset."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-fieldset--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-fieldset--events-properties&lang=fr"
   width="1200"
   height="2300"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/lien/code.md
+++ b/src/fr/composants/lien/code.md
@@ -40,7 +40,7 @@ Remarque : Seuls les fichiers dont l'URL est de la même origine que le site We
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-link."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-link--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-link--events-properties&lang=fr"
   width="1200"
   height="1300"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/menu-des-themes-et-sujets/code.md
+++ b/src/fr/composants/menu-des-themes-et-sujets/code.md
@@ -22,7 +22,7 @@ Remarque : Si vous souhaitez ajouter un menu de thèmes et sujets à la page d'a
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-topic-menu."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-theme-and-topic-menu--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-theme-and-topic-menu--events-properties&lang=fr"
   width="1200"
   height="1850"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/message-derreur/code.md
+++ b/src/fr/composants/message-derreur/code.md
@@ -40,7 +40,7 @@ La personne qui reçoit un message d'erreur doit :
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-error-message."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-message--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-message--events-properties&lang=fr"
   width="1200"
   height="1000"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/pagination/code.md
+++ b/src/fr/composants/pagination/code.md
@@ -86,7 +86,7 @@ url = {
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-pagination."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-pagination--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-pagination--events-properties&lang=fr"
   width="1200"
   height="1500"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/pied-de-page/code.md
+++ b/src/fr/composants/pied-de-page/code.md
@@ -68,7 +68,7 @@ Pour la bande de lien du pied de page, réglez l'élément `sub-links` en passan
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-footer."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties&lang=fr"
   width="1200"
   height="2150"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/recherche/code.md
+++ b/src/fr/composants/recherche/code.md
@@ -30,7 +30,7 @@ Utilisez le composant recherche pour aider les gens à trouver des renseignement
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-search."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-search--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-search--events-properties&lang=fr"
   width="1200"
   height="1150"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/resume-de-erreurs/code.md
+++ b/src/fr/composants/resume-de-erreurs/code.md
@@ -36,7 +36,7 @@ Rédigez des en-têtes d'erreur plus précis en utilisant l'attribut `heading`.
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-error-summary."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-summary--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-error-summary--events-properties&lang=fr"
   width="1200"
   height="1600"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/selection/code.md
+++ b/src/fr/composants/selection/code.md
@@ -24,7 +24,7 @@ Utilisez l'attribut `default-value` pour configurer la première option dans la 
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-select."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-select--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-select--events-properties&lang=fr"
   width="1200"
   height="2200"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/signature/code.md
+++ b/src/fr/composants/signature/code.md
@@ -29,7 +29,7 @@ Utilisez la signature dans <gcds-link href="{{ links.header }}">l'en-tête</gcds
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-signature."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-signature--events-properties#events--properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-signature--events-properties#events--properties&lang=fr"
   width="1200"
   height="1100"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/tableau-de-donnees/code.md
+++ b/src/fr/composants/tableau-de-donnees/code.md
@@ -14,7 +14,7 @@ tags: ['datatableFR', 'code']
 
 <iframe
   title="iframeTitle"
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-data-table--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-data-table--events-properties&lang=fr"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/televerseur-de-fichiers/code.md
+++ b/src/fr/composants/televerseur-de-fichiers/code.md
@@ -26,7 +26,7 @@ Utilisez l'attribut `accept` pour définir les types de fichiers acceptés par l
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-file-uploader."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-file-uploader--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-file-uploader--events-properties&lang=fr"
   width="1200"
   height="1850"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/texte/code.md
+++ b/src/fr/composants/texte/code.md
@@ -40,7 +40,7 @@ Le composant texte affiche du contenu sans titre avec les styles correspondants 
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-text."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-text--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-text--events-properties&lang=fr"
   width="1200"
   height="1650"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/titre/code.md
+++ b/src/fr/composants/titre/code.md
@@ -45,7 +45,7 @@ Les niveaux de titre suivent un ordre séquentiel et hiérarchique : les niveaux
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-heading."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-heading--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-heading--events-properties&lang=fr"
   width="1200"
   height="1300"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/zone-de-texte/code.md
+++ b/src/fr/composants/zone-de-texte/code.md
@@ -29,7 +29,7 @@ La zone de texte donne aux utilisateur·rice·s la possibilité de fournir les r
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-textarea."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-textarea--events-properties"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-textarea--events-properties&lang=fr"
   width="1200"
   height="2050"
   style="display: block; margin: 0 auto;"


### PR DESCRIPTION
# Summary | Résumé

For new properties and events frame rendering logic, add a `lang` query string to the `src` attribute of the iframe.
