### PR TITLE
fix: Remove end paragraph tag from gird example

### DIFF
--- a/src/en/components/grid/code.md
+++ b/src/en/components/grid/code.md
@@ -76,12 +76,11 @@ Mobile
 </div>
 
 {% viewCode "en" "preview-grid-flexible" "gcds-grid" %}
-<gcds-grid tag="article" columns-desktop="1fr 1fr 1fr" columns-tablet="1fr 1fr" columns="1fr" gap="300">
-
-  <p>This is some example content to display the grid component.</p>
-  <p>This is some example content to display the grid component.</p>
-  <p>This is some example content to display the grid component.</p>
-</gcds-grid>
+  <gcds-grid tag="article" columns-desktop="1fr 1fr 1fr" columns-tablet="1fr 1fr" columns="1fr" gap="300">
+    <p>This is some example content to display the grid component.</p>
+    <p>This is some example content to display the grid component.</p>
+    <p>This is some example content to display the grid component.</p>
+  </gcds-grid>
 {% endviewCode %}
 
 Set the minimum and maximum width to design equal-width columns with restrictions to limit how wide they will span on any screen size.
@@ -126,12 +125,11 @@ Mobile
 </div>
 
 {% viewCode "en" "preview-grid-fixed-width" "gcds-grid" %}
-<gcds-grid tag="article" columns="repeat(auto-fit, minmax(100px, 300px))" gap="500">
-
-  <p>This is some example content to display the grid component.</p>
-  <p>This is some example content to display the grid component.</p>
-  <p>This is some example content to display the grid component.</p>
-</gcds-grid>
+  <gcds-grid tag="article" columns="repeat(auto-fit, minmax(100px, 300px))" gap="500">
+    <p>This is some example content to display the grid component.</p>
+    <p>This is some example content to display the grid component.</p>
+    <p>This is some example content to display the grid component.</p>
+  </gcds-grid>
 {% endviewCode %}
 
 {% include "partials/getcode.njk" %}

--- a/src/fr/composants/grille/code.md
+++ b/src/fr/composants/grille/code.md
@@ -76,12 +76,11 @@ Mobile
 </div>
 
 {% viewCode "fr" "preview-grid-flexible" "gcds-grid" %}
-<gcds-grid tag="article" columns-desktop="1fr 1fr 1fr" columns-tablet="1fr 1fr" columns="1fr" gap="300">
-
-  <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
-  <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
-  <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
-</gcds-grid>
+  <gcds-grid tag="article" columns-desktop="1fr 1fr 1fr" columns-tablet="1fr 1fr" columns="1fr" gap="300">
+    <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
+    <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
+    <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
+  </gcds-grid>
 {% endviewCode %}
 
 Définissez la largeur minimale et la largeur maximale pour concevoir des colonnes de largeur égale afin de limiter la largeur des colonnes sur n'importe quelle taille d'écran.
@@ -126,12 +125,11 @@ Mobile
 </div>
 
 {% viewCode "fr" "preview-grid-fixed-width" "gcds-grid" %}
-<gcds-grid tag="article" columns="repeat(auto-fit, minmax(100px, 300px))" gap="500">
-
-  <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
-  <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
-  <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
-</gcds-grid>
+  <gcds-grid tag="article" columns="repeat(auto-fit, minmax(100px, 300px))" gap="500">
+    <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
+    <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
+    <p>Ceci est un exemple de contenu pour illustrer le composant Grille.</p>
+  </gcds-grid>
 {% endviewCode %}
 
 {% include "partials/getcode.njk" %}


### PR DESCRIPTION
# Summary | Résumé

Change formatting of `gcds-grid` examples to prevent an extra `</p>` tag from appearing behind the `gcds-grid` tag in the code highlight on the code pages. 

## Before

``` html
<gcds-grid tag="article" columns="repeat(auto-fit, minmax(100px, 300px))" gap="500"></p>
  <p>This is some example content to display the grid component.</p>
  <p>This is some example content to display the grid component.</p>
  <p>This is some example content to display the grid component.</p>
</gcds-grid>
```

## After 

``` html
<gcds-grid tag="article" columns="repeat(auto-fit, minmax(100px, 300px))" gap="500">
<p>This is some example content to display the grid component.</p>
<p>This is some example content to display the grid component.</p>
<p>This is some example content to display the grid component.</p>
</gcds-grid>

```
