### PR TITLE
refactor: replace "styles" with "get involved" in top-nav

### DIFF
--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -5,7 +5,7 @@ eleventyNavigation:
   key: contactusEN
   title: Contact us
   locale: en
-  order: 3
+  order: 2
 translationKey: 'contactus'
 contactForm: en
 date: 'git Last Modified'
@@ -21,7 +21,7 @@ With an account, use our <gcds-link external href="{{ links.githubCompsIssues }}
 
 ## Give feedback, request support, or sign up
 
-Use this form to provide feedback or ask questions, get help using GC Design System, or sign up for our mailing list or demo.    
+Use this form to provide feedback or ask questions, get help using GC Design System, or sign up for our mailing list or demo.
 
 <form class="my-500 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactEN" />

--- a/src/en/get-involved.md
+++ b/src/en/get-involved.md
@@ -6,8 +6,7 @@ eleventyNavigation:
   key: getinvolvedEN
   title: Get involved
   locale: en
-  order: 4
-  hideMain: true
+  order: 3
 ---
 
 # Get involved

--- a/src/en/styles/styles.md
+++ b/src/en/styles/styles.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   title: Styles
   locale: en
   order: 2
+  hideMain: true
 translationKey: 'foundatons'
 github: https://github.com/cds-snc/gcds-tokens
 date: 'git Last Modified'

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -5,7 +5,7 @@ eleventyNavigation:
   key: contactusFR
   title: Contactez-nous
   locale: fr
-  order: 3
+  order: 2
 translationKey: 'contactus'
 contactForm: fr
 date: 'git Last Modified'
@@ -15,13 +15,13 @@ date: 'git Last Modified'
 
 ## Formulaire de soutien GitHub
 
-Avec votre compte GitHub, utilisez notre <gcds-link external href="{{ links.githubCompsIssues }}">formulaire de soutien</gcds-link> pour signaler des bogues et obtenir un soutien technique. Vous aurez accès aux problèmes (issues) passés et verrez les progrès accomplis.      
+Avec votre compte GitHub, utilisez notre <gcds-link external href="{{ links.githubCompsIssues }}">formulaire de soutien</gcds-link> pour signaler des bogues et obtenir un soutien technique. Vous aurez accès aux problèmes (issues) passés et verrez les progrès accomplis.
 
 <hr class="my-500" />
 
 ## Envoyer des commentaires, demander de l’aide ou s’inscrire
 
-Remplissez le formulaire suivant pour nous envoyer vos commentaires, demander de l’aide pour utiliser Système de design GC, ou vous inscrire à notre liste d’envoi ou à une démo. 
+Remplissez le formulaire suivant pour nous envoyer vos commentaires, demander de l’aide pour utiliser Système de design GC, ou vous inscrire à notre liste d’envoi ou à une démo.
 
 <form class="my-500 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactFR" />

--- a/src/fr/simpliquer.md
+++ b/src/fr/simpliquer.md
@@ -6,8 +6,7 @@ eleventyNavigation:
   key: getinvolvedFR
   title: S'impliquer
   locale: fr
-  order: 4
-  hideMain: true
+  order: 3
 ---
 
 # S'impliquer

--- a/src/fr/styles/styles.md
+++ b/src/fr/styles/styles.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   title: Styles
   locale: fr
   order: 2
+  hideMain: true
 translationKey: 'foundatons'
 github: https://github.com/cds-snc/gcds-tokens
 cardlist:


### PR DESCRIPTION
# Summary | Résumé

Remove "Styles" from our top-nav and replace with a link to the "Get involved" page instead.