### PR TITLE
Removed a paragraph that did not exist in FR and had a missing word.

### DIFF
--- a/src/en/components/button/design.md
+++ b/src/en/components/button/design.md
@@ -32,4 +32,3 @@ date: 'git Last Modified'
 - Avoid re-using label text on the same page or using labels that sound a lot alike. A person using assistive technology will hear the label text repeated in rapid succession without cues to tell which button's for which action.
 - Stay away from verb phrases or expressions that may be unfamiliar to non-fluent speakers.
 
-Tip: Language constructions like sign up and sign in can be confusing because the "up" and "in" add little meaning and alongside other they can be hard to tell apart.


### PR DESCRIPTION
# Summary | Résumé

Removed a paragraph that did not exist in FR and had a missing word.
See issue https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/953
- https://github.com/cds-snc/design-gc-conception/issues/953
# Test instructions | Instructions pour tester la modification


On the Button-design page, this paragraph is not found in FR, moreover there seems to be a missing word after "other" that is needed. Removing the paragraph for now: 
"Tip: Language constructions like sign up and sign in can be confusing because the "up" and "in" add little meaning and alongside other they can be hard to tell apart."

The EN will be removed until later time when the missing word is added and the FR is included
