### PR TITLE
feat: contact us form freshdesk integration

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -13,6 +13,7 @@ const contextMenu = require('./utils/context-menu');
 const displayTokens = require('./utils/display-tokens');
 const markdownAnchor = require('./utils/anchor');
 const slugify = require('./utils/slugify');
+const { encode } = require('html-entities');
 
 const { execSync } = require('child_process');
 
@@ -153,6 +154,10 @@ module.exports = function (eleventyConfig) {
       });
     });
     return colourName;
+  });
+
+  eleventyConfig.addFilter('encode-html', data => {
+    return encode(data);
   });
 
   eleventyConfig.addFilter('stringify', data => {

--- a/api/src/constants.js
+++ b/api/src/constants.js
@@ -1,2 +1,43 @@
 export const DOMAIN_EN = 'https://design-system.alpha.canada.ca';
 export const DOMAIN_FR = 'https://systeme-design.alpha.canada.ca';
+
+export const learnMoreOptions = {
+  en: {
+    options: [
+      {
+        id: 'learnMoreMailingList',
+        label: 'Sign me up for the mailing list.',
+        value: 'mailing_list',
+      },
+      {
+        id: 'learnMoreDemo',
+        label: 'Contact me for a demo.',
+        value: 'demo',
+      },
+      {
+        id: 'learnMoreResearch',
+        label: 'Contact me for usability research.',
+        value: 'usability_research',
+      },
+    ],
+  },
+  fr: {
+    options: [
+      {
+        id: 'learnMoreMailingList',
+        label: "Ajoutez-moi à votre liste d'envoi.",
+        value: 'mailing_list',
+      },
+      {
+        id: 'learnMoreDemo',
+        label: 'Contactez-moi pour une démo.',
+        value: 'demo',
+      },
+      {
+        id: 'learnMoreResearch',
+        label: "Contactez-moi pour les études sur l'utilisabilité.",
+        value: 'usability_research',
+      },
+    ],
+  },
+};

--- a/api/src/constants.js
+++ b/api/src/constants.js
@@ -1,0 +1,2 @@
+export const DOMAIN_EN = 'https://design-system.alpha.canada.ca';
+export const DOMAIN_FR = 'https://systeme-design.alpha.canada.ca';

--- a/api/src/freshdesk.js
+++ b/api/src/freshdesk.js
@@ -1,0 +1,22 @@
+export const createTicket = async ticket => {
+  const { name, email, subject, message } = ticket;
+  const url = `https://api.freshdesk.com/api/v2/tickets`;
+  const body = {
+    description: message,
+    email,
+    subject,
+    name,
+    status: 2,
+  };
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Basic ${Buffer.from(
+        `${process.env.FRESHDESK_API_KEY}:X`,
+      ).toString('base64')}`,
+    },
+    body: JSON.stringify(body),
+  });
+  return response;
+};

--- a/api/src/freshdesk.js
+++ b/api/src/freshdesk.js
@@ -5,7 +5,6 @@
  * @param data
  * @returns {Promise<Response>}
  */
-
 export const createTicket = async (settings, data, lang) => {
   const { name, email, message, learnMore, familiarityGCDS } = data;
   const { FRESHDESK_API_KEY } = settings;
@@ -72,7 +71,7 @@ export const createTicket = async (settings, data, lang) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Basic ${btoa(`${FRESHDESK_API_KEY}:XxDummyTestKeyX`)}`,
+        'Authorization': `Basic ${btoa(`${FRESHDESK_API_KEY}:x`)}`,
       },
       body: postData,
     });

