### PR TITLE
fix(search): hide deprecated components from search

### DIFF
--- a/src/en/components/radio/base.md
+++ b/src/en/components/radio/base.md
@@ -4,6 +4,7 @@ github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/co
 figma: https://www.figma.com/file/mh2maMG2NBtk41k1O1UGHV/GC-Design-System?type=design&node-id=462-110&mode=design&t=juCIOMIg2VKfCrQA-0
 permalink: false
 tags: ['radioEN', 'header']
+nocrawl: true
 ---
 
 # Radio <br>`<gcds-radio>`

--- a/src/en/components/radio/code.md
+++ b/src/en/components/radio/code.md
@@ -4,6 +4,7 @@ layout: 'layouts/component-documentation.njk'
 translationKey: 'radioCode'
 tags: ['radioEN', 'code']
 date: 'git Last Modified'
+nocrawl: true
 ---
 
 ## Build a radio

--- a/src/en/components/radio/design.md
+++ b/src/en/components/radio/design.md
@@ -4,6 +4,7 @@ layout: 'layouts/component-documentation.njk'
 translationKey: 'radioDesign'
 tags: ['radioEN', 'design']
 date: 'git Last Modified'
+nocrawl: true
 ---
 
 ## Radio anatomy – with fieldset

--- a/src/en/components/radio/use-case.md
+++ b/src/en/components/radio/use-case.md
@@ -16,6 +16,7 @@ translationKey: 'radio'
 tags: ['radioEN', 'usage']
 permalink: /en/components/radio/
 date: 'git Last Modified'
+nocrawl: true
 ---
 
 Take a look at what problems radios solve to see if they fit the problem you're solving for.

--- a/src/fr/composants/bouton-radio/base.md
+++ b/src/fr/composants/bouton-radio/base.md
@@ -4,6 +4,7 @@ github: https://github.com/cds-snc/gcds-components/tree/main/packages/web/src/co
 figma: https://www.figma.com/file/o4SguSZdar2CCFzSkWNrmB/Syst%C3%A8me-de-design-GC?type=design&node-id=348-5024&mode=design&t=1DaL24vHpjRRfHHm-0
 permalink: false
 tags: ['radioFR', 'header']
+nocrawl: true
 ---
 
 # Bouton radio <br>`<gcds-radio>`

--- a/src/fr/composants/bouton-radio/cas-dutilisation.md
+++ b/src/fr/composants/bouton-radio/cas-dutilisation.md
@@ -16,6 +16,7 @@ translationKey: 'radio'
 tags: ['radioFR', 'usage']
 permalink: /fr/composants/bouton-radio/
 date: 'git Last Modified'
+nocrawl: true
 ---
 
 Explorez les problèmes que les boutons radio règlent et découvrez s’ils peuvent servir à résoudre votre problème particulier.

--- a/src/fr/composants/bouton-radio/code.md
+++ b/src/fr/composants/bouton-radio/code.md
@@ -4,6 +4,7 @@ layout: 'layouts/component-documentation.njk'
 translationKey: 'radioCode'
 tags: ['radioFR', 'code']
 date: 'git Last Modified'
+nocrawl: true
 ---
 
 ## Créer un bouton radio

--- a/src/fr/composants/bouton-radio/design.md
+++ b/src/fr/composants/bouton-radio/design.md
@@ -4,6 +4,7 @@ layout: 'layouts/component-documentation.njk'
 translationKey: 'radioDesign'
 tags: ['radioFR', 'design']
 date: 'git Last Modified'
+nocrawl: true
 ---
 
 ## Structure du bouton radio - avec jeu de champ


### PR DESCRIPTION
# Summary | Résumé
Fixes
- https://github.com/cds-snc/design-gc-conception/issues/982

# Testing
1. Search for "sentence case" (EN link: https://pr-373.djtlis5vpn8jd.amplifyapp.com/en/search/?q=sentence+case)
2. Should not list the deprecated Radio component in the results