### PR TITLE
Update top nav label

### DIFF
--- a/src/_data/nav.js
+++ b/src/_data/nav.js
@@ -2,11 +2,11 @@ module.exports = {
   en: {
     title: 'GC Design system',
     url: '/en',
-    label: 'Main',
+    label: 'Main menu',
   },
   fr: {
     title: 'Système de design GC',
     url: '/fr',
-    label: 'Principal',
+    label: 'Menu principal',
   },
 };

--- a/src/en/components/side-navigation/base.md
+++ b/src/en/components/side-navigation/base.md
@@ -15,21 +15,24 @@ A side navigation is a vertical list of page links on the left side of the scree
 {% enddocLinks %}
 
 {% componentPreview "Side navigation component preview" "px-300 pt-400 pb-200" %}
-<gcds-side-nav label="GC Forms">
-<gcds-nav-link href="#">Why GC Forms</gcds-nav-link>
-<gcds-nav-group menu-label="Features" open-trigger="Features">
-<gcds-nav-group menu-label="Build and manage forms yourself" open-trigger="Build and manage forms yourself">
-<gcds-nav-link href="#">Review in both official languages side-by-side</gcds-nav-link>
-<gcds-nav-link href="#">Get form responses delivered securely</gcds-nav-link>
-<gcds-nav-link href="#">Test forms before publishing</gcds-nav-link>
-</gcds-nav-group>
-<gcds-nav-group menu-label="Publish trusted, user-friendly forms" open-trigger="Publish trusted, user-friendly forms">
-<gcds-nav-link href="#">Forms that people can fill out anywhere</gcds-nav-link>
-<gcds-nav-link href="#">Forms that save time and effort</gcds-nav-link>
-<gcds-nav-link href="#">Forms with the GC look and feel</gcds-nav-link>
-</gcds-nav-group>
-</gcds-nav-group>
-<gcds-nav-link href="#">Guidance</gcds-nav-link>
-<gcds-nav-link href="#">Contact us</gcds-nav-link>
-</gcds-side-nav>
+
+<div aria-hidden="true">
+  <gcds-side-nav label="GC Forms">
+    <gcds-nav-link href="#">Why GC Forms</gcds-nav-link>
+    <gcds-nav-group menu-label="Features" open-trigger="Features">
+      <gcds-nav-group menu-label="Build and manage forms yourself" open-trigger="Build and manage forms yourself">
+        <gcds-nav-link href="#">Review in both official languages side-by-side</gcds-nav-link>
+        <gcds-nav-link href="#">Get form responses delivered securely</gcds-nav-link>
+        <gcds-nav-link href="#">Test forms before publishing</gcds-nav-link>
+      </gcds-nav-group>
+      <gcds-nav-group menu-label="Publish trusted, user-friendly forms" open-trigger="Publish trusted, user-friendly forms">
+        <gcds-nav-link href="#">Forms that people can fill out anywhere</gcds-nav-link>
+        <gcds-nav-link href="#">Forms that save time and effort</gcds-nav-link>
+        <gcds-nav-link href="#">Forms with the GC look and feel</gcds-nav-link>
+      </gcds-nav-group>
+    </gcds-nav-group>
+    <gcds-nav-link href="#">Guidance</gcds-nav-link>
+    <gcds-nav-link href="#">Contact us</gcds-nav-link>
+  </gcds-side-nav>
+</div>
 {% endcomponentPreview %}

--- a/src/en/components/theme-and-topic-menu/base.md
+++ b/src/en/components/theme-and-topic-menu/base.md
@@ -15,6 +15,9 @@ The theme and topic menu is a navigation to the top tasks of Government of Canad
 {% enddocLinks %}
 
 {% componentPreview "Theme and topic menu component preview" "px-0 py-400" %}
+
+<div aria-hidden="true">
   <gcds-topic-menu>
   </gcds-topic-menu>
+</div>
 {% endcomponentPreview %}

--- a/src/en/components/top-navigation/base.md
+++ b/src/en/components/top-navigation/base.md
@@ -15,15 +15,18 @@ A top navigation is a horizontal list of page links.
 {% enddocLinks %}
 
 {% componentPreview "Top navigation component preview" %}
