### PR TITLE
Update get-involved.md

### DIFF
--- a/src/en/get-involved.md
+++ b/src/en/get-involved.md
@@ -27,18 +27,16 @@ We're sharing what we're working on and what we'll work on next. To get updates 
 ### Contribute to our next priorities
 
 <div>
-  <gcds-heading tag="h4" margin-bottom="0">Icon component</gcds-heading>
+  <gcds-heading tag="h4" margin-bottom="0">Data table</gcds-heading>
   <ul class="mb-400">
-    <li>The icon component displays optimized responsive visual content.</li>
-    <li><strong>Expected release:</strong> Fall 2024</li>
+    <li>Data table is a way to organize and display large amounts of data in rows and columns.</li>
   </ul>
 </div>
 
 <div>
-  <gcds-heading tag="h4" margin-bottom="0">Standard page template</gcds-heading>
+  <gcds-heading tag="h4" margin-bottom="0">Tag</gcds-heading>
   <ul class="mb-400">
-    <li>The standard page template provides the basic layout for Canada.ca web pages.</li>
-    <li><strong>Expected release:</strong> Fall 2024</li>
+    <li>Tag is a component used for items that need to be labeled, categorized, or organized using keywords that describe them. </li>
   </ul>
 </div>
 
@@ -70,6 +68,14 @@ Provide any of the following for each component or pattern:
   <gcds-heading tag="h4" margin-bottom="0">Stepper</gcds-heading>
   <ul class="mb-400">
     <li>The stepper is being enhanced to provide a clear and organized way to guide people through a multi-step process.</li>
+    <li><strong>Expected release:</strong> Summer 2024</li>
+  </ul>
+</div>
+
+<div>
+  <gcds-heading tag="h4" margin-bottom="0">Date input</gcds-heading>
+  <ul class="mb-400">
+    <li>A date input is a space to enter a known date.</li>
     <li><strong>Expected release:</strong> Summer 2024</li>
   </ul>
 </div>


### PR DESCRIPTION
Update to "Contribute to next priorities" section:

- delete icon component
- delete standard page template
(we aren't actually accepting contributions for these)

Replace w/:

- Data table & tag components

Update "coming soon" section:

- add Date input


NOTE: 
For future, "contribute to next priorities" section will not include dates for the components.  We will also only list components in this section that we are actually accepting contributions that we would be willing to incorporate.  Icons and standard page template aren't really open for contribution at this stage.  Data table and tag components are.  

This release was also pushed without modifying the "Contribute to next priorities" issue section in Github (see attached image).  The old content was listed as the three drop down options.  This needs to be modified.
![Screenshot 2024-08-14 at 10 48 52 AM](https://github.com/user-attachments/assets/1c0c63b8-e083-4196-a383-676434f3fe6d)

