### PR TITLE
fix: Remove mention of pageChangeHandler

### DIFF
--- a/src/en/components/pagination/code.md
+++ b/src/en/components/pagination/code.md
@@ -30,7 +30,6 @@ Use list styled pagination when you are dealing with a larger number of pages.
 - Set the total number of pages in your sequence with the `total-pages` attribute using a numeric value.
 - Set the current or active page with the `current-page` attribute using a numeric value.
 - Opt to use the `url` attribute to provide the component with a group of page links. This can be an object if you are working in a JS environment, or a string if you are using HTML.
-- The `pageChangeHandler` is used to track any page change events.
 
 #### Apply the URL object for list-style pagination
 

--- a/src/fr/composants/pagination/code.md
+++ b/src/fr/composants/pagination/code.md
@@ -30,7 +30,6 @@ Utilisez la pagination sous forme de liste si votre contenu est étendu sur un p
 - Définissez le nombre total de pages pour votre séquence à l’aide de l’attribut `total-pages` en utilisant un nombre.
 - Définissez la page actuelle ou active à l’aide de l’attribut `current-page` en utilisant un nombre.
 - Choisissez d’utiliser l’attribut `url` pour fournir au composant un groupe de liens de pages. Il peut s’agir d’un objet si vous travaillez dans un environnement JS ou d’une chaîne si vous utilisez HTML.
-- L’attribut `pageChangeHandler` est utilisé pour le suivi des modifications de pages.
 
 #### Appliquez l’objet de l’URL pour la pagination sous forme de liste.
 


### PR DESCRIPTION
# Summary | Résumé

Remove mention of `pageChangeHandler` from pagination Code guidance. This function has been replaced with custom events and details in `v0.21.0` of `@cdssnc/gcds-components`
