### PR TITLE
feat: add french figma links

### DIFF
--- a/src/en/components/breadcrumbs/base.md
+++ b/src/en/components/breadcrumbs/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-breadcrumbs
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=2353%3A7848&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=2353-7841&mode=design&t=TM0vYuC6hpDwd6Un-0
 permalink: false
 tags: ['breadcrumbsEN', 'header']
 ---

--- a/src/en/components/checkbox/base.md
+++ b/src/en/components/checkbox/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-checkbox
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=2760%3A8318&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=462-320&mode=design&t=cnzP5UArhqfb5Bks-0
 permalink: false
 tags: ['checkboxEN', 'header']
 ---

--- a/src/en/components/error-message/base.md
+++ b/src/en/components/error-message/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-error-message
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=479%3A317&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=1649-4784&mode=design&t=yuubqbZ20OPdSpzG-0
 permalink: false
 tags: ['errormessageEN', 'header']
 ---

--- a/src/en/components/error-summary/base.md
+++ b/src/en/components/error-summary/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-error-summary
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=953%3A2237&t=CNFu5vZBMMrGho6u-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=1579-4801&mode=design&t=nZvCaWxei92XepSm-0
 permalink: false
 tags: ['errorsummaryEN', 'header']
 ---

--- a/src/en/components/file-uploader/base.md
+++ b/src/en/components/file-uploader/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-file-uploader
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=963%3A2472&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=963-2452&mode=design&t=fxDZJkieTzAabZFV-0
 permalink: false
 tags: ['fileuploaderEN', 'header']
 ---

--- a/src/en/components/header/base.md
+++ b/src/en/components/header/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-header
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=2928%3A13680&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=2043-5684&mode=design&t=Lvks9nlgmvkIeHOc-0
 permalink: false
 tags: ['headerEN', 'header']
 ---

--- a/src/en/components/input/base.md
+++ b/src/en/components/input/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-input
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=855%3A2811&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=2-598&mode=design&t=2my46MmKTAF9hApN-0
 permalink: false
 tags: ['inputEN', 'header']
 ---

--- a/src/en/components/language-toggle/base.md
+++ b/src/en/components/language-toggle/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-lang-toggle
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=1792%3A4992&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=1780-5094&mode=design&t=2my46MmKTAF9hApN-0
 permalink: false
 tags: ['langtoggleEN', 'header']
 ---

--- a/src/en/components/radio/base.md
+++ b/src/en/components/radio/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-radio
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=818%3A3759&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=462-110&mode=design&t=juCIOMIg2VKfCrQA-0
 permalink: false
 tags: ['radioEN', 'header']
 ---

--- a/src/en/components/select/base.md
+++ b/src/en/components/select/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-select
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=856%3A2826&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=751-1131&mode=design&t=YfKyxtnIsaUPj6F3-0
 permalink: false
 tags: ['selectEN', 'header']
 ---

--- a/src/en/components/signature/base.md
+++ b/src/en/components/signature/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-signature
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=2319%3A8211&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=1862-5581&mode=design&t=jycz1FchiyRCsxpt-0
 permalink: false
 tags: ['signatureEN', 'header']
 ---

--- a/src/en/components/textarea/base.md
+++ b/src/en/components/textarea/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-textarea
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=856%3A2774&t=CNFu5vZBMMrGho6u-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=3-599&mode=design&t=2my46MmKTAF9hApN-0
 permalink: false
 tags: ['textareaEN', 'header']
 ---

--- a/src/en/components/theme-and-topic-menu/base.md
+++ b/src/en/components/theme-and-topic-menu/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-topic-menu
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=8424-2028&mode=design&t=hrO7Ny2trtHm84aD-0
+figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=7696-5049&mode=design&t=2my46MmKTAF9hApN-0
 permalink: false
 tags: ['themeand-topic-menuEN', 'header']
 ---

