### PR TITLE
fix: Add autocomplete to contact form fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
-    "@cdssnc/gcds-components": "^0.17.0",
-    "@cdssnc/gcds-tokens": "^1.10.1",
+    "@cdssnc/gcds-components": "^0.19.1",
+    "@cdssnc/gcds-tokens": "^1.11.1",
     "@cdssnc/gcds-utility": "^1.0.7",
     "@quasibit/eleventy-plugin-sitemap": "^2.1.4",
     "chroma-js": "^2.4.2",

--- a/src/en/components/grid/base.md
+++ b/src/en/components/grid/base.md
@@ -6,6 +6,8 @@ permalink: false
 tags: ['gridEN', 'header']
 ---
 
+{{ locale }}
+
 # Grid <br>`<gcds-grid>`
 
 _Also called: layout, columns, columns layout, grid container._

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -31,8 +31,8 @@ We’d like to talk to you. Get in touch to request a demo, ask a question, or m
   <input type="hidden" name="form-name" value="contactEN" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 
-  <gcds-input type="text" input-id="name" label="Full name" size="30" required></gcds-input>
-  <gcds-input type="email" input-id="email" label="Email address" size="50" required></gcds-input>
+  <gcds-input type="text" input-id="name" label="Full name" size="30" autocomplete="name" required></gcds-input>
+  <gcds-input type="email" input-id="email" label="Email address" size="50" autocomplete="email" required></gcds-input>
   <gcds-fieldset fieldset-id="reasonForContact" legend="Reason for your communication" required>
     <gcds-radio radio-id="requestADemo" name="reasonForContact" label="Request a demo" value="Request a demo" hint="Book a demo of GC Design System for your team."></gcds-radio>
     <gcds-radio radio-id="reportAnIssue" name="reasonForContact" label="Report an issue" value="Report an issue" hint="Communicate a problem you've found."></gcds-radio>

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -31,8 +31,8 @@ Nous sommes à l’écoute. Contactez-nous pour demander une démonstration, pos
   <input type="hidden" name="form-name" value="contactFR" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 
-  <gcds-input type="text" input-id="name" label="Nom complet" size="30" required></gcds-input>
-  <gcds-input type="email" input-id="email" label="Adresse courriel" size="50" required></gcds-input>
+  <gcds-input type="text" input-id="name" label="Nom complet" size="30" autocomplete="name" required></gcds-input>
+  <gcds-input type="email" input-id="email" label="Adresse courriel" size="50" autocomplete="email" required></gcds-input>
   <gcds-fieldset fieldset-id="reasonForContact" legend="Raison de votre communication" required>
     <gcds-radio radio-id="requestADemo" name="reasonForContact" label="Demander une démonstration" value="Request a demo | Demander une démonstration" hint="Réservez une démonstration de Système de design GC pour votre équipe."></gcds-radio>
     <gcds-radio radio-id="reportAnIssue" name="reasonForContact" label="Signaler un problème" value="Report an issue | Signaler un problème" hint="Communiquez un problème que vous avez trouvé."></gcds-radio>


### PR DESCRIPTION
# Summary | Résumé

Update to latest version of `@cdssnc/gcds-components` to receive new autocomplete updates. Add autocomplete attribute to the Full name and email fields on contact us page.
