### PR TITLE
feat: add global background tokens (en)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "devDependencies": {
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
     "@cdssnc/gcds-components": "^0.19.1",
-    "@cdssnc/gcds-tokens": "^1.13.0",
-    "@cdssnc/gcds-utility": "^1.0.7",
+    "@cdssnc/gcds-tokens": "^1.13.2",
+    "@cdssnc/gcds-utility": "^1.1.0",
     "@quasibit/eleventy-plugin-sitemap": "^2.1.4",
     "chroma-js": "^2.4.2",
     "eleventy-plugin-svg-contents": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
     "@cdssnc/gcds-components": "^0.19.1",
-    "@cdssnc/gcds-tokens": "^1.11.1",
+    "@cdssnc/gcds-tokens": "^1.13.0",
     "@cdssnc/gcds-utility": "^1.0.7",
     "@quasibit/eleventy-plugin-sitemap": "^2.1.4",
     "chroma-js": "^2.4.2",

--- a/src/en/styles/colour/colour.md
+++ b/src/en/styles/colour/colour.md
@@ -21,12 +21,16 @@ tokenTable:
     value: Hex
     use-case: Purpose
   useCases:
-    text-primary: Main text colour on a white or 100 shade background (like --gcds-color-blue-100).
-    text-secondary: Contrast text colour (alternative to primary) on a white background.
-    text-light: Main light text colour on a 700 shade or darker background (like --gcds-color-blue-700).
+    text-light: Main light text colour. Use on a background shade of 700 or darker (like --gcds-bg-dark).
+    text-primary: Main text colour. Use on a background shade of 50 or lighter (like --gcds-bg-white).
+    text-secondary: Contrast text colour (alternative to primary). Use on a background shade of 50 or lighter (like --gcds-bg-white).
     link-default: Default link colour for links on a white background.
     link-hover: Hover link colour for links on a white background.
     link-light: Main light link colour for links on 700 shade or darker background (like --gcds-color-blue-700).
+    bg-dark: Main dark background colour. Use with a text shade of 100 or lighter (like --gcds-text-light).
+    bg-light: Light background colour (alternative to white). Use with a text shade of 700 or darker (like --gcds-text-primary).
+    bg-primary: Highlight background colour. Use with a text shade of 100 or lighter (like --gcds-text-light).
+    bg-white: Main background colour. Use with a text shade of 700 or darker (like --gcds-text-primary).
     border-default: Default border colour for borders and icons on a white background.
     danger-background: Danger background colour for background emphasis on a destructive action or critical feedback.
     danger-border: Danger border colour for borders on white or danger backgrounds for emphasis on a destructive action or critical feedback.
@@ -74,6 +78,10 @@ Use global state tokens:
 ### Link
 
 {% include "partials/token_table.njk", token: 'link', type: 'color' %}
+
+### Background
+
+{% include "partials/token_table.njk", token: 'bg', type: 'color' %}
 
 ### Border
 

--- a/src/fr/styles/couleur/couleur.md
+++ b/src/fr/styles/couleur/couleur.md
@@ -21,12 +21,16 @@ tokenTable:
     value: Valeur hex
     use-case: Utilisation
   useCases:
-    text-primary: Couleur de texte principal pour les arrière-plans blancs ou à valeur 100 (p. ex. --gcds-color-blue-100).
-    text-secondary: Couleur de texte contrastante (par rapport à la couleur du texte principal) sur un arrière-plan blanc.
-    text-light: Couleur de texte pâle principal pour les arrière-plans à valeur 700 ou plus sombres (p. ex. --gcds-color-blue-700).
+    text-light: Couleur claire principale du texte. À utiliser sur un arrière-plan de nuance 700 ou plus foncé (comme --gcds-bg-dark).
+    text-primary: Couleur principale du texte. À utiliser sur un arrière-plan de nuance 50 ou plus clair (comme --gcds-bg-white).
+    text-secondary: Couleur de texte contrastante (alternative à --gcds-text-primary). À utiliser sur un arrière-plan de nuance 50 ou plus clair (comme --gcds-bg-white).
     link-default: Couleur de lien par défaut pour les hyperliens sur un arrière-plan blanc.
     link-hover: Couleur de lien pointé pour les hyperliens sur un arrière-plan blanc.
     link-light: Couleur d'hyperlien pâle par défaut pour les arrière-plans à valeur 700 ou plus sombres (p. ex. --gcds-color-blue-700).
+    bg-dark: Couleur foncée principale de l'arrière-plan. À utiliser avec du texte de nuance 100 ou plus clair (comme --gcds-text-light).
+    bg-light: Couleur claire d'arrière plan (alternative à --gcds-bg-white). À utiliser avec du texte de nuance 700 ou plus foncé (comme --gcds-text-primary).
+    bg-primary: Couleur de surbrillance de l'arrière-plan. À utiliser avec du texte de nuance 100 ou plus clair (comme --gcds-text-light).
+    bg-white: Couleur principale de l'arrière-plan. À utiliser avec du texte de nuance 700 ou plus foncé (comme --gcds-text-primary).
     border-default: Couleur par défaut pour les bordures et les icônes sur un arrière-plan blanc.
     danger-background: La couleur de l'arrière-plan de danger pour accentuer une action destructrice ou un retour d'expérience critique en arrière-plan.
     danger-border: La couleur de la bordure de danger sur blanc ou sur arrière-plans de danger pour accentuer une action destructrice ou un retour d'expérience critique.
@@ -74,6 +78,10 @@ Utilisez les unités de style d'état global pour :
 ### Lien
 
 {% include "partials/token_table.njk", token: 'link', type: 'color' %}
+
+### Arrière-plan
+
+{% include "partials/token_table.njk", token: 'bg', type: 'color' %}
 
 ### Bordure
 


### PR DESCRIPTION
# Summary | Résumé

Add new global background tokens to our documentation site to help inform users about our main brand colour.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/731)

Note: currently waiting on translation.

