### PR TITLE
refactor: improve error summary alt text

### DIFF
--- a/src/en/components/error-summary/design.md
+++ b/src/en/components/error-summary/design.md
@@ -13,7 +13,7 @@ tags: ['errorsummaryEN', 'design']
   <li>The <strong>error summary item</strong> links to the error context and includes the same text as the error message (a call to action statement to address the error).</li>
 </ol>
 
-<img class="b-sm b-default p-400" src="/images/en/components/anatomy/gcds-error-summary-anatomy.svg" alt="Button anatomy showing the Button label branching to the container and arrow icon." />
+<img class="b-sm b-default p-400" src="/images/en/components/anatomy/gcds-error-summary-anatomy.svg" alt="A red rectangle frames a prominent heading that reads 'There's a problem' and a numbered list of 3 links with error summary items in the link text." />
 
 ## Design and accessibility for error summaries
 

--- a/src/en/components/error-summary/use-case.md
+++ b/src/en/components/error-summary/use-case.md
@@ -9,7 +9,7 @@ eleventyNavigation:
   otherNames: error overview.
   description: A list of user errors on a page or in a flow.
   thumbnail: /images/common/components/preview-error-summary.svg
-  alt: A red outlined box holds one thick grey line above a stack of  three smaller thick red lines representing a heading and text.
+  alt: A red rectangle frames a prominent heading that reads "There's a problem" and a numbered list of 3 links with error summary items in the link text.
   state: published
 translationKey: 'errorsummary'
 tags: ['errorsummaryEN', 'usage']

--- a/src/en/components/error-summary/use-case.md
+++ b/src/en/components/error-summary/use-case.md
@@ -9,7 +9,7 @@ eleventyNavigation:
   otherNames: error overview.
   description: A list of user errors on a page or in a flow.
   thumbnail: /images/common/components/preview-error-summary.svg
-  alt: A red rectangle frames a prominent heading that reads "There's a problem" and a numbered list of 3 links with error summary items in the link text.
+  alt: A red rectangle holds one thick grey line above a stack of three smaller thick red lines representing a heading and links.
   state: published
 translationKey: 'errorsummary'
 tags: ['errorsummaryEN', 'usage']

--- a/src/fr/composants/resume-de-erreurs/cas-dutilisation.md
+++ b/src/fr/composants/resume-de-erreurs/cas-dutilisation.md
@@ -9,7 +9,7 @@ eleventyNavigation:
   otherNames: liste d'erreurs.
   description: Un résumé des erreurs consiste en une liste des erreurs de saisie dans un formulaire.
   thumbnail: /images/common/components/preview-error-summary.svg
-  alt: Un encadré à la bordure rouge renferme une épaisse ligne grise qui représente un titre et qui surmonte trois épaisses lignes rouges plus courtes représentant du texte.
+  alt: Un rectangle rouge encadre un titre proéminent lisant "Il y a un problème" ainsi qu'une liste numérotée comprenant 3 liens avec des éléments du résumé des erreurs dans le texte de lien.
   state: published
 translationKey: 'errorsummary'
 tags: ['errorsummaryFR', 'usage']

--- a/src/fr/composants/resume-de-erreurs/cas-dutilisation.md
+++ b/src/fr/composants/resume-de-erreurs/cas-dutilisation.md
@@ -9,7 +9,7 @@ eleventyNavigation:
   otherNames: liste d'erreurs.
   description: Un résumé des erreurs consiste en une liste des erreurs de saisie dans un formulaire.
   thumbnail: /images/common/components/preview-error-summary.svg
-  alt: Un rectangle rouge encadre un titre proéminent lisant "Il y a un problème" ainsi qu'une liste numérotée comprenant 3 liens avec des éléments du résumé des erreurs dans le texte de lien.
+  alt: Un encadré à la bordure rouge renferme une épaisse ligne grise qui représente un titre et qui surmonte trois épaisses lignes rouges plus courtes représentant des liens.
   state: published
 translationKey: 'errorsummary'
 tags: ['errorsummaryFR', 'usage']

--- a/src/fr/composants/resume-de-erreurs/design.md
+++ b/src/fr/composants/resume-de-erreurs/design.md
@@ -13,7 +13,7 @@ tags: ['errorsummaryFR', 'design']
   <li>L'<strong>élément du résumé des erreurs</strong> est lié au contexte d'erreur et comporte le même texte que le message d'erreur (un énoncé d'appel à l'action pour le corriger).</li>
 </ol>
 
-<img class="b-sm b-default p-400" src="/images/fr/components/anatomy/gcds-error-summary-anatomy.svg" alt="L'anatomie d'un bouton identifiant l'étiquette, le conteneur et l'icone qui forme le composant." />
+<img class="b-sm b-default p-400" src="/images/fr/components/anatomy/gcds-error-summary-anatomy.svg" alt="Un rectangle rouge encadre un titre proéminent lisant 'Il y a un problème' ainsi qu’une liste numérotée comprenant 3 liens avec des éléments du résumé des erreurs dans le texte de lien." />
 
 ## Conception et accessibilité des résumés des erreurs
 


### PR DESCRIPTION
# Summary | Résumé

Improve error summary alt text - even though we reverted the error summary style changes, Amy had worked on improving the alt text descriptions for the error summary preview + anatomy images which I still want to update.