--- a/src/fr/composants/Case-a-cocher/base.md
+++ b/src/fr/composants/Case-a-cocher/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-checkbox
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=2760%3A8318&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=348-4547&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['checkboxFR', 'header']
 ---

--- a/src/fr/composants/Chemin-de-navigation/base.md
+++ b/src/fr/composants/Chemin-de-navigation/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-breadcrumbs
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=2353%3A7848&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=48-2119&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['breadcrumbsFR', 'header']
 ---

--- a/src/fr/composants/barre-de-navigation-laterale/base.md
+++ b/src/fr/composants/barre-de-navigation-laterale/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-side-nav
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=5633-11428&mode=design&t=4ltBpy3FPMc9pXcL-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-1347&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['sidenavigationFR', 'header']
 ---

--- a/src/fr/composants/barre-de-navigation-superieure/base.md
+++ b/src/fr/composants/barre-de-navigation-superieure/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-top-nav
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=4738-10759&mode=design&t=PaKRkbpFLPNx99bv-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-1348&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['topnavigationFR', 'header']
 ---

--- a/src/fr/composants/bascule-de-langue/base.md
+++ b/src/fr/composants/bascule-de-langue/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-lang-toggle
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=1792%3A4992&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=48-10341&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['langtoggleFR', 'header']
 ---

--- a/src/fr/composants/boite/base.md
+++ b/src/fr/composants/boite/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-container
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=6660-15761&mode=design&t=yAHkop3p7GgECtHy-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-2006&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['containerFR', 'header']
 ---

--- a/src/fr/composants/bouton-radio/base.md
+++ b/src/fr/composants/bouton-radio/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-radio
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=818%3A3759&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=348-5024&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['radioFR', 'header']
 ---

--- a/src/fr/composants/bouton/base.md
+++ b/src/fr/composants/bouton/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-button
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=817-4607&mode=design&t=qwNFRgCKhnoUtRXO-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=8-2054&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['buttonFR', 'header']
 ---

--- a/src/fr/composants/carte/base.md
+++ b/src/fr/composants/carte/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-card
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=5757-12701&mode=design&t=qwNFRgCKhnoUtRXO-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=48-3396&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['cardFR', 'header']
 ---

--- a/src/fr/composants/champ-de-saisie/base.md
+++ b/src/fr/composants/champ-de-saisie/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-input
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=855%3A2811&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-2007&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['inputFR', 'header']
 ---

--- a/src/fr/composants/date-de-modification/base.md
+++ b/src/fr/composants/date-de-modification/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-date-modified
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=3471-9955&mode=design&t=4uA1VfR0YnyStZyZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=48-6634&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['datemodifiedFR', 'header']
 ---

--- a/src/fr/composants/details/base.md
+++ b/src/fr/composants/details/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-details
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=1097-2733&mode=design&t=qwNFRgCKhnoUtRXO-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=8-4626&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['detailsFR', 'header']
 ---

--- a/src/fr/composants/en-tete/base.md
+++ b/src/fr/composants/en-tete/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-header
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=2928%3A13680&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-2305&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['headerFR', 'header']
 ---

--- a/src/fr/composants/grille/base.md
+++ b/src/fr/composants/grille/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-grid
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=13172-65&mode=design&t=qwNFRgCKhnoUtRXO-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=48-9883&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['gridFR', 'header']
 ---

--- a/src/fr/composants/indicateur-detape/base.md
+++ b/src/fr/composants/indicateur-detape/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-stepper
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=970-2581&mode=design&t=qwNFRgCKhnoUtRXO-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-2656&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['stepperFR', 'header']
 ---

--- a/src/fr/composants/jeu-de-champs/base.md
+++ b/src/fr/composants/jeu-de-champs/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-fieldset
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=2328-7660&mode=design&t=qwNFRgCKhnoUtRXO-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-2817&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['fieldsetFR', 'header']
 ---

--- a/src/fr/composants/lien/base.md
+++ b/src/fr/composants/lien/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-link
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=2646-8407&mode=design&t=Fc8G98RMn9FnseDi-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=8-5038&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['linkFR', 'header']
 ---

