### PR TITLE
Update a-propos-FRENCH.md

### DIFF
--- a/src/fr/a-propos.md
+++ b/src/fr/a-propos.md
@@ -18,7 +18,7 @@ Nous accordons la priorité aux composants et aux configurations utiles à la pl
 
 Le [Service numérique canadien](https://numerique.canada.ca/) crée et entretient Système de design GC avec l’aide de l’équipe du système de conception de Canada.ca. 
 
-### Notre collaboration avec le système de conception de Canada.ca
+## Notre collaboration avec le système de conception de Canada.ca
 
 Système de design GC intègre les éléments obligatoires de Canada.ca. Nous collaborons avec le Bureau de la transformation numérique (BTN) au sein du Service numérique canadien afin d’évaluer le système de design et d’ajouter des éléments à notre feuille de route. Le BTN continue à offrir ses conseils et son soutien aux praticiens et praticiennes du Web et du numérique au sein du GC.
 
@@ -32,7 +32,7 @@ Système de design GC vous aide à livrer plus rapidement vos produits dans l’
 
 ### Des expériences reconnaissables : des sites Web du GC faciles à reconnaître et inspirant confiance
 
-Nos composants et styles Web vous offrent : 
+Nos <gcds-link href="{{ links.components }}">composants</gcds-link> et <gcds-link href="{{ links.styles }}">styles</gcds-link> Web vous offrent :
 
 - Un respect par défaut des normes fédérales et des bonnes pratiques d’utilisabilité;
 - Un même résultat final, peu importe l’infrastructure ou l’environnement que vous utilisez;

--- a/src/fr/a-propos.md
+++ b/src/fr/a-propos.md
@@ -12,48 +12,43 @@ eleventyNavigation:
 
 # À propos de Système de design GC
 
-## Pourquoi Système de design GC est la solution pour vous
+Système de design GC offre des blocs de construction de base ainsi qu’un langage de configuration vous permettant de concevoir et de créer une expérience uniforme en laquelle les personnes vouées à utiliser vos services pourront avoir confiance. Les composants et les unités de style fournissent une image de marque et des expériences standard du gouvernement du Canada, peu importe votre infrastructure de développement. 
 
-Système de design GC offre des blocs de base et un format de modèle commun pour les services numériques de première ligne. Les composants et les unités de style fournissent une image de marque et des expériences standards du gouvernement du Canada, peu importe votre infrastructure de développement.  
+Nous accordons la priorité aux composants et aux configurations utiles à la plupart des équipes du GC. ​​Nous testons actuellement la version alpha de Système de design GC, ce qui correspond à la première version utilisable d’un produit. Utilisez le système de design pour entamer la création d’un site Web ou d’une application et aidez-nous à l’améliorer pour les fonctionnaires.
 
-Faites appel à Système de design GC pour répondre aux exigences du gouvernement du Canada en matière de prestation de services et de communication numérique :
+Le [Service numérique canadien](https://numerique.canada.ca/) crée et entretient Système de design GC avec l’aide de l’équipe du système de conception de Canada.ca. 
 
-- Mettez en œuvre des produits reconnaissables, prévisibles et accessibles.
-- Créez et concevez une expérience fiable et unifiée pour les personnes qui utilisent vos services.
+### Notre collaboration avec le système de conception de Canada.ca
 
-### Simplifiez votre prestation numérique
+Système de design GC intègre les éléments obligatoires de Canada.ca. Nous collaborons avec le Bureau de la transformation numérique (BTN) au sein du Service numérique canadien afin d’évaluer le système de design et d’ajouter des éléments à notre feuille de route. Le BTN continue à offrir ses conseils et son soutien aux praticiens et praticiennes du Web et du numérique au sein du GC.
 
-Le Service numérique canadien est là pour appuyer la prestation de services modernes. Système de design GC vous aide à produire plus rapidement en :
+## Des résultats plus rapides avec Système de design GC
 
-- <strong>Réduisant le travail manuel et répétitif </strong> grâce à des <gcds-link href="{{ links.components }}">composants</gcds-link> et des <gcds-link href="{{ links.styles }}">styles réutilisables</gcds-link>, ainsi qu’à des ressources Figma pour le prototypage rapide.
-- <strong>Veillant par défaut à la conformité aux normes fédérales</strong> et aux meilleures pratiques en matière d’accessibilité.
-- <strong>Unissant le code, la conception et les conseils</strong>, afin que vous disposiez de toutes les bases pour créer des expériences utilisables et inclusives.
+Système de design GC vous aide à livrer plus rapidement vos produits dans l’infrastructure de votre choix. Cet outil vous permet de réduire le volume de tâches manuelles et répétitives et de répondre aux exigences du gouvernement du Canada en matière de prestation de services numérique, d’accessibilité et de communication. Utilisez Système de design GC pour offrir des expériences :
 
-### Travaillez dans l’infrastructure qui vous convient.
+- Reconnaissables;
+- Prévisibles;
+- Accessibles.
 
-Nos composants et nos styles vous offrent :
+### Des expériences reconnaissables : des sites Web du GC faciles à reconnaître et inspirant confiance
 
-- <strong>Un même résultat</strong>, peu importe l’infrastructure ou l’environnement que vous utilisez.
-- <strong>Des efforts minimaux de codage</strong> et de redéfinition des valeurs : les unités de style pour l’espacement, la typographie et les couleurs réduisent les mises à jour manuelles.
-- <strong>Un point de départ accessible</strong> : Nous avons intégré l’accessibilité dès le départ et offrons des conseils pour toutes vos décisions de mise en œuvre.
+Nos composants et styles Web vous offrent : 
 
-### Aidez à créer des expériences de service du GC uniformes
+- Un respect par défaut des normes fédérales et des bonnes pratiques d’utilisabilité;
+- Un même résultat final, peu importe l’infrastructure ou l’environnement que vous utilisez;
+- Des options réutilisables qui éliminent des tâches de codage et de redéfinition des valeurs; les unités de style réduisent les mises à jour manuelles.
 
-Système de design GC soutient une expérience de service uniforme grâce aux éléments suivants :
+### Des expériences prévisibles : des interactions conçues pour favoriser la réussite des tâches
 
-- <strong>Des éléments d’interaction prévisibles</strong> conçus pour favoriser la réussite des tâches.
-- <strong>Une conception inclusive</strong> pour une prestation de services numériques bilingue et équitable.
-- <strong>Des conseils d’accessibilité</strong> sur les plans cognitif et physique, notamment sur le codage, la clarification des demandes et la communication des erreurs.
+Nous avons combiné code, conception et conseils pour vous fournir : 
 
-## L’équipe du SNC qui élabore Système de design GC
+- Tous les éléments de base pour créer l’expérience de service numérique bilingue et équitable à laquelle les Canadiens et Canadiennes s’attendent; 
+- La flexibilité d’ajuster les composants pour répondre aux besoins d’utilisabilité propres à votre situation;
+- Des ressources Figma permettant de créer rapidement des prototypes haute fidélité pour un passage fluide à la phase de production. 
 
-Nous sommes une équipe de fonctionnaires du Service numérique canadien qui travaille à améliorer Système de design GC. Nous avons récemment commencé à agrandir notre équipe et à renforcer nos efforts de collaboration.
+### Des expériences accessibles : l’accessibilité comme priorité
 
-Nous avons pour mission d’améliorer la qualité de l’expérience qu’ont les gens avec le gouvernement en mettant à l’échelle des interfaces utilisateur reconnaissables, prévisibles et inclusives dans les services numériques.
+- Des éléments de conception et de code intégrant l’accessibilité dès le départ;
+- Des conseils sur les plans cognitif et physique, notamment sur le codage, la clarification des demandes et la communication des erreurs;
+- Des tests et audits continus en matière d’accessibilité auprès de personnes utilisant des technologies d’assistance ainsi que des tests automatisés. 
 
-### Canaux de collaboration et de soutien
-
-- Soumettez un problème (issue) dans GitHub pour obtenir <gcds-link href="{{ links.githubTokensIssues }}">des unités de style</gcds-link>, <gcds-link href="{{ links.githubIssues }}">des composants</gcds-link>, ou <gcds-link href="{{ links.githubDocsIssues }}">de la documentation</gcds-link>.
-- Utilisez notre <gcds-link href="{{ links.contact }}">formulaire Contactez-nous</gcds-link> pour vous inscrire à des tests d’utilisabilité et d’accessibilité, demander une démonstration ou nous rencontrer.
-
-Vous avez des questions? Avez-vous un changement ou une nouvelle fonctionnalité à nous suggérer? Faites-nous part de vos commentaires pour nous aider à améliorer Système de design GC.


### PR DESCRIPTION
Update About Us content in French

# Summary | Résumé

Work related to Zenhub card #708 - Revise About Us Section.  Based on new [About Us-FR](https://docs.google.com/document/d/10PakWVc0alWUA0HXTmPeyaMpbf8yr7beYtgvlVeNUro/edit?usp=sharing) content

Left off the "Canaux de collaboration et de soutien" section until we revise the "Get involved" and Contact Us pages. 

