### PR TITLE
fix: error loading old fontawesome kit

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -20,7 +20,7 @@ customHeaders:
           report-uri https://csp-report-to.security.cdssandbox.xyz/report;
           default-src 'self' https://kit.fontawesome.com/ https://cdn.jsdelivr.net/npm/;
           font-src 'self' fonts.gstatic.com https://unpkg.com/font-awesome@4.7.0/;
-          script-src 'self' 'wasm-unsafe-eval' www.googletagmanager.com www.google-analytics.com https://kit.fontawesome.com https://cdn.jsdelivr.net/npm/ 'unsafe-inline';
+          script-src 'self' 'wasm-unsafe-eval' www.googletagmanager.com www.google-analytics.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/ 'unsafe-inline';
           frame-src www.googletagmanager.com www.google-analytics.com https://cds-snc.github.io/;
           connect-src 'self' www.googletagmanager.com www.google-analytics.com www.canada.ca;
           img-src 'self' data: https: www.w3.org;

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -19,7 +19,7 @@ customHeaders:
         value: >-
           report-uri https://csp-report-to.security.cdssandbox.xyz/report;
           default-src 'self' https://kit.fontawesome.com/ https://cdn.jsdelivr.net/npm/;
-          font-src 'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/;
+          font-src 'self' fonts.gstatic.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/;
           script-src 'self' 'wasm-unsafe-eval' www.googletagmanager.com www.google-analytics.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/ 'unsafe-inline';
           frame-src www.googletagmanager.com www.google-analytics.com https://cds-snc.github.io/;
           connect-src 'self' www.googletagmanager.com www.google-analytics.com www.canada.ca;

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -19,7 +19,7 @@ customHeaders:
         value: >-
           report-uri https://csp-report-to.security.cdssandbox.xyz/report;
           default-src 'self' https://kit.fontawesome.com/ https://cdn.jsdelivr.net/npm/;
-          font-src 'self' fonts.gstatic.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/;
+          font-src 'self' fonts.gstatic.com https://unpkg.com/font-awesome@4.7.0/ https://cdnjs.cloudflare.com/ajax/libs/font-awesome/;
           script-src 'self' 'wasm-unsafe-eval' www.googletagmanager.com www.google-analytics.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/ 'unsafe-inline';
           frame-src www.googletagmanager.com www.google-analytics.com https://cds-snc.github.io/;
           connect-src 'self' www.googletagmanager.com www.google-analytics.com www.canada.ca;

--- a/customHttp.yml
+++ b/customHttp.yml
@@ -19,7 +19,7 @@ customHeaders:
         value: >-
           report-uri https://csp-report-to.security.cdssandbox.xyz/report;
           default-src 'self' https://kit.fontawesome.com/ https://cdn.jsdelivr.net/npm/;
-          font-src 'self' fonts.gstatic.com https://unpkg.com/font-awesome@4.7.0/;
+          font-src 'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/;
           script-src 'self' 'wasm-unsafe-eval' www.googletagmanager.com www.google-analytics.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/ 'unsafe-inline';
           frame-src www.googletagmanager.com www.google-analytics.com https://cds-snc.github.io/;
           connect-src 'self' www.googletagmanager.com www.google-analytics.com www.canada.ca;

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -24,8 +24,8 @@
     <script src="{{ '/scripts/code-copy.js' | url }}"></script>
     <link rel="icon" type="image/x-icon" sizes="96x96" href="{{ '/favicon.ico' | url }}">
 
-    {# Font awesome 6 kit for this doc website. Anyone can create a free kit for open source. #}
-    <script src="https://kit.fontawesome.com/892cb27850.js" crossorigin="anonymous"></script>
+    <!-- Icons Font Awesome (to access icons, import Font Awesome) -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" crossorigin="anonymous">
 
     <!-- GC Design System  Components-->
     <link rel="stylesheet" href="{{ '/components/dist/gcds/gcds.css' | url }}">

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -23,8 +23,8 @@
     <script src="{{ '/scripts/code-showcase.js' | url }}"></script>
     <link rel="icon" type="image/x-icon" sizes="96x96" href="{{ '/favicon.ico' | url }}">
 
-    {# Font awesome 6 kit for this doc website. Anyone can create a free kit for open source. #}
-    <script src="https://kit.fontawesome.com/892cb27850.js" crossorigin="anonymous"></script>
+    <!-- Icons Font Awesome (to access icons, import Font Awesome) -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" crossorigin="anonymous">
 
     <!-- GC Design System  Components-->
     <link rel="stylesheet" href="{{ '/components/dist/gcds/gcds.css' | url }}">


### PR DESCRIPTION
# Summary | Résumé

There's an error loading fontawesome; I copied our installation instructions and used that instead for consistency and to get rid of the error.

<img width="1773" alt="Screenshot 2024-06-05 at 9 48 42 AM" src="https://github.com/cds-snc/gcds-docs/assets/916044/78b512ba-a794-4096-b46d-a27797653a6f">
