### PR TITLE
feat: add new privacy notice page

### DIFF
--- a/src/_data/footer.js
+++ b/src/_data/footer.js
@@ -1,10 +1,22 @@
 module.exports = {
   en: {
+    social: 'Social media',
+    socialurl: 'https://www.canada.ca/en/social.html',
+    mobile: 'Mobile applications',
+    mobileurl: 'https://www.canada.ca/en/mobile.html',
+    about: 'About Canada.ca',
+    abouturl: 'https://design.canada.ca/about/',
     terms: 'Terms and conditions',
     termsurl: 'https://www.canada.ca/en/transparency/terms.html',
     privacy: 'Privacy',
   },
   fr: {
+    social: 'Médias sociaux',
+    socialurl: 'https://www.canada.ca/fr/sociaux.html',
+    mobile: 'Applications mobiles',
+    mobileurl: 'https://www.canada.ca/fr/mobile.html',
+    about: 'À propos de Canada.ca',
+    abouturl: 'https://conception.canada.ca/a-propos/',
     terms: 'Avis',
     termsurl: 'https://www.canada.ca/fr/transparence/avis.html',
     privacy: 'Confidentialité',

--- a/src/_data/footer.js
+++ b/src/_data/footer.js
@@ -3,12 +3,10 @@ module.exports = {
     terms: 'Terms and conditions',
     termsurl: 'https://www.canada.ca/en/transparency/terms.html',
     privacy: 'Privacy',
-    privacyurl: 'https://www.canada.ca/en/transparency/privacy.html',
   },
   fr: {
     terms: 'Avis',
     termsurl: 'https://www.canada.ca/fr/transparence/avis.html',
     privacy: 'Confidentialité',
-    privacyurl: 'https://www.canada.ca/fr/transparence/confidentialite.html',
   },
 };

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -46,8 +46,9 @@
 
 
       <gcds-footer
+        display="full"
         lang="{{ locale }}"
-        sub-links='{ "{{ footer[locale].terms }}": "{{ footer[locale].termsurl }}", "{{ footer[locale].privacy }}": "{{ links.privacy }}" }'
+        sub-links='{ "{{ footer[locale].social }}": "{{ footer[locale].socialurl }}", "{{ footer[locale].mobile }}": "{{ footer[locale].mobileurl }}", "{{ footer[locale].about }}": "{{ footer[locale].abouturl }}", "{{ footer[locale].terms }}": "{{ footer[locale].termsurl }}", "{{ footer[locale].privacy }}": "{{ links.privacy }}" }'
       ></gcds-footer>
 
     </div>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -44,9 +44,10 @@
         </gcds-date-modified>
       </main>
 
+
       <gcds-footer
-        display="compact"
         lang="{{ locale }}"
+        sub-links='{ "{{ footer[locale].terms }}": "{{ footer[locale].termsurl }}", "{{ footer[locale].privacy }}": "{{ links.privacy }}" }'
       ></gcds-footer>
 
     </div>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -63,8 +63,8 @@
       </main>
 
       <gcds-footer
-        display="compact"
         lang="{{ locale }}"
+        sub-links='{ "{{ footer[locale].terms }}": "{{ footer[locale].termsurl }}", "{{ footer[locale].privacy }}": "{{ links.privacy }}" }'
       ></gcds-footer>
 
     </div>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -63,8 +63,9 @@
       </main>
 
       <gcds-footer
+        display="full"
         lang="{{ locale }}"
-        sub-links='{ "{{ footer[locale].terms }}": "{{ footer[locale].termsurl }}", "{{ footer[locale].privacy }}": "{{ links.privacy }}" }'
+        sub-links='{ "{{ footer[locale].social }}": "{{ footer[locale].socialurl }}", "{{ footer[locale].mobile }}": "{{ footer[locale].mobileurl }}", "{{ footer[locale].about }}": "{{ footer[locale].abouturl }}", "{{ footer[locale].terms }}": "{{ footer[locale].termsurl }}", "{{ footer[locale].privacy }}": "{{ links.privacy }}" }'
       ></gcds-footer>
 
     </div>

--- a/src/en/about-us.md
+++ b/src/en/about-us.md
@@ -1,5 +1,5 @@
 ---
-title: About GC Design System
+title: About
 translationKey: aboutus
 layout: 'layouts/base.njk'
 eleventyNavigation:
@@ -14,7 +14,7 @@ eleventyNavigation:
 
 ## Why GC Design System is right for you
 
-GC Design System offers basic building blocks and a common pattern language for frontline digital services. Components and tokens provide standard Government of Canada branding and experiences for any framework you’re using.  
+GC Design System offers basic building blocks and a common pattern language for frontline digital services. Components and tokens provide standard Government of Canada branding and experiences for any framework you’re using.
 
 Use GC Design System to meet Government of Canada requirements for digital service delivery and communication:
 
@@ -49,7 +49,7 @@ GC Design System supports a seamless service experience with:
 
 We’re a team of public servants at the Canadian Digital Service building and improving GC Design System. We’ve recently begun growing our team and increasing collaboration.
 
-Our goal is to improve the quality of people's experiences with government by scaling recognizable, predictable, and inclusive user interfaces across digital services.  
+Our goal is to improve the quality of people's experiences with government by scaling recognizable, predictable, and inclusive user interfaces across digital services.
 
 ### Collaboration and support channels
 

--- a/src/en/en.json
+++ b/src/en/en.json
@@ -50,14 +50,37 @@
 
     "about": "/en/about-us",
     "contact": "/en/contact",
+    "contactMail": "mailto:cds-snc@servicecanada.gc.ca",
 
     "comingSoon": "/en/coming-soon",
     "demo": "/en/demo",
     "releaseNotes": "https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md",
+    "privacy": "/en/privacy-notice",
 
     "figma": "https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=4%3A1006&t=qguKsJtr1ityUsUN-0",
 
     "fontAwesome": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css",
+
+    "accessToInformationAct": "https://laws-lois.justice.gc.ca/eng/acts/a-1/page-1.html",
+    "airtable": "https://www.airtable.com/",
+    "airtablePrivacy": "https://www.airtable.com/company/privacy",
+    "airtableTermsOfService": "https://www.airtable.com/company/tos",
+    "cds": "https://digital.canada.ca/",
+    "cdsPrivacy": "https://digital.canada.ca/privacy/",
+    "cdsSecurityNotice": "https://digital.canada.ca/security-notice/",
+    "directivePrivacyPractices": "https://www.tbs-sct.canada.ca/pol/doc-eng.aspx?id=18309",
+    "electronicNetworkMonitoringLogs": "https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/info-source/standard-personal-information-banks.html#psu905",
+    "esdc": "https://www.canada.ca/en/employment-social-development.html",
+    "esdcAct": "https://laws-lois.justice.gc.ca/eng/acts/h-5.7/FullText.html",
+    "freshdesk": "https://www.freshworks.com/freshdesk/",
+    "freshworks": "https://www.freshworks.com/",
+    "freshworksPrivacy": "https://www.freshworks.com/privacy/",
+    "gcPrivacy": "https://www.canada.ca/en/transparency/privacy.html",
+    "gcNotify": "https://notification.canada.ca/",
+    "gcNotifyTermsOfUse": "https://notification.canada.ca/terms",
+    "outreachActivities": "https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/info-source/standard-personal-information-banks.html#psu938",
+    "privacyAct": "https://laws-lois.justice.gc.ca/ENG/ACTS/P-21/index.html",
+    "privacyCommissionerCanada": "https://www.priv.gc.ca/en/for-individuals/",
 
     "github": "https://github.com/cds-snc/gcds-components",
     "githubDocsIssues": "https://github.com/cds-snc/gcds-docs/issues",

--- a/src/en/privacy-notice.md
+++ b/src/en/privacy-notice.md
@@ -1,0 +1,72 @@
+---
+title: Privacy notice
+translationKey: privacy
+layout: 'layouts/base.njk'
+eleventyNavigation:
+  key: privacyEN
+  title: Privacy notice
+  locale: en
+  order: 4
+  hideMain: true
+---
+
+# Privacy Notice
+
+GC Design System is built by the <gcds-link href="{{ links.cds }}" target="_blank">Canadian Digital Service</gcds-link>, part of <gcds-link href="{{ links.esdc }}" target="_blank">Employment and Social Development Canada</gcds-link>. The <gcds-link href="{{ links.gcPrivacy }}" target="_blank">Government of Canada website (Canada.ca)</gcds-link> and <gcds-link href="{{ links.cdsPrivacy }}" target="_blank">the Canadian Digital Service website</gcds-link> have their own privacy practices, which are described in the linked documents.
+
+You do not have to sign up or provide personal information to use GC Design System. However, we collect some information automatically when you visit our website and in some cases you may choose to voluntarily provide more information to us.
+
+## Information we collect automatically
+
+### IP addresses
+
+By default, we log Internet Protocol (IP) addresses to monitor our website infrastructure and security. The IP address identifies the network location of the device you use to visit this website. We do not link these logs with any other information you might voluntarily provide while using the website, such as your name or email address.
+
+​​You can read about how we handle this specific information in <gcds-link href="{{ links.electronicNetworkMonitoringLogs }}" target="_blank">Electronic Network Monitoring Logs, PSU 905</gcds-link>.
+
+### Web analytics
+
+Analytics show us how people use our web pages. By studying how people navigate, we can improve this website. We do not use analytics to collect identifying information.
+
+We use Google Analytics for information about:
+
+- Pages people visit, links they select and documents they download.
+- Types of operating systems that visit this website.
+- Browsers that visit this website and the browser's approximate location.
+- Date and time of visits.
+
+## You can voluntarily provide some information to us
+
+If you choose to subscribe to our email newsletter, share feedback through our contact form, send us an email, or attend a demo, we may collect your personal information. In some cases, we may use third-party applications to collect and process information, as indicated below.
+
+The information you provide can help us improve GC Design System. For example, we may use your contact information to invite you to provide feedback on GC Design System or participate in user research.
+
+If you use other Canadian Digital Service Platform Services, we may also share information with those services to improve your experience.
+
+### Subscribing to the GC Design System email newsletter
+
+We use <gcds-link href="{{ links.gcNotify }}" target="_blank">GC Notify</gcds-link> to send our email newsletter and <gcds-link href="{{ links.airtable }}" target="_blank">AirTable</gcds-link>, a third-party application, for information management. Sign up is voluntary and subject to <gcds-link href="{{ links.gcNotifyTermsOfUse }}" target="_blank">GC Notify Terms of Use</gcds-link> and the <gcds-link href="{{ links.airtablePrivacy }}" target="_blank">Privacy Policy</gcds-link> and <gcds-link href="{{ links.airtableTermsOfService }}" target="_blank">Terms of Service</gcds-link> for the AirTable platform.
+
+If you choose to subscribe, you provide your name, email address, and whether you currently use GC Design System. By subscribing, you agree to receive emails about GC Design System, including product updates, relevant resources, and requests for feedback.
+
+### Sharing feedback through our contact form
+
+We use <gcds-link href="{{ links.freshdesk }}" target="_blank">Freshdesk</gcds-link>, a third-party application owned by <gcds-link href="{{ links.freshworks }}" target="_blank">Freshworks</gcds-link>, to manage messages submitted through the <gcds-link href="{{ links.contact }}" target="_blank">GC Design System contact form</gcds-link>. Using our contact form is voluntary and information submitted is subject to <gcds-link href="{{ links.freshworksPrivacy }}" target="_blank">Freshwork's Privacy Notice</gcds-link>.
+
+If you choose to send a message through our contact form, you provide your name, email address, and information about your inquiry, and we will use this information to respond to your request.
+
+## We protect your privacy
+
+As part of Employment and Social Development Canada, Section 5.1 of the <gcds-link href="{{ links.esdcAct }}" target="_blank">Department of Employment and Social Development Act</gcds-link> gives us permission to collect and store this information.
+
+You can find more information about the type of information we hold about you and what we do with it <gcds-link href="{{ links.outreachActivities }}" target="_blank">Outreach Activities, PSU 938</gcds-link>.
+
+We handle your information under Part 4 of the <gcds-link href="{{ links.esdcAct }}" target="_blank">Department of Employment and Social Development Act</gcds-link>, <gcds-link href="{{ links.accessToInformationAct }}" target="_blank">Access to Information Act</gcds-link>, and <gcds-link href="{{ links.privacyAct }}" target="_blank">Privacy Act</gcds-link>. We also follow the <gcds-link href="{{ links.directivePrivacyPractices }}" target="_blank">Directive on Privacy Practices</gcds-link>.
+
+If you have security concerns about this website or other Canadian Digital Service products, please see our <gcds-link href="{{ links.cdsSecurityNotice }}" target="_blank">Security Notice</gcds-link>.
+
+## You have privacy rights
+
+The law requires that we protect your privacy. You have the right to access and review your personal information. You can <gcds-link href="{{ links.contactMail }}">contact us</gcds-link> to check or update your information.
+
+You also have the right to raise concerns about how we handle your personal information. To learn more or to make a formal complaint, contact the <gcds-link href="{{ links.privacyCommissionerCanada }}" target="_blank">Privacy Commissioner of Canada</gcds-link>.

--- a/src/fr/avis-de-confidentialite.md
+++ b/src/fr/avis-de-confidentialite.md
@@ -1,0 +1,72 @@
+---
+title: Avis de confidentialité
+translationKey: privacy
+layout: 'layouts/base.njk'
+eleventyNavigation:
+  key: privacyFR
+  title: Avis de confidentialité
+  locale: fr
+  order: 4
+  hideMain: true
+---
+
+# Avis de confidentialité
+
+Système de design GC est développé par le <gcds-link href="{{ links.cds }}" target="_blank">Service numérique canadien</gcds-link> au sein d'<gcds-link href="{{ links.esdc }}" target="_blank">Emploi et développement social Canada</gcds-link>. Le <gcds-link href="{{ links.gcPrivacy }}" target="_blank">site Web du gouvernement du Canada (Canada.ca)</gcds-link> et le <gcds-link href="{{ links.cdsPrivacy }}" target="_blank">site Web du Service numérique canadien</gcds-link> bénéficient chacun de leurs propres pratiques de protection des renseignements personnels. Celles-ci sont décrites dans les documents joints.
+
+Vous n'avez pas besoin de vous inscrire ou de fournir des renseignements personnels pour utiliser Système de design GC. Nous recueillons néanmoins certaines informations de façon automatique lorsque vous visitez notre site Web. Il se peut également que vous décidiez de nous fournir volontairement des renseignements additionnels dans certains cas.
+
+## Renseignements collectés automatiquement
+
+### Adresses IP
+
+Nous consignons automatiquement les adresses de protocole Internet (IP) afin de surveiller l'infrastructure de notre site Web et d'en assurer la sécurité. L'adresse IP identifie l'emplacement du réseau de l'appareil que vous utilisez pour naviguer sur le site Web. Nous n'établissons pas de liens entre ces journaux de réseau et les autres informations que vous avez pu volontairement fournir, comme votre nom ou votre adresse courriel, lorsque vous avez navigué sur le site Web.
+
+Vous pouvez vous renseigner sur la façon dont nous gérons ce type précis de renseignements dans <gcds-link href="{{ links.electronicNetworkMonitoringLogs }}" target="_blank">Journaux de contrôle des réseaux électroniques, POU 905</gcds-link>.
+
+### Analytique Web
+
+L'analytique Web révèle comment les gens utilisent nos pages Web. L'étude de ce comportement nous permet d'améliorer le site Web. Nous n'utilisons pas l'analytique Web pour collecter des renseignements permettant de vous identifier.
+
+Nous utilisons Google Analytics pour obtenir les informations suivantes :
+
+- Les pages visitées, les liens utilisés et les documents téléchargés.
+- Les systèmes d'exploitation utilisés pour accéder à ce site Web.
+- Les navigateurs Web utilisés pour visiter ce site Web et la localisation approximative du navigateur.
+- La date et l'heure des visites.
+
+## Vous pouvez nous fournir des renseignements sur une base volontaire
+
+Si vous décidez de vous abonner à notre infolettre, de nous faire part de commentaires au moyen de notre formulaire de contact, de nous envoyer un courriel ou de participer à une démo, nous pouvons recueillir vos renseignements personnels. Dans certains cas, nous pouvons utiliser des applications tierces pour recueillir et traiter des renseignements, comme nous l'indiquons plus loin.
+
+Les informations que vous nous transmettez peuvent nous aider à améliorer Système de design GC. Nous pouvons par exemple utiliser vos coordonnées pour vous inviter à donner votre avis sur Système de design GC ou à participer à une activité de recherche utilisateur.
+
+Si vous utilisez d'autres services de plateforme du Service numérique canadien, il est possible que nous leur communiquions certains de ces renseignements pour améliorer votre expérience.
+
+### Abonnement à l'infolettre de Système de design GC
+
+Nous utilisons <gcds-link href="{{ links.gcNotify }}" target="_blank">Notification GC</gcds-link> pour envoyer notre infolettre, et nous utilisons <gcds-link href="{{ links.airtable }}" target="_blank">AirTable</gcds-link>, une application tierce, pour assurer la gestion des renseignements. L'abonnement à l'infolettre se fait sur une base volontaire et est soumis aux <gcds-link href="{{ links.gcNotifyTermsOfUse }}" target="_blank">conditions d'utilisation de Notification GC</gcds-link> ainsi qu'à la <gcds-link href="{{ links.airtablePrivacy }}" target="_blank">Politique de confidentialité</gcds-link> et aux <gcds-link href="{{ links.airtableTermsOfService }}" target="_blank">conditions d'utilisation</gcds-link> de la plateforme AirTable.
+
+Si vous choisissez de vous abonner, vous fournirez votre nom et votre adresse courriel, et vous indiquerez si vous utilisez actuellement Système de design GC. En choisissant de vous abonner, vous consentez à recevoir des courriels au sujet de Système de design GC, y compris des mises à jour de produit, des ressources pertinentes et des sollicitations de commentaires.
+
+### Commentaires envoyés au moyen du formulaire de contact
+
+Nous utilisons <gcds-link href="{{ links.freshdesk }}" target="_blank">Freshdesk</gcds-link>, une application tierce détenue par <gcds-link href="{{ links.freshworks }}" target="_blank">Freshworks</gcds-link>, pour assurer la gestion des messages envoyés au moyen du <gcds-link href="{{ links.contact }}" target="_blank">formulaire de contact de Système de design GC</gcds-link>. L'usage de notre formulaire de contact est volontaire, et les informations envoyées sont soumises à la <gcds-link href="{{ links.freshworksPrivacy }}" target="_blank">Politique de confidentialité de Freshwork</gcds-link>.
+
+Si vous choisissez d'envoyer un message au moyen de notre formulaire de contact, vous fournirez votre nom, votre adresse courriel et des renseignements propres à votre demande. Nous utiliserons ces renseignements pour répondre à votre demande.
+
+## Nous veillons à votre confidentialité
+
+Nous faisons partie d'Emploi et développement social Canada, ce qui nous autorise à recueillir et à conserver des renseignements personnels en vertu de l'article 5.1 de la <gcds-link href="{{ links.esdcAct }}" target="_blank">Loi sur le ministère de l'Emploi et du Développement social</gcds-link>.
+
+Vous pouvez trouver de plus amples informations sur le type de renseignements que nous recueillons sur vous et l'usage que nous en faisons dans <gcds-link href="{{ links.outreachActivities }}" target="_blank">Activités de sensibilisation — POU 938</gcds-link>.
+
+Nous traitons vos renseignements conformément à la partie 4 de la <gcds-link href="{{ links.esdcAct }}" target="_blank">Loi sur le ministère de l'Emploi et du Développement social</gcds-link>, à la <gcds-link href="{{ links.accessToInformationAct }}" target="_blank">Loi sur l'accès à l'information</gcds-link>, et à la <gcds-link href="{{ links.privacyAct }}" target="_blank">Loi sur la protection des renseignements personnels</gcds-link>. Nous nous conformons également aux exigences de la <gcds-link href="{{ links.directivePrivacyPractices }}" target="_blank">Directive sur les pratiques relatives à la protection de la vie privée</gcds-link>.
+
+En cas de préoccupation liée à la sécurité de ce site Web ou de tout autre produit du Service numérique canadien, veuillez consulter notre <gcds-link href="{{ links.cdsSecurityNotice }}" target="_blank">Avis de sécurité</gcds-link>.
+
+## Votre droit à la vie privée
+
+En vertu de la Loi, nous devons protéger votre vie privée. Vous avez le droit d'accéder à vos renseignements personnels et de les examiner. Vous pouvez <gcds-link href="{{ links.contactMail }}">nous contacter</gcds-link> pour vérifier ou mettre à jour vos renseignements.
+
+Vous avez également le droit de soulever des questions sur la façon dont nous traitons vos renseignements personnels. Pour en savoir plus ou pour déposer une plainte officielle, contactez le <gcds-link href="{{ links.privacyCommissionerCanada }}" target="_blank">Commissaire à la protection de la vie privée du Canada</gcds-link>.

--- a/src/fr/fr.json
+++ b/src/fr/fr.json
@@ -50,14 +50,37 @@
 
     "about": "/fr/a-propos",
     "contact": "/fr/contactez",
+    "contactMail": "mailto:cds-snc@servicecanada.gc.ca",
 
     "comingSoon": "/fr/developpement-en-cours",
     "demo": "/fr/demo",
     "releaseNotes": "https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md",
+    "privacy": "/fr/avis-de-confidentialite/",
 
     "figma": "https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=4%3A1006&t=qguKsJtr1ityUsUN-0",
 
     "fontAwesome": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css",
+
+    "accessToInformationAct": "https://laws-lois.justice.gc.ca/fra/lois/a-1/page-1.html",
+    "airtable": "https://www.airtable.com/",
+    "airtablePrivacy": "https://www.airtable.com/company/privacy/fr",
+    "airtableTermsOfService": "https://www.airtable.com/company/tos/fr",
+    "cds": "https://numerique.canada.ca/",
+    "cdsPrivacy": "https://numerique.canada.ca/confidentialite/",
+    "cdsSecurityNotice": "https://numerique.canada.ca/avis-de-securite/",
+    "directivePrivacyPractices": "https://www.tbs-sct.canada.ca/pol/doc-fra.aspx?id=18309",
+    "electronicNetworkMonitoringLogs": "https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/info-source/fichiers-renseignements-personnels-ordinaires.html#pou905",
+    "esdc": "https://www.canada.ca/fr/emploi-developpement-social.html",
+    "esdcAct": "https://laws-lois.justice.gc.ca/fra/lois/h-5.7/TexteComplet.html",
+    "freshdesk": "https://www.freshworks.com/freshdesk/",
+    "freshworks": "https://www.freshworks.com/",
+    "freshworksPrivacy": "https://www.freshworks.com/privacy/",
+    "gcPrivacy": "https://www.canada.ca/fr/transparence/confidentialite.html",
+    "gcNotify": "https://notification.canada.ca/accueil",
+    "gcNotifyTermsOfUse": "https://notification.canada.ca/conditions-dutilisation",
+    "outreachActivities": "https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/info-source/fichiers-renseignements-personnels-ordinaires.html#pou938",
+    "privacyAct": "https://laws-lois.justice.gc.ca/fra/lois/p-21/index.html",
+    "privacyCommissionerCanada": "https://www.priv.gc.ca/fr/pour-les-individus/",
 
     "github": "https://github.com/cds-snc/gcds-components",
     "githubDocsIssues": "https://github.com/cds-snc/gcds-docs/issues",


### PR DESCRIPTION
# Summary | Résumé

Create a privacy notice page for the GCDS website and use this opportunity to include the main band of the footer to be more aligned with Canada.ca guidance (Sam's recommendation for this is in the Zenhub ticket).

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/786)

[English content](https://docs.google.com/document/d/1dMlZNWSvmip-46DWnn58BrTpk1hiYOFC2RtJ0-eZ0LU/edit#heading=h.ol1g61vav7xc)

[French content](https://docs.google.com/document/d/152Z_H683zjFaLg1D7bbUsfr49fY_g1Z_BCr9Lmrzev0/edit)