### PR TITLE
[WIP] feat: add page find

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -13,6 +13,8 @@ const displayTokens = require('./utils/display-tokens');
 const markdownAnchor = require('./utils/anchor');
 const slugify = require('./utils/slugify');
 
+const { execSync } = require('child_process')
+
 module.exports = function (eleventyConfig) {
   // Pass through copies
 
@@ -21,6 +23,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy('./src/styles/prism.css');
   eleventyConfig.addPassthroughCopy('./src/images');
   eleventyConfig.addPassthroughCopy('./src/scripts/code-showcase.js');
+  eleventyConfig.addPassthroughCopy('./src/scripts/search.js');
   eleventyConfig.addPassthroughCopy('./src/admin/config.yml');
   eleventyConfig.addPassthroughCopy('./src/favicon.ico');
   eleventyConfig.addPassthroughCopy({ './src/variables/': 'variables' });
@@ -281,6 +284,10 @@ module.exports = function (eleventyConfig) {
       };
     });
   });
+
+  eleventyConfig.on('eleventy.after', () => {
+    execSync(`npx pagefind --site _site --glob \"**/*.html\"`, { encoding: 'utf-8' })
+  })
 
   return {
     pathPrefix: process.env.PATH_PREFIX || '/',

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@quasibit/eleventy-plugin-sitemap": "^2.1.4",
     "chroma-js": "^2.4.2",
     "eleventy-plugin-svg-contents": "^0.7.0",
+    "pagefind": "^1.0.4",
     "prettier": "3.2.5",
     "prompt-sync": "^4.2.0",
     "replace-in-file": "^7.0.0",

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -30,6 +30,11 @@
     <link rel="stylesheet" href="{{ '/components/dist/gcds/gcds.css' | url }}">
     <script type="module" src="/components/dist/gcds/gcds.esm.js"></script>
     <script nomodule src="/components/dist/gcds/gcds.js"></script>
+
+    <!-- Pagefind -->
+    <script src="/pagefind/pagefind.js" type="module"></script>
+    <script src="{{ '/scripts/search.js' | url }}" type="module"></script>
+
   </head>
   <body>
     {% include "partials/header.njk" %}

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -30,6 +30,11 @@
     <link rel="stylesheet" href="{{ '/components/dist/gcds/gcds.css' | url }}">
     <script type="module" src="/components/dist/gcds/gcds.esm.js"></script>
     <script nomodule src="/components/dist/gcds/gcds.js"></script>
+
+    <!-- Pagefind -->
+    <script src="/pagefind/pagefind.js" type="module"></script>
+    <script src="{{ '/scripts/search.js' | url }}" type="module"></script>
+
   </head>
   <body>
     {% include "partials/header.njk" %}

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -24,4 +24,6 @@
 >
   {% include "partials/nav.njk" %}
   {% include "partials/breadcrumbs.njk" %}
+  {% include "partials/search.njk" %}
+
 </gcds-header>

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -17,6 +17,8 @@
   {% endif %}
 {% endfor %}
 
+
+
 <gcds-header
   lang="{{ locale }}"
   skip-to-href="#mc"

--- a/src/_includes/partials/search.njk
+++ b/src/_includes/partials/search.njk
@@ -1,0 +1,3 @@
+<gcds-search search-id="search" slot="search" placeholder="design system" action="javascript:void(0);">
+    <div id="results" class="search-results"></div>
+</gcds-search>

--- a/src/scripts/search.js
+++ b/src/scripts/search.js
@@ -1,0 +1,49 @@
+function onElementAvailable(selector, callback) {
+  const observer = new MutationObserver(mutations => {
+    if (document.querySelector(selector)) {
+      observer.disconnect();
+      callback();
+    }
+  });
+
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+}
+
+function addResult(result) {
+    // console.log(result);
+    let results = document.querySelector('#results');
+    let resultElement = document.createElement('div');
+    console.log('title is...', encodeURIComponent(result.meta.title);
+    resultElement.innerHTML = `<gcds-link href="${result.url}">${encodeURIComponent(result.meta.title)}</gcds-link>`;
+    resultElement.innerHTML += `<gcds-text size="caption" role="secondary" character-limit="false" margin-bottom="0">${result.excerpt}</gcds-text>`;
+    results.appendChild(resultElement);
+}
+
+function clearResults() {
+    let results = document.querySelector('#results');
+    results.innerHTML = '';
+}
+
+import * as pagefind from "/pagefind/pagefind.js";
+onElementAvailable('gcds-search', async () => {
+  await pagefind.options({
+    baseUrl: "/",
+  });
+
+
+  let searchComponent = document.querySelector('gcds-search');
+
+  // search on submit event
+  searchComponent.addEventListener('gcdsSubmit', async function (e) {
+    clearResults();
+    const searchTerm = searchComponent.querySelector('input').value
+    const search = await pagefind.search(searchTerm);
+
+    // length could also be from search.unfilteredResultCount
+    for (const result of search.results) {
+        let data = await result.data();
+        console.log('data is', data);
+        addResult(data);
+    }
+  })
+});

--- a/src/scripts/search.js
+++ b/src/scripts/search.js
@@ -10,12 +10,20 @@ function onElementAvailable(selector, callback) {
 }
 
 function addResult(result) {
-    // console.log(result);
     let results = document.querySelector('#results');
     let resultElement = document.createElement('div');
-    console.log('title is...', encodeURIComponent(result.meta.title);
-    resultElement.innerHTML = `<gcds-link href="${result.url}">${encodeURIComponent(result.meta.title)}</gcds-link>`;
-    resultElement.innerHTML += `<gcds-text size="caption" role="secondary" character-limit="false" margin-bottom="0">${result.excerpt}</gcds-text>`;
+    let link = document.createElement('gcds-link');
+    link.setAttribute('href', result.url);
+    link.innerText = result.meta.title;
+    resultElement.appendChild(link);
+
+    let gcdsText = document.createElement('gcds-text');
+    gcdsText.setAttribute('size', 'caption');
+    gcdsText.setAttribute('role', 'secondary');
+    gcdsText.setAttribute('character-limit', 'false');
+    gcdsText.setAttribute('margin-bottom', '0');
+    gcdsText.innerHTML = result.excerpt;
+    resultElement.appendChild(gcdsText);
     results.appendChild(resultElement);
 }
 
@@ -30,7 +38,6 @@ onElementAvailable('gcds-search', async () => {
     baseUrl: "/",
   });
 
-
   let searchComponent = document.querySelector('gcds-search');
 
   // search on submit event
@@ -42,7 +49,6 @@ onElementAvailable('gcds-search', async () => {
     // length could also be from search.unfilteredResultCount
     for (const result of search.results) {
         let data = await result.data();
-        console.log('data is', data);
         addResult(data);
     }
   })

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -3,9 +3,8 @@
   background-color: var(--gcds-textarea-default-background);
   border: var(--gcds-border-width-sm) solid var(--gcds-border-default);
   z-index: 9999;
-  margin-top: 100px;
-  margin-left: 20px;
-  padding: var(--gcds-spacing-300);
+  margin-top: calc(var(--gcds-input-min-width-and-height) + var(--gcds-input-outline-width));
+  //margin-left: 20px;
   padding: var(--gcds-textarea-padding);
 
   div {

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -1,0 +1,18 @@
+.search-results {
+  position: absolute;
+  background-color: var(--gcds-textarea-default-background);
+  border: var(--gcds-border-width-sm) solid var(--gcds-border-default);
+  z-index: 9999;
+  margin-top: 100px;
+  margin-left: 20px;
+  padding: var(--gcds-spacing-300);
+  padding: var(--gcds-textarea-padding);
+
+  div {
+    margin-bottom: var(--gcds-spacing-300);
+  }
+}
+
+.search-results:empty {
+  display: none;
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -363,6 +363,24 @@ nav.tabs a[aria-current=page]:focus {
   border-color: var(--gcds-focus-background);
 }
 
+.search-results {
+  position: absolute;
+  background-color: var(--gcds-textarea-default-background);
+  border: var(--gcds-border-width-sm) solid var(--gcds-border-default);
+  z-index: 9999;
+  margin-top: 100px;
+  margin-left: 20px;
+  padding: var(--gcds-spacing-300);
+  padding: var(--gcds-textarea-padding);
+}
+.search-results div {
+  margin-bottom: var(--gcds-spacing-300);
+}
+
+.search-results:empty {
+  display: none;
+}
+
 .hero {
   margin: calc(-1 * var(--gcds-spacing-200));
   background: url(../../images/common/home/home-hero.jpg) top center no-repeat;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -368,9 +368,7 @@ nav.tabs a[aria-current=page]:focus {
   background-color: var(--gcds-textarea-default-background);
   border: var(--gcds-border-width-sm) solid var(--gcds-border-default);
   z-index: 9999;
-  margin-top: 100px;
-  margin-left: 20px;
-  padding: var(--gcds-spacing-300);
+  margin-top: calc(var(--gcds-input-min-width-and-height) + var(--gcds-input-outline-width));
   padding: var(--gcds-textarea-padding);
 }
 .search-results div {

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -12,6 +12,7 @@
 @import 'components/component-preview-box';
 @import 'components/table';
 @import 'components/tabs';
+@import 'components/search';
 
 // Pages
 @import 'pages/home';


### PR DESCRIPTION
# Summary | Résumé
Yesterday I tried Pagefind and it was quick and easy to get started with. However, that was because I used their own UI which doesn't work with our components. So I dug around their documentation a bit and it looks like we can absolutely use our own components with pagefind because they also provide just their JS search API, albeit it does require a lot more frontend dev work.

This is their JS API docs: https://pagefind.app/docs/api/

At the time of the PR here is how this quick (and ugly, sorry!) feature looks like
<kbd>
English search
<img width="1462" alt="Screenshot 2024-03-15 at 10 50 03 PM" src="https://github.com/cds-snc/gcds-docs/assets/916044/3b96c34f-79c5-4b77-a6bf-2437e8ee2bfb">
</kbd>
<kbd>
French search
<img width="779" alt="Screenshot 2024-03-15 at 11 00 27 PM" src="https://github.com/cds-snc/gcds-docs/assets/916044/60f50450-032d-4540-8d17-2d5c0c13eebf">
</kbd>

# More work is required:
**Frontend development**
- Would be great to have designs for the results, or how it should look like
- Could someone help with the frontend dev + interactions part, using our components and adding styles etc

**Content work**
At the moment, I simply ran the most basic indexing pagefind could do. The results could definitely be better
- We need to [work on the indexing](https://pagefind.app/docs/indexing/)
- We need to [look into the weights](https://pagefind.app/docs/weighting/) etc 
- We could also look into [filters](https://pagefind.app/docs/js-api-filtering/)!

## Note
The PR preview environments won't work on active development since we need a nonce for the JS amongst other things. CSP won't be happy sadly.

Part of:
- https://github.com/cds-snc/design-gc-conception/issues/494
- https://github.com/cds-snc/design-gc-conception/issues/493
- https://github.com/cds-snc/design-gc-conception/issues/693
- https://github.com/cds-snc/design-gc-conception/issues/464