--- a/api/src/freshdesk.js
+++ b/api/src/freshdesk.js
@@ -1,22 +1,92 @@
-export const createTicket = async ticket => {
-  const { name, email, subject, message } = ticket;
-  const url = `https://api.freshdesk.com/api/v2/tickets`;
-  const body = {
-    description: message,
-    email,
-    subject,
-    name,
-    status: 2,
+/**
+ * Creates a new ticket in Freshdesk
+ * API Docs - https://developers.freshdesk.com/api/
+ * @param settings
+ * @param data
+ * @returns {Promise<Response>}
+ */
+
+export const createTicket = async (settings, data, lang) => {
+  const { name, email, message, learnMore, familiarityGCDS } = data;
+  const { FRESHDESK_API_KEY } = settings;
+  const url = `https://cds-snc.freshdesk.com/api/v2/tickets`;
+
+  if (!FRESHDESK_API_KEY) {
+    console.error('[ERROR] Missing Freshdesk API Key');
+    return Promise.resolve({ status: 400, ok: false });
+  }
+
+  // Tags for Freshdesk
+  const tags = ['z_skip_opsgenie', 'z_skip_urgent_escalation'];
+  if (learnMore.includes('mailing_list')) {
+    tags.push('Design_Request_MailingList');
+  }
+  if (learnMore.includes('demo')) {
+    tags.push('Design_Request_Demo');
+  }
+  if (learnMore.includes('usability_research')) {
+    tags.push('Design_Request_Research');
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    tags.push('Design_Staging');
+  } else {
+    tags.push('Design_Production');
+  }
+
+  // Build the description field
+  let description = `Name: ${name}<br>Email: ${email}<br>Message: ${message}<br>Learn More: ${learnMore}<br>Familiarity with GC Design System: ${familiarityGCDS}`;
+  let subject = 'GC Design System Contact Form';
+  let customFields = {
+    cf_language: 'English',
   };
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Basic ${Buffer.from(
-        `${process.env.FRESHDESK_API_KEY}:X`,
-      ).toString('base64')}`,
-    },
-    body: JSON.stringify(body),
+
+  // Update the fields for French
+  if (lang === 'fr') {
+    subject = 'Formulaire de contact Système de design GC';
+    customFields = {
+      cf_language: 'Français',
+    };
+    description = `Nom: ${name}<br>Courriel: ${email}<br>Message: ${message}<br>En savoir plus: ${learnMore}<br>Familiarité avec le Système de design GC: ${familiarityGCDS}`;
+  }
+
+  const postData = JSON.stringify({
+    name: name ? name : 'Anonymous',
+    email: email ? email : '',
+    type: 'Question',
+    source: 2,
+    priority: 1,
+    status: 2,
+    product_id: 61000003764,
+    tags: tags,
+    group_id: 61000175431,
+    subject: subject,
+    description: description,
+    custom_fields: customFields,
   });
-  return response;
+
+  console.log('[INFO] Sending to Freshdesk API: ', postData);
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Basic ${btoa(`${FRESHDESK_API_KEY}:XxDummyTestKeyX`)}`,
+      },
+      body: postData,
+    });
+    if (response?.ok === false) {
+      console.error(
+        `[ERROR] Failed to send to Freshdesk [${response.status}] - ${email} - ${postData}`,
+      );
+      const errorDetail = response.text();
+      throw new Error(`Freshdesk error with response: ${errorDetail}`);
+    } else {
+      return response;
+    }
+  } catch (e) {
+    console.error('[ERROR] Failed to send to Freshdesk', e);
+    return Promise.resolve({ status: 500, ok: false });
+  }
 };

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -65,7 +65,7 @@ app.post('/submission', async (req, res) => {
     parameters = {
       'gc-design-system-config': {
         EMAIL_TARGET: '',
-        FRESHDESK_API_KEY: '',
+        FRESHDESK_API_KEY: process.env['FRESHDESK_API_KEY'],
         NOTIFY_API_KEY: '',
         NOTIFY_TEMPLATE_ID: '',
       },

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -47,13 +47,25 @@ app.post('/submission', async (req, res) => {
   }
 
   // Extract the fields from the form submission
-  const { name, email, message, learnMore, familiarityGCDS, honeypot } = body;
+  let { name, email, message, familiarityGCDS, honeypot } = body;
+
+  const learnMore = [];
+  if (body['learn-more-mailing-list']) {
+    learnMore.push('mailing_list');
+  }
+  if (body['learn-more-demo']) {
+    learnMore.push('demo');
+  }
+  if (body['learn-more-research']) {
+    learnMore.push('usability_research');
+  }
 
   let parameters;
   if (process.env['NODE_ENV'] === 'development') {
     parameters = {
       'gc-design-system-config': {
         EMAIL_TARGET: '',
+        FRESHDESK_API_KEY: '',
         NOTIFY_API_KEY: '',
         NOTIFY_TEMPLATE_ID: '',
       },

--- a/api/src/notify.js
+++ b/api/src/notify.js
@@ -1,10 +1,13 @@
 /**
  * Send an email using the Notify API
  * API Docs - https://documentation.notification.canada.ca/
- * @param message
+ * @param settings
+ * @param data
  * @returns {Promise<Response>}
  */
-export const sendEmail = async (settings, data) => {
+
+import { learnMoreOptions } from './constants.js';
+export const sendEmail = async (settings, data, lang) => {
   const { EMAIL_TARGET, NOTIFY_TEMPLATE_ID, NOTIFY_API_KEY } = settings;
   const { name, email, message, learnMore, familiarityGCDS } = data;
 
@@ -13,6 +16,20 @@ export const sendEmail = async (settings, data) => {
     'Content-Type': 'application/json',
   };
 
+  let learnMoreStringArray = [];
+  if (learnMore) {
+    learnMore.forEach(answer => {
+      let learnMoreOption = learnMoreOptions[lang].options.find(
+        option => option.value === answer,
+      );
+
+      // Get the label for a human-readable description
+      if (learnMoreOption) {
+        learnMoreStringArray.push(learnMoreOption.label);
+      }
+    });
+  }
+
   const postData = JSON.stringify({
     email_address: EMAIL_TARGET,
     template_id: NOTIFY_TEMPLATE_ID,
@@ -20,8 +37,8 @@ export const sendEmail = async (settings, data) => {
       name: name,
       email: email,
       message: message ? message : '',
-      learnMore: learnMore ? learnMore : '',
-      familiarityGCDS: familiarityGCDS ? familiarityGCDS : '',
+      learnMore: learnMoreStringArray,
+      familiarityGCDS: familiarityGCDS,
     },
   });
 

--- a/api/src/notify.js
+++ b/api/src/notify.js
@@ -1,0 +1,45 @@
+/**
+ * Send an email using the Notify API
+ * API Docs - https://documentation.notification.canada.ca/
+ * @param message
+ * @returns {Promise<Response>}
+ */
+export const sendEmail = async (settings, data) => {
+  const { EMAIL_TARGET, NOTIFY_TEMPLATE_ID, NOTIFY_API_KEY } = settings;
+  const { name, email, message, learnMore, familiarityGCDS } = data;
+
+  const headers = {
+    'Authorization': `ApiKey-v1 ${NOTIFY_API_KEY}`,
+    'Content-Type': 'application/json',
+  };
+
+  const postData = JSON.stringify({
+    email_address: EMAIL_TARGET,
+    template_id: NOTIFY_TEMPLATE_ID,
+    personalisation: {
+      name: name,
+      email: email,
+      message: message ? message : '',
+      learnMore: learnMore ? learnMore : '',
+      familiarityGCDS: familiarityGCDS ? familiarityGCDS : '',
+    },
+  });
+
+  console.log('[INFO] Sending to Notify: ', postData);
+  const response = await fetch(
+    'https://api.notification.canada.ca/v2/notifications/email',
+    {
+      method: 'POST',
+      headers: headers,
+      body: postData,
+    },
+  );
+
+  if (response?.ok === false) {
+    console.error('[ERROR] Failed to send to Notify');
+    const errorDetail = await response.text();
+    console.error('[ERROR] Notify error detail: ', errorDetail);
+  }
+
+  return response;
+};

--- a/api/src/notify.js
+++ b/api/src/notify.js
@@ -5,7 +5,6 @@
  * @param data
  * @returns {Promise<Response>}
  */
-
 import { learnMoreOptions } from './constants.js';
 export const sendEmail = async (settings, data, lang) => {
   const { EMAIL_TARGET, NOTIFY_TEMPLATE_ID, NOTIFY_API_KEY } = settings;

--- a/api/src/utils.js
+++ b/api/src/utils.js
@@ -1,0 +1,18 @@
+import { DOMAIN_EN, DOMAIN_FR } from './constants.js';
+
+export const redirectUser = (origin, forwardedOrigin, lang, res) => {
+  // Attempt to get origin URL from request. If origin is null, use the default domains (en or fr) based on language
+  origin = origin && origin !== 'null' ? origin : forwardedOrigin;
+  origin =
+    origin && origin !== 'null'
+      ? origin
+      : lang === 'en'
+        ? DOMAIN_EN
+        : DOMAIN_FR;
+
+  const contactPath =
+    lang == 'en' ? '/en/contact/thanks' : '/fr/contactez/merci';
+  const redirectTo = origin + contactPath;
+  console.log(`[INFO] Redirecting to ${redirectTo}`);
+  res.redirect(303, redirectTo);
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@11ty/eleventy-navigation": "^0.3.2",
     "axios": "^1.6.0",
     "eleventy-plugin-code-clipboard": "^0.1.0",
+    "html-entities": "^2.5.2",
     "markdown-it": "^13.0.0",
     "moment": "^2.29.1",
     "npm-run-all2": "^5.0.0"

--- a/src/_data/contactus.js
+++ b/src/_data/contactus.js
@@ -23,20 +23,17 @@ module.exports = {
       {
         id: 'familiarityUsingGCDS',
         label: "J'utilise actuellement Système de design GC.",
-        value:
-          "I'm currently using GC Design System | J'utilise actuellement Système de design GC.",
+        value: "J'utilise actuellement Système de design GC.",
       },
       {
         id: 'familiarityExploringGCDS',
         label: "J'ai exploré Système de design GC.",
-        value:
-          "I've been exploring GC Design System | J'ai exploré Système de design GC.",
+        value: "J'ai exploré Système de design GC.",
       },
       {
         id: 'familiarityNeverUsedGCDS',
         label: "Je n'ai jamais utilisé Système de design GC.",
-        value:
-          "I've never used GC Design System | Je n'ai jamais utilisé Système de design GC.",
+        value: "Je n'ai jamais utilisé Système de design GC.",
       },
     ],
   },

--- a/src/_data/contactus.js
+++ b/src/_data/contactus.js
@@ -3,18 +3,18 @@ module.exports = {
     options: [
       {
         id: 'familiarityUsingGCDS',
-        label: 'I&#39;m currently using GC Design System.',
-        value: 'I&#39;m currently using GC Design System.',
+        label: "I'm currently using GC Design System.",
+        value: "I'm currently using GC Design System.",
       },
       {
         id: 'familiarityExploringGCDS',
-        label: 'I&#39;ve been exploring GC Design System.',
-        value: 'I&#39;ve been exploring GC Design System.',
+        label: "I've been exploring GC Design System.",
+        value: "I've been exploring GC Design System.",
       },
       {
         id: 'familiarityNeverUsedGCDS',
-        label: 'I&#39;ve never used GC Design System.',
-        value: 'I&#39;ve never used GC Design System.',
+        label: "I've never used GC Design System.",
+        value: "I've never used GC Design System.",
       },
     ],
   },
@@ -22,21 +22,21 @@ module.exports = {
     options: [
       {
         id: 'familiarityUsingGCDS',
-        label: 'J&#39;utilise actuellement Système de design GC.',
+        label: "J'utilise actuellement Système de design GC.",
         value:
-          'I&#39;m currently using GC Design System | J&#39;utilise actuellement Système de design GC.',
+          "I'm currently using GC Design System | J'utilise actuellement Système de design GC.",
       },
       {
         id: 'familiarityExploringGCDS',
-        label: 'J&#39;ai exploré Système de design GC.',
+        label: "J'ai exploré Système de design GC.",
         value:
-          'I&#39;ve been exploring GC Design System | J&#39;ai exploré Système de design GC.',
+          "I've been exploring GC Design System | J'ai exploré Système de design GC.",
       },
       {
         id: 'familiarityNeverUsedGCDS',
-        label: 'Je n&#39;ai jamais utilisé Système de design GC.',
+        label: "Je n'ai jamais utilisé Système de design GC.",
         value:
-          'I&#39;ve never used GC Design System | Je n&#39;ai jamais utilisé Système de design GC.',
+          "I've never used GC Design System | Je n'ai jamais utilisé Système de design GC.",
       },
     ],
   },

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -32,13 +32,13 @@ We offer custom demos for teams who want to know more about using GC Design Syst
 <gcds-textarea name="message" label="Give feedback or ask a question" textarea-id="message"></gcds-textarea>
 
   <gcds-fieldset fieldset-id="learnMore" legend="Learn more about GC Design System" hint="Choose as many options as you'd like.">
-    <gcds-checkbox checkbox-id="learnMoreMailingList" label="Sign me up for the mailing list." value="Sign me up for the mailing list." name="learnMore"></gcds-checkbox>
-    <gcds-checkbox checkbox-id="learnMoreDemo" label="Contact me for a demo." value="Contact me for a demo." name="learnMore"></gcds-checkbox>
-    <gcds-checkbox checkbox-id="learnMoreResearch" label="Contact me for usability research." value="Contact me for usability research." name="learnMore"></gcds-checkbox>
+    <gcds-checkbox checkbox-id="learnMoreMailingList" label="Sign me up for the mailing list." value="learn-more-mailing-list" name="learn-more-mailing-list"></gcds-checkbox>
+    <gcds-checkbox checkbox-id="learnMoreDemo" label="Contact me for a demo." value="learn-more-demo" name="learn-more-demo"></gcds-checkbox>
+    <gcds-checkbox checkbox-id="learnMoreResearch" label="Contact me for usability research." value="learn-more-mailing-list" name="learn-more-research"></gcds-checkbox>
   </gcds-fieldset>
 
   <gcds-fieldset fieldset-id="familiarityGCDS" legend="Familiarity with the product" hint="Select 1 option." required>
-    <gcds-radio-group name="familiarityGCDS" options='{{ contactus[locale].options | stringify }}'>
+    <gcds-radio-group name="familiarityGCDS" options='{{ contactus[locale].options | stringify | encode-html}}'>
     </gcds-radio-group>
   </gcds-fieldset>
 

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -23,7 +23,7 @@ Send us your feedback or questions on the following form, or get in touch on <gc
 
 We offer custom demos for teams who want to know more about using GC Design System.
 
-<form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
+<form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="https://x2c6xfxxnotcknsu4d5onhu2um0eotqp.lambda-url.ca-central-1.on.aws/submission">
   <input type="hidden" name="form-name" value="contactEN" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -23,7 +23,7 @@ Send us your feedback or questions on the following form, or get in touch on <gc
 
 We offer custom demos for teams who want to know more about using GC Design System.
 
-<form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="https://x2c6xfxxnotcknsu4d5onhu2um0eotqp.lambda-url.ca-central-1.on.aws/submission">
+<form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactEN" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -32,13 +32,13 @@ Nous offrons des démos personnalisées aux équipes qui souhaitent en savoir pl
 <gcds-textarea name="message" label="Commentaires ou questions" textarea-id="message"></gcds-textarea>
 
   <gcds-fieldset fieldset-id="learnMore" legend="Apprenez-en plus sur Système de design GC" hint="Choisissez autant d'options que vous le souhaitez.">
-    <gcds-checkbox checkbox-id="learnMoreMailingList" label="Ajoutez-moi à votre liste d'envoi." value="Ajoutez-moi à votre liste d'envoi." name="learnMore"></gcds-checkbox>
-    <gcds-checkbox checkbox-id="learnMoreDemo" label="Contactez-moi pour une démo." value="Contactez-moi pour une démo." name="learnMore"></gcds-checkbox>
-    <gcds-checkbox checkbox-id="learnMoreResearch" label="Contactez-moi pour les études sur l'utilisabilité." value="Contactez-moi pour les études sur l'utilisabilité." name="learnMore"></gcds-checkbox>
+    <gcds-checkbox checkbox-id="learnMoreMailingList" label="Ajoutez-moi à votre liste d'envoi." value="learn-more-mailing-list" name="learn-more-mailing-list"></gcds-checkbox>
+    <gcds-checkbox checkbox-id="learnMoreDemo" label="Contactez-moi pour une démo." value="learn-more-demo" name="learn-more-demo"></gcds-checkbox>
+    <gcds-checkbox checkbox-id="learnMoreResearch" label="Contactez-moi pour les études sur l'utilisabilité." value="learn-more-research" name="learn-more-research"></gcds-checkbox>
   </gcds-fieldset>
 
   <gcds-fieldset fieldset-id="familiarityGCDS" legend="Connaissance du produit" hint="Sélectionnez 1 option." required>
-    <gcds-radio-group name="familiarityGCDS" options='{{ contactus[locale].options | stringify }}'>
+    <gcds-radio-group name="familiarityGCDS" options='{{ contactus[locale].options | stringify | encode-html }}'>
     </gcds-radio-group>
   </gcds-fieldset>
 


### PR DESCRIPTION
# Summary | Résumé
- Refactored the old API and added a freshdesk integration
- Added an encode filter for eleventy so we don't always have to write the html encoding (had to do so with the radio group on the contact us form)
- Followed the guide from here: https://github.com/cds-snc/platform-helpdesk/wiki/GC-Design-System-How-to-create-Freshdesk-tickets-using-the-API
  - Add tags as appropriate. Fixed the `learnMore` checkbox to better handle the logic for this. We need to set the `name` on those checkboxes to be different, I noticed that `value` is not enough especially when testing I would just get `learnMore: checked` and not the actual value
  - Use the appropriate language for the different fields
  -  I've kept most of the other settings the same
    ``` 
    const postData = JSON.stringify({
    name: name ? name : 'Anonymous',
    email: email ? email : '',
    type: 'Question',
    source: 2,
    priority: 1,
    status: 2,
    product_id: 61000003764,
    tags: tags,
    group_id: 61000175431,
    subject: subject,
    description: description,
    custom_fields: customFields,
  });
   ```
- Also added a fallback to Notify if Freshdesk fails. And just simply log the error if that one fails too.

Tested with English and French on Freshdesk, as well as Notify and they work quite well. May have to cleanup some tickets in Freshdesk.

**Dev/ops note**: I've updated the `API_CONFIG` secret on https://github.com/cds-snc/gcds-terraform but still haven't applied it onto `DesignSystem-Production` AWS account. Will revisit with SRE and tech ops on Monday to make sure we have the correct API Config on the website. If the `FRESHDESK_API_KEY` doesn't exit, what this code will do is proceed to use Notify.
- [x] FRESHDESK_API_KEY is set on AWS prod environment

**Testing note**: The PR Preview URLs will show the updates to the contact us form but hitting submit on those will simply hit the _old_ API and **not** the updates indicated in this PR.