-<gcds-top-nav label="Top navigation component preview" alignment="right" lang="en">
-<gcds-nav-link href="#red" slot="home">GC Notify</gcds-nav-link>
-<gcds-nav-link href="#red">Why GC Notify</gcds-nav-link>
-<gcds-nav-group menu-label="Features submenu" open-trigger="Features">
-<gcds-nav-link href="#red" current>Create reusable templates</gcds-nav-link>
-<gcds-nav-link href="#red">Personalize messages</gcds-nav-link>
-<gcds-nav-link href="#red">Schedule messages</gcds-nav-link>
-<gcds-nav-link href="#red">Send messages automatically</gcds-nav-link>
-</gcds-nav-group>
-<gcds-nav-link href="#red">Contact us</gcds-nav-link>
-</gcds-top-nav>
+
+<div aria-hidden="true">
+  <gcds-top-nav label="Top navigation component preview" alignment="right" lang="en">
+    <gcds-nav-link href="#red" slot="home">GC Notify</gcds-nav-link>
+    <gcds-nav-link href="#red">Why GC Notify</gcds-nav-link>
+    <gcds-nav-group menu-label="Features submenu" open-trigger="Features">
+      <gcds-nav-link href="#red" current>Create reusable templates</gcds-nav-link>
+      <gcds-nav-link href="#red">Personalize messages</gcds-nav-link>
+      <gcds-nav-link href="#red">Schedule messages</gcds-nav-link>
+      <gcds-nav-link href="#red">Send messages automatically</gcds-nav-link>
+    </gcds-nav-group>
+    <gcds-nav-link href="#red">Contact us</gcds-nav-link>
+  </gcds-top-nav>
+</div>
 {% endcomponentPreview %}

--- a/src/fr/composants/barre-de-navigation-laterale/base.md
+++ b/src/fr/composants/barre-de-navigation-laterale/base.md
@@ -15,21 +15,24 @@ La barre de navigation latérale est une liste de liens de navigation située du
 {% enddocLinks %}
 
 {% componentPreview "Aperçu du composant barre de navigation latérale" "px-300 pt-400 pb-200" %}
-<gcds-side-nav label="Formulaires GC" lang="fr">
-<gcds-nav-link href="#">Pourquoi Formulaires GC</gcds-nav-link>
-<gcds-nav-group menu-label="Fonctionnalités" open-trigger="Fonctionnalités">
-<gcds-nav-group menu-label="Créez et gérez des formulaires vous-même" open-trigger="Créez et gérez des formulaires vous-même">
-<gcds-nav-link href="#">Révisez dans les deux langues officielles côte à côte</gcds-nav-link>
-<gcds-nav-link href="#">Obtenez les réponses aux formulaires en toute sécurité</gcds-nav-link>
-<gcds-nav-link href="#">Testez votre formulaire avant la publication</gcds-nav-link>
-</gcds-nav-group>
-<gcds-nav-group menu-label="Publier des formulaires fiables et conviviaux" open-trigger="Publier des formulaires fiables et conviviaux">
-<gcds-nav-link href="#">Des formulaires pouvant être remplis n’importe où</gcds-nav-link>
-<gcds-nav-link href="#">Des formulaires qui aident à gagner du temps et de l’énergie</gcds-nav-link>
-<gcds-nav-link href="#">Des formulaires ayant l’apparence du GC</gcds-nav-link>
-</gcds-nav-group>
-</gcds-nav-group>
-<gcds-nav-link href="#">Guides de référence</gcds-nav-link>
-<gcds-nav-link href="#">Nous contacter</gcds-nav-link>
-</gcds-side-nav>
+
+<div aria-hidden="true">
+  <gcds-side-nav label="Formulaires GC" lang="fr">
+    <gcds-nav-link href="#">Pourquoi Formulaires GC</gcds-nav-link>
+    <gcds-nav-group menu-label="Fonctionnalités" open-trigger="Fonctionnalités">
+      <gcds-nav-group menu-label="Créez et gérez des formulaires vous-même" open-trigger="Créez et gérez des formulaires vous-même">
+        <gcds-nav-link href="#">Révisez dans les deux langues officielles côte à côte</gcds-nav-link>
+        <gcds-nav-link href="#">Obtenez les réponses aux formulaires en toute sécurité</gcds-nav-link>
+        <gcds-nav-link href="#">Testez votre formulaire avant la publication</gcds-nav-link>
+      </gcds-nav-group>
+      <gcds-nav-group menu-label="Publier des formulaires fiables et conviviaux" open-trigger="Publier des formulaires fiables et conviviaux">
+        <gcds-nav-link href="#">Des formulaires pouvant être remplis n’importe où</gcds-nav-link>
+        <gcds-nav-link href="#">Des formulaires qui aident à gagner du temps et de l’énergie</gcds-nav-link>
+        <gcds-nav-link href="#">Des formulaires ayant l’apparence du GC</gcds-nav-link>
+      </gcds-nav-group>
+    </gcds-nav-group>
+    <gcds-nav-link href="#">Guides de référence</gcds-nav-link>
+    <gcds-nav-link href="#">Nous contacter</gcds-nav-link>
+  </gcds-side-nav>
+</div>
 {% endcomponentPreview %}

