### PR TITLE
fix: breadcrumbs navigation landmark being repeated

### DIFF
--- a/src/_data/tabsnav.js
+++ b/src/_data/tabsnav.js
@@ -1,0 +1,8 @@
+module.exports = {
+  en: {
+    label: 'Content tabs',
+  },
+  fr: {
+    label: 'TO DO',
+  },
+};

--- a/src/_data/tabsnav.js
+++ b/src/_data/tabsnav.js
@@ -1,8 +1,8 @@
 module.exports = {
   en: {
-    label: 'Content tabs',
+    label: 'Guidance tabs',
   },
   fr: {
-    label: 'TO DO',
+    label: 'Onglet de consignes',
   },
 };

--- a/src/_includes/layouts/component-documentation.njk
+++ b/src/_includes/layouts/component-documentation.njk
@@ -7,7 +7,7 @@
 {% block content %}
   {% if tabs %}
     {{ tabs.header.templateContent | safe }}
-    <nav class="tabs mb-400" aria-label="{{ navLabel or title }}">
+    <nav class="tabs mb-400" aria-label="{{ tabsnav[locale].label }}">
       <ul>
         {% for key, tab in documentation[locale] %}
           {% if tabs[key].url %}

--- a/src/en/components/breadcrumbs/base.md
+++ b/src/en/components/breadcrumbs/base.md
@@ -16,8 +16,12 @@ Breadcrumbs is a path to the current page from each preceding level of the site'
 {% enddocLinks %}
 
 {% componentPreview "Breadcrumbs component preview" %}
-<gcds-breadcrumbs>
-<gcds-breadcrumbs-item href="#">Home page</gcds-breadcrumbs-item>
-<gcds-breadcrumbs-item href="#">Parent page link</gcds-breadcrumbs-item>
-</gcds-breadcrumbs-item>
+
+<div aria-hidden="true">
+  <gcds-breadcrumbs>
+    <gcds-breadcrumbs-item href="#">Home page</gcds-breadcrumbs-item>
+    <gcds-breadcrumbs-item href="#">Parent page link</gcds-breadcrumbs-item>
+    </gcds-breadcrumbs-item>
+  </gcds-breadcrumbs>
+</div>
 {% endcomponentPreview %}

--- a/src/fr/composants/Chemin-de-navigation/base.md
+++ b/src/fr/composants/Chemin-de-navigation/base.md
@@ -16,8 +16,12 @@ Un chemin d'accès à la page actuelle à partir de chaque niveau précédent de
 {% enddocLinks %}
 
 {% componentPreview "Aperçu du composant de chemin de navigation" %}
-<gcds-breadcrumbs>
-<gcds-breadcrumbs-item href="#">Page d'accueil</gcds-breadcrumbs-item>
-<gcds-breadcrumbs-item href="#">Lien vers la page parent</gcds-breadcrumbs-item>
-</gcds-breadcrumbs-item>
+
+<div aria-hidden="true">
+  <gcds-breadcrumbs>
+    <gcds-breadcrumbs-item href="#">Page d'accueil</gcds-breadcrumbs-item>
+    <gcds-breadcrumbs-item href="#">Lien vers la page parent</gcds-breadcrumbs-item>
+    </gcds-breadcrumbs-item>
+  </gcds-breadcrumbs>
+</div>
 {% endcomponentPreview %}


### PR DESCRIPTION
# Summary | Résumé

When viewing the page landmarks, several landmarks are labeled as "Breadcrumbs navigation". This includes:

- The breadcrumbs in the header slot
- The breadcrumbs component example
- The tabs (Use case, design, code)
- The breadcrumb example in the code builder

Note: We will not be able to remove the breadcrumbs landmark from the code builder. The only way to remove it would be to change the component itself which doesn't make sense OR to hide the code builder for the breadcrumbs completely for screen reader users which is also not a great option.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/761)