--- a/src/fr/composants/menu-des-themes-et-sujets/base.md
+++ b/src/fr/composants/menu-des-themes-et-sujets/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-topic-menu
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=8424-2028&mode=design&t=hrO7Ny2trtHm84aD-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-2818&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['themeand-topic-menuFR', 'header']
 ---

--- a/src/fr/composants/message-derreur/base.md
+++ b/src/fr/composants/message-derreur/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-error-message
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=479%3A317&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=48-7032&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['errormessageFR', 'header']
 ---

--- a/src/fr/composants/pagination/base.md
+++ b/src/fr/composants/pagination/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-pagination
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=1431-4617&mode=design&t=Z9AVq2wKmGmXJc7j-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-2995&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['paginationFR', 'header']
 ---

--- a/src/fr/composants/pied-de-page/base.md
+++ b/src/fr/composants/pied-de-page/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-footer
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=1802-4983&mode=design&t=qlhQWm8dGLGWTIi1-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-2996&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['footerFR', 'header']
 ---

--- a/src/fr/composants/recherche/base.md
+++ b/src/fr/composants/recherche/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-search
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=7301-1409&mode=design&t=yMaP24b3Wfu5x6t5-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-2997&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['searchFR', 'header']
 ---

--- a/src/fr/composants/resume-de-erreurs/base.md
+++ b/src/fr/composants/resume-de-erreurs/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-error-summary
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=953%3A2237&t=CNFu5vZBMMrGho6u-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=48-9037&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['errorsummaryFR', 'header']
 ---

--- a/src/fr/composants/selection/base.md
+++ b/src/fr/composants/selection/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-select
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=856%3A2826&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-3340&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['selectFR', 'header']
 ---

--- a/src/fr/composants/signature/base.md
+++ b/src/fr/composants/signature/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-signature
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=2319%3A8211&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-3339&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['signatureFR', 'header']
 ---

--- a/src/fr/composants/televerseur-de-fichiers/base.md
+++ b/src/fr/composants/televerseur-de-fichiers/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-file-uploader
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=963%3A2472&t=ciEmm7GYyGAY73zZ-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=116-2&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['fileuploaderFR', 'header']
 ---

--- a/src/fr/composants/texte/base.md
+++ b/src/fr/composants/texte/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-text
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=10053-348&mode=design&t=E0XGUkSN8iUhsIDS-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-3353&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['textFR', 'header']
 ---

--- a/src/fr/composants/titre/base.md
+++ b/src/fr/composants/titre/base.md
@@ -1,6 +1,6 @@
 ---
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-heading
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?type=design&node-id=9439-44&mode=design&t=E0XGUkSN8iUhsIDS-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-3354&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['headingFR', 'header']
 ---

--- a/src/fr/composants/zone-de-texte/base.md
+++ b/src/fr/composants/zone-de-texte/base.md
@@ -1,7 +1,7 @@
 ---
 layout: 'layouts/base.njk'
 github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/components/gcds-textarea
-figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=856%3A2774&t=CNFu5vZBMMrGho6u-0
+figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=114-3355&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['textareaFR', 'header']
 ---

--- a/src/fr/fr.json
+++ b/src/fr/fr.json
@@ -57,7 +57,7 @@
     "releaseNotes": "https://github.com/cds-snc/gcds-components/blob/main/CHANGELOG.md",
     "privacy": "/fr/avis-de-confidentialite/",
 
-    "figma": "https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/Canadian-Digital-Service%E2%80%A8---GC-Design-System?node-id=4%3A1006&t=qguKsJtr1ityUsUN-0",
+    "figma": "https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=226-31997&mode=design&t=MNtR7hfKusf7RKxF-0",
 
     "fontAwesome": "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css",
 


### PR DESCRIPTION
# Summary | Résumé

Point Figma links on FR pages to FR library. I also caught a few EN links that were broken or didn't link to the correct place.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/897)