--- a/src/fr/composants/barre-de-navigation-superieure/base.md
+++ b/src/fr/composants/barre-de-navigation-superieure/base.md
@@ -16,16 +16,17 @@ Une barre de navigation supérieure est une liste horizontale de liens de page.
 
 {% componentPreview "Aperçu du composant de barre de navigation supérieure" %}
 
-<!-- CHECK LABEL -->
-<gcds-top-nav label="Aperçu du composant de barre de navigation supérieure" alignment="right" lang="fr">
-<gcds-nav-link href="#red" slot="home">Notification GC</gcds-nav-link>
-<gcds-nav-link href="#red">Pourquoi Notification GC</gcds-nav-link>
-<gcds-nav-group menu-label="Fonctionnalités"  open-trigger="Fonctionnalités">
-<gcds-nav-link href="#red" current>Créer des gabarits réutilisables</gcds-nav-link>
-<gcds-nav-link href="#red">Personnaliser les messages</gcds-nav-link>
-<gcds-nav-link href="#red">Planifier la date et l’heure d’envoi</gcds-nav-link>
-<gcds-nav-link href="#red">Envoyer des messages automatiquement</gcds-nav-link>
-</gcds-nav-group>
-<gcds-nav-link href="#red">Nous joindre</gcds-nav-link>
-</gcds-top-nav>
+<div aria-hidden="true">
+  <gcds-top-nav label="Aperçu du composant de barre de navigation supérieure" alignment="right" lang="fr">
+    <gcds-nav-link href="#red" slot="home">Notification GC</gcds-nav-link>
+    <gcds-nav-link href="#red">Pourquoi Notification GC</gcds-nav-link>
+    <gcds-nav-group menu-label="Fonctionnalités"  open-trigger="Fonctionnalités">
+      <gcds-nav-link href="#red" current>Créer des gabarits réutilisables</gcds-nav-link>
+      <gcds-nav-link href="#red">Personnaliser les messages</gcds-nav-link>
+      <gcds-nav-link href="#red">Planifier la date et l’heure d’envoi</gcds-nav-link>
+      <gcds-nav-link href="#red">Envoyer des messages automatiquement</gcds-nav-link>
+    </gcds-nav-group>
+    <gcds-nav-link href="#red">Nous joindre</gcds-nav-link>
+  </gcds-top-nav>
+</div>
 {% endcomponentPreview %}

--- a/src/fr/composants/menu-des-themes-et-sujets/base.md
+++ b/src/fr/composants/menu-des-themes-et-sujets/base.md
@@ -15,6 +15,9 @@ Le menu des thèmes et sujets est un mécanisme de navigation vers les tâches l
 {% enddocLinks %}
 
 {% componentPreview "Aperçu du composant de menu des thèmes et sujets" "px-0 py-400" %}
+
+<div aria-hidden="true">
   <gcds-topic-menu>
   </gcds-topic-menu>
+</div>
 {% endcomponentPreview %}


### PR DESCRIPTION
# Summary | Résumé

Updated top-nav label for main page navigation. Added `aria-hidden` to other menu components (`side-nav`, `top-nav`, `topic-menu`) to avoid confusing navigation landmarks for assistive technology users.