### PR TITLE
chore: Update GC Design System packages (tokens + components)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
-    "@cdssnc/gcds-components": "^0.22.1",
-    "@cdssnc/gcds-tokens": "^1.13.3",
+    "@cdssnc/gcds-components": "^0.22.2",
+    "@cdssnc/gcds-tokens": "^1.14.1",
     "@cdssnc/gcds-utility": "^1.2.1",
     "@quasibit/eleventy-plugin-sitemap": "^2.1.4",
     "chroma-js": "^2.4.2",


### PR DESCRIPTION
# Summary | Résumé

Update doc site to use latest versions of `gcds-tokens` and `gcds-components` to take advantage of a11y fixes made for Safari.
