### PR TITLE
Update typography - and and.md

### DIFF
--- a/src/en/styles/typography/typography.md
+++ b/src/en/styles/typography/typography.md
@@ -45,7 +45,7 @@ date: 'git Last Modified'
 
 Typography tokens include the style, arrangement, and appearance of letters, numbers, and symbols.
 
-## Typography and and accessibility
+## Typography and accessibility
 
 GC Design System components meet <gcds-link external href="{{ links.wcagTextSpacing }}" target="_blank">level AA of the Web Content Accessibility Guidelines (WCAG 2.1)</gcds-link> for text spacing and AAA for visual presentation.
 


### PR DESCRIPTION
Deleted extra "and" in "Typography and accessibility" heading

# Summary | Résumé

There were two "and"s in the heading "Typography and and accessibility"

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
