### PR TITLE
fix: update details preview image to align border

### DIFF
--- a/src/images/common/components/preview-details.svg
+++ b/src/images/common/components/preview-details.svg
@@ -3,6 +3,6 @@
 <path d="M73.5 113L60.9426 92L86.0574 92L73.5 113Z" fill="#2B4380" fill-opacity="0.75"/>
 <rect x="101" y="143" width="240" height="20" rx="10" fill="#A8ADB4" fill-opacity="0.5"/>
 <rect x="101" y="183" width="240" height="20" rx="10" fill="#A8ADB4" fill-opacity="0.5"/>
-<rect width="8" height="80" transform="translate(60 133)" fill="#7D828B"/>
+<rect width="8" height="80" transform="translate(69.5 133)" fill="#7D828B"/>
 <rect x="102" y="93" width="160" height="20" rx="10" fill="#2B4380" fill-opacity="0.75"/>
 </svg>


### PR DESCRIPTION
# Summary | Résumé

Noticed during our call with the OAS team today that the preview image for the details component was still showing the old border alignment. I updated the image in Figma and here to match the new design.