### PR TITLE
feat: add new accessibility page

### DIFF
--- a/src/en/accessibility.md
+++ b/src/en/accessibility.md
@@ -1,0 +1,13 @@
+---
+title: Accessibility
+translationKey: accessibility
+layout: 'layouts/base.njk'
+eleventyNavigation:
+  key: accessibilityEN
+  title: Accessibility
+  locale: en
+  order: 4
+  hideMain: true
+---
+
+# Accessibility

--- a/src/en/accessibility.md
+++ b/src/en/accessibility.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   locale: en
   order: 4
   hideMain: true
+nocrawl: true
 ---
 
 # Accessibility

--- a/src/en/roadmap.md
+++ b/src/en/roadmap.md
@@ -14,107 +14,93 @@ eleventyNavigation:
 ## Timeline: Q1 (Apr - Jun 2024) 
 
 ### Theme: Product Growth
-
-#### Items:
 - **Support for Server Side Rendering frameworks**
-  - Enable teams using NextJS (like GC Forms, OAS BE, Dental, EI) to code with GC Design System.
-  - Put a plan in place for integrating with Stencil when SSR support is released.
+  - Enable teams using NextJS (like GC Forms, OAS BE, Dental, EI) to code with GC Design System. [Completed]
+  - Put a plan in place for integrating with Stencil when SSR support is released. [Deprioritized]
 - **Bilingual design library**
-  - Produce and maintain a bilingual Figma library, with assets and guidance in both official languages.
+  - Produce and maintain a bilingual Figma library, with assets and guidance in both official languages. [Completed]
 - **New functionality and improvements**
-  - Full VueJS package.
-  - Improvements to Angular package (better support for event handling).
-  - Cards component version 2.
-  - Fieldset component in Figma design library.
-  - New Components:Icons (custom icons, not as third party package), Cards v2.
-  - Begin testing on canada.ca managed services (AEM, Drupal).
+  - Full VueJS package. [Completed]
+  - Improvements to Angular package (better support for event handling). [Completed]
+  - Cards component version 2. [Completed]
+  - Stepper component version 2. [Completed]
+  - Fieldset component in Figma design library. [Completed]
+  - Icons (custom icons, not as third party package). [In progress]
+  - Begin testing on canada.ca managed services (AEM, Drupal). [Completed]
 
 ### Theme: Research
-#### Items:
 - **Accessibility, usability, and onboarding**
-  - Research, interviews, surveys to improve onboarding, usability, accessibility.
+  - Research, interviews, surveys to improve onboarding, usability, accessibility. [Completed]
 
 ### Theme: Engagement
 - **Contribution model**
-  - Define and implement a contribution model with Design teams in GC.
+  - Define and implement a contribution model with Design teams in GC. [Completed]
 - **Outreach**
-  - Establish regular mailing lists to keep the community informed.
-  - Launch post demo surveys.
+  - Establish regular mailing lists to keep the community informed. [Completed]
+  - Launch post demo surveys. [Completed]
 
 ## Timeline: Q2 (Jul - Sep 2024) 
-
 ### Theme: Product Growth
-
-#### Items:
 - **New functionality and improvements**
-  - 5 standard templates.
-  - Utility framework (alpha).
-  - New Components: Date input, Alert / Notice, Tags (Labels).
-  - Resolve any conflicting styles with Canada.ca mandatory components.
+  - 5 standard templates. [In progress]
+  - Utility framework (alpha). [In progress]
+  - New Components: Date input, Alert / Notice, Tags (Labels). [In progress]
+  - Resolve any conflicting styles with Canada.ca mandatory components. [In progress]
 
 ### Theme: Research
-#### Items:
 - **Accessibility, usability, and onboarding**
-  - Establish product metrics.
-  - Identify and plan to resolve pain points, process for releasing breaking changes, Figma design library access.
-  - Conduct usability testing and accessibility testing with end users.
+  - Establish product metrics. [In progress]
+  - Identify and plan to resolve pain points, process for releasing breaking changes, Figma design library access. [In progress]
+  - Conduct usability testing and accessibility testing with end users. [In progress]
 
 ### Theme: Engagement
-#### Items:
 - **Outreach**
-  - Establish a Service Level Agreement.
-  - Setup recurring scheduled demos with self sign up.
-  - Establish regular touchpoints with the community.
+  - Establish a Service Level Agreement. [In progress]
+  - Setup recurring scheduled demos with self sign up. [In progress]
+  - Establish regular touchpoints with the community. [In progress]
 
 ## Timeline: Q3 (Oct - Dec 2024) 
 
 ### Theme: Product Growth
-#### Items:
 - **Technical onboarding**
-  - Produce and test out a dedicated developer onboarding experience, including starter apps, technical documentation and more.
-  - Product and test out a dedicated designer onboarding experience.
+  - Produce and test out a dedicated developer onboarding experience, including starter apps, technical documentation and more. [Not started]
+  - Product and test out a dedicated designer onboarding experience. [Not started]
 - **CDTS functionality**
-  - Leveraging standard templates, provide the full functionality of Centrally Deployed Templates Solution (CDTS) to help with onboarding and adoption.
+  - Leveraging standard templates, provide the full functionality of Centrally Deployed Templates Solution (CDTS) to help with onboarding and adoption. [Not started]
 - **Integration with canada.ca**
-  - Increase access to GC Design System by offering a path from design.canada.ca.
+  - Increase access to GC Design System by offering a path from design.canada.ca. [Not started]
 - **Product metrics & analytics**
-  - Establish clear ways of measuring adoption and ROI.
-    - Adoption, time to build and cost saving, user satisfaction, fit of available adoption strategies (frameworks, touch points).
+  - Establish clear ways of measuring adoption and ROI. [Not started]
+    - Adoption, time to build and cost saving, user satisfaction, fit of available adoption strategies (frameworks, touch points). [Not started]
 
 ### Theme: Research
-#### Items:
 - **GC Design ecosystem and user needs research**
-  - Understand the different Design System offerings and alternatives across GC.
-  - Understand and categorize the needs of different user groups across GC.
-  - Share evidence for accessibility and policy compliance on the GC Design System website.
+  - Understand the different Design System offerings and alternatives across GC. [In progress]
+  - Understand and categorize the needs of different user groups across GC. [Not started]
+  - Share evidence for accessibility and policy compliance on the GC Design System website. [Not started]
 
 ### Theme: Engagement
-#### Items:
 - **Targeted demos**
-  - Test "use case" targeted demos and Q&As for more personalized outreach.
+  - Test "use case" targeted demos and Q&As for more personalized outreach. [Not started]
 
 ## Timeline: Q4 (Jan - Mar 2025) 
 
 ### Theme: Product Growth
-#### Items:
 - **New functionality and improvements**
-  - Aim for beta or full release
-  - Aim for a standardized process of integration with AEM and Drupal.
-  - Additional templates, patterns, and components as needed.
+  - Aim for beta release [Not started]
+  - Aim for a standardized process of integration with AEM and Drupal. [Not started]
+  - Additional templates, patterns, and components as needed. [Not started]
 
 ### Theme: Research
-#### Items:
 - **Testing**
-  - UAccessibility testing completed with 30 people through the year.
-  - 5 completed usability research activities through the year.
+  - Accessibility testing completed with 30 people through the year. [In progress]
+  - 5 completed usability research activities through the year. [Not started]
 
 ### Theme: Engagement
-#### Items:
 - **Outreach**
-  - Highlight successful contributions via blog and other media
-  - Create and share product marketing videos to encourage adoption
+  - Highlight successful contributions via blog and other media. [Not started]
+  - Create and share product marketing videos to encourage adoption. [Not started]
 
 ## Collaboration and support channels
-
 Check out our [Get involved page]({{ links.getInvolved }}) to learn about what we're working on and how you can contribute.
 Visit our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub repo</gcds-link> to report an issue or make a suggestion.

--- a/src/en/roadmap.md
+++ b/src/en/roadmap.md
@@ -14,12 +14,12 @@ eleventyNavigation:
 ## Timeline: Q1 (Apr - Jun 2024) 
 
 ### Theme: Product Growth
-- **Support for Server Side Rendering frameworks**
+#### Support for Server Side Rendering frameworks
   - Enable teams using NextJS (like GC Forms, OAS BE, Dental, EI) to code with GC Design System. [Completed]
   - Put a plan in place for integrating with Stencil when SSR support is released. [Deprioritized]
-- **Bilingual design library**
+#### Bilingual design library
   - Produce and maintain a bilingual Figma library, with assets and guidance in both official languages. [Completed]
-- **New functionality and improvements**
+#### New functionality and improvements
   - Full VueJS package. [Completed]
   - Improvements to Angular package (better support for event handling). [Completed]
   - Cards component version 2. [Completed]
@@ -29,32 +29,32 @@ eleventyNavigation:
   - Begin testing on canada.ca managed services (AEM, Drupal). [Completed]
 
 ### Theme: Research
-- **Accessibility, usability, and onboarding**
+#### Accessibility, usability, and onboarding
   - Research, interviews, surveys to improve onboarding, usability, accessibility. [Completed]
 
 ### Theme: Engagement
-- **Contribution model**
+#### Contribution model
   - Define and implement a contribution model with Design teams in GC. [Completed]
-- **Outreach**
+#### Outreach
   - Establish regular mailing lists to keep the community informed. [Completed]
   - Launch post demo surveys. [Completed]
 
 ## Timeline: Q2 (Jul - Sep 2024) 
 ### Theme: Product Growth
-- **New functionality and improvements**
+#### New functionality and improvements
   - 5 standard templates. [In progress]
   - Utility framework (alpha). [In progress]
   - New Components: Date input, Alert / Notice, Tags (Labels). [In progress]
   - Resolve any conflicting styles with Canada.ca mandatory components. [In progress]
 
 ### Theme: Research
-- **Accessibility, usability, and onboarding**
+#### Accessibility, usability, and onboarding
   - Establish product metrics. [In progress]
   - Identify and plan to resolve pain points, process for releasing breaking changes, Figma design library access. [In progress]
   - Conduct usability testing and accessibility testing with end users. [In progress]
 
 ### Theme: Engagement
-- **Outreach**
+#### Outreach
   - Establish a Service Level Agreement. [In progress]
   - Setup recurring scheduled demos with self sign up. [In progress]
   - Establish regular touchpoints with the community. [In progress]
@@ -62,42 +62,42 @@ eleventyNavigation:
 ## Timeline: Q3 (Oct - Dec 2024) 
 
 ### Theme: Product Growth
-- **Technical onboarding**
+#### Technical onboarding
   - Produce and test out a dedicated developer onboarding experience, including starter apps, technical documentation and more. [Not started]
   - Product and test out a dedicated designer onboarding experience. [Not started]
-- **CDTS functionality**
+#### CDTS functionality
   - Leveraging standard templates, provide the full functionality of Centrally Deployed Templates Solution (CDTS) to help with onboarding and adoption. [Not started]
-- **Integration with canada.ca**
+#### Integration with canada.ca
   - Increase access to GC Design System by offering a path from design.canada.ca. [Not started]
-- **Product metrics & analytics**
+#### Product metrics & analytics
   - Establish clear ways of measuring adoption and ROI. [Not started]
     - Adoption, time to build and cost saving, user satisfaction, fit of available adoption strategies (frameworks, touch points). [Not started]
 
 ### Theme: Research
-- **GC Design ecosystem and user needs research**
+#### GC Design ecosystem and user needs research
   - Understand the different Design System offerings and alternatives across GC. [In progress]
   - Understand and categorize the needs of different user groups across GC. [Not started]
   - Share evidence for accessibility and policy compliance on the GC Design System website. [Not started]
 
 ### Theme: Engagement
-- **Targeted demos**
+#### Targeted demos
   - Test "use case" targeted demos and Q&As for more personalized outreach. [Not started]
 
 ## Timeline: Q4 (Jan - Mar 2025) 
 
 ### Theme: Product Growth
-- **New functionality and improvements**
+#### New functionality and improvements
   - Aim for beta release [Not started]
   - Aim for a standardized process of integration with AEM and Drupal. [Not started]
   - Additional templates, patterns, and components as needed. [Not started]
 
 ### Theme: Research
-- **Testing**
+#### Testing
   - Accessibility testing completed with 30 people through the year. [In progress]
   - 5 completed usability research activities through the year. [Not started]
 
 ### Theme: Engagement
-- **Outreach**
+#### Outreach
   - Highlight successful contributions via blog and other media. [Not started]
   - Create and share product marketing videos to encourage adoption. [Not started]
 

--- a/src/fr/accessibilite.md
+++ b/src/fr/accessibilite.md
@@ -1,0 +1,13 @@
+---
+title: Accessibilité
+translationKey: accessibility
+layout: 'layouts/base.njk'
+eleventyNavigation:
+  key: accessibilityFR
+  title: Accessibilité
+  locale: fr
+  order: 4
+  hideMain: true
+---
+
+# Accessibilité

--- a/src/fr/accessibilite.md
+++ b/src/fr/accessibilite.md
@@ -8,6 +8,7 @@ eleventyNavigation:
   locale: fr
   order: 4
   hideMain: true
+nocrawl: true
 ---
 
 # Accessibilité

--- a/src/fr/feuille-de-route.md
+++ b/src/fr/feuille-de-route.md
@@ -15,94 +15,94 @@ eleventyNavigation:
 
 ### Thème: Croissance du produit
 - **Prise en charge d’infrastructures pour le rendu côté serveur**
-  - Permettre aux équipes utilisant NextJS (p. ex. : Formulaires GC, estimateur des prestations de la Sécurité de la vieillesse, soins dentaires, assurance-emploi) de coder à l’aide de Système de design GC. [Completed]
-  - Établir un plan d’intégration de Stencil une fois que le rendu côté serveur est déployé. [Completed]
+  - Permettre aux équipes utilisant NextJS (p. ex. : Formulaires GC, estimateur des prestations de la Sécurité de la vieillesse, soins dentaires, assurance-emploi) de coder à l’aide de Système de design GC. [Terminé]
+  - Établir un plan d’intégration de Stencil une fois que le rendu côté serveur est déployé. [Dépriorisé]
 
 - **Bibliothèque de design bilingue**
-  - Produire et entretenir une bibliothèque Figma bilingue, où les ressources et les lignes directrices sont dans les deux langues officielles. [Completed]
+  - Produire et entretenir une bibliothèque Figma bilingue, où les ressources et les lignes directrices sont dans les deux langues officielles. [Terminé]
 - **Nouvelles fonctionnalités et améliorations**
-  - Paquet VueJS complet. [Completed]
-  - Améliorations au paquet Angular (pour la gestion des évènements). [Completed]
-  - Version 2 du composant Carte. [Completed]
-  - Version 2 du composant Indicateur d'étape. [Completed]
-  - Composant Jeu de champ dans la bibliothèque de design Figma. [Completed]
-  - Icône (développé à l’interne, pas d’un paquet tiers). [In progress]
-  - Commencer les tests sur les services gérés de Canada.ca (AEM, Drupal). [Completed]
+  - Paquet VueJS complet. [Terminé]
+  - Améliorations au paquet Angular (pour la gestion des évènements). [Terminé]
+  - Version 2 du composant Carte. [Terminé]
+  - Version 2 du composant Indicateur d'étape. [Terminé]
+  - Composant Jeu de champ dans la bibliothèque de design Figma. [Terminé]
+  - Icône (développé à l’interne, pas d’un paquet tiers). [En cours]
+  - Commencer les tests sur les services gérés de Canada.ca (AEM, Drupal). [Terminé]
 
 ### Thème: Recherche
 - **Accessibilité, utilisabilité et intégration**
-  - Recherche, entretiens et sondages pour améliorer l’intégration, l’utilisabilité et l’accessibilité. [Completed]
+  - Recherche, entretiens et sondages pour améliorer l’intégration, l’utilisabilité et l’accessibilité. [Terminé]
 
 ### Thème: Mobilisation
 - **Modèle de contribution**
-  - Définir et mettre en œuvre un modèle de contribution pour les équipes de conception du GC. [Completed]
+  - Définir et mettre en œuvre un modèle de contribution pour les équipes de conception du GC. [Terminé]
 - **Sensibilisation**
-  - Mettre en place des listes d’envoi régulières pour tenir la communauté informée. [Completed]
-  - Lancer les sondages post-démo. [Completed]
+  - Mettre en place des listes d’envoi régulières pour tenir la communauté informée. [Terminé]
+  - Lancer les sondages post-démo. [Terminé]
 
 ## Échéancier: T2 (juillet à septembre 2024) 
 
 ### Thème: Croissance du produit
 - **Nouvelles fonctionnalités et améliorations**
-  - 5 modèles standards. [In progress]
-  - Cadre utilitaire (alpha). [In progress]
-  - Nouveaux composants : champ de date, alerte/avis, étiquette (tag). [In progress]
-  - Résoudre les conflits de style par rapport aux composants obligatoires de Canada.ca. [In progress]
+  - 5 modèles standards. [En cours]
+  - Cadre utilitaire (alpha). [En cours]
+  - Nouveaux composants : champ de date, alerte/avis, étiquette (tag). [En cours]
+  - Résoudre les conflits de style par rapport aux composants obligatoires de Canada.ca. [En cours]
 
 ### Thème: Recherche
 - **Accessibilité, utilisabilité et intégration**
-  - Mettre en place des indicateurs relatifs au produit. [In progress]
-  - Repérer les sources de difficulté et planifier leur résolution, processus pour publier des changements au code non rétrocompatibles, accès à la bibliothèque de design Figma. [In progress]
-  - Mener des tests d’utilisabilité et d’accessibilité avec des utilisatrices et utilisateurs. [In progress]
+  - Mettre en place des indicateurs relatifs au produit. [En cours]
+  - Repérer les sources de difficulté et planifier leur résolution, processus pour publier des changements au code non rétrocompatibles, accès à la bibliothèque de design Figma. [En cours]
+  - Mener des tests d’utilisabilité et d’accessibilité avec des utilisatrices et utilisateurs. [En cours]
 
 ### Thème: Mobilisation
 - **Sensibilisation**
-  - Mettre en place un accord sur les niveaux de service (ANS). [In progress]
-  - Mettre en place des démos récurrentes auxquelles les gens s’inscrivent. [In progress]
-  - Établir des points de contact réguliers avec la communauté. [In progress]
+  - Mettre en place un accord sur les niveaux de service (ANS). [En cours]
+  - Mettre en place des démos récurrentes auxquelles les gens s’inscrivent. [En cours]
+  - Établir des points de contact réguliers avec la communauté. [En cours]
 
 ## Échéancier: T3 (octobre à décembre 2024) 
 
 ### Thème: Croissance du produit
 - **Intégration technique**
-  - Élaborer et tester une expérience d’intégration pour les développeur·euse·s qui comprend des applications de démarrage, de la documentation technique, et autres. [Not started]
-  - Élaborer et tester une expérience d’intégration pour les concepteur·rice·s. [Not started]
+  - Élaborer et tester une expérience d’intégration pour les développeur·euse·s qui comprend des applications de démarrage, de la documentation technique, et autres. [Non commencé]
+  - Élaborer et tester une expérience d’intégration pour les concepteur·rice·s. [Non commencé]
 
 - **Fonctionnalité SGDC**
-  - Fournir, en utilisant les modèles standards, une fonctionnalité complète de la Solution de gabarits à déploiement centralisé (SGDC) qui facilitera l’intégration et l’adoption. [Not started]
+  - Fournir, en utilisant les modèles standards, une fonctionnalité complète de la Solution de gabarits à déploiement centralisé (SGDC) qui facilitera l’intégration et l’adoption. [Non commencé]
 - **Intégration avec Canada.ca**
-  - Augmenter l’accès vers Système de design GC en offrant une voie d’accès à partir de conception.canada.ca. [Not started]
+  - Augmenter l’accès vers Système de design GC en offrant une voie d’accès à partir de conception.canada.ca. [Non commencé]
 - **Indicateurs et données analytiques**
-  - Définir des façons claires de mesurer l’adoption et le rendement des investissements. [Not started]
-    - Adoption, temps de développement, économies, satisfaction utilisateur, adéquation des stratégies d’adoption à disposition (cadres d’adoption, points de contact). [Not started]
+  - Définir des façons claires de mesurer l’adoption et le rendement des investissements. [Non commencé]
+    - Adoption, temps de développement, économies, satisfaction utilisateur, adéquation des stratégies d’adoption à disposition (cadres d’adoption, points de contact). [Non commencé]
 
 ### Thème: Recherche
 - **Recherche sur l’écosystème et les besoins utilisateurs relatifs à la conception au GC**
-  - Comprendre les diverses offres et alternatives à Système de design au GC. [In progress]
-  - Comprendre et catégoriser les besoins des différents groupes utilisateurs au GC. [Not started]
-  - Montrer des preuves d’accessibilité et de conformité aux politiques sur le site Web de Système de design GC. [Not started]
+  - Comprendre les diverses offres et alternatives à Système de design au GC. [En cours]
+  - Comprendre et catégoriser les besoins des différents groupes utilisateurs au GC. [Non commencé]
+  - Montrer des preuves d’accessibilité et de conformité aux politiques sur le site Web de Système de design GC. [Non commencé]
 
 ### Thème: Mobilisation
 - **Démos ciblées**
-  - Tester des démos et des séances questions-réponses ciblant des « cas d’utilisation » précis pour une approche plus personnalisée. [Not started]
+  - Tester des démos et des séances questions-réponses ciblant des « cas d’utilisation » précis pour une approche plus personnalisée. [Non commencé]
 
 ## Échéancier: T4 (janvier à mars 2025)
 
 ### Thème: Croissance du produit
 - **Nouvelles fonctionnalités et améliorations**
-  - Viser une version bêta ou complète. [Not started]
-  - Viser un processus standardisé pour l’intégration avec AEM et Drupal. [Not started]
-  - Nouveaux modèles, patrons de conception et composants au besoin. [Not started]
+  - Viser une version bêta ou complète. [Non commencé]
+  - Viser un processus standardisé pour l’intégration avec AEM et Drupal. [Non commencé]
+  - Nouveaux modèles, patrons de conception et composants au besoin. [Non commencé]
 
 ### Thème: Recherche
 - **Tests**
-  - Tests d’accessibilité menés auprès de 30 personnes d’ici la fin du T4. [In progress]
-  - 5 activités de recherche portant sur l’utilisabilité achevées d’ici la fin du T4. [Not started]
+  - Tests d’accessibilité menés auprès de 30 personnes d’ici la fin du T4. [En cours]
+  - 5 activités de recherche portant sur l’utilisabilité achevées d’ici la fin du T4. [Non commencé]
 
 ### Thème: Mobilisation
 - **Sensibilisation**
-  - Mettre en valeur les contributions ayant porté fruit par le biais du blogue ou d’autres supports. [Not started]
-  - Créer et diffuser des vidéos marketing encourageant l’adoption du produit. [Not started]
+  - Mettre en valeur les contributions ayant porté fruit par le biais du blogue ou d’autres supports. [Non commencé]
+  - Créer et diffuser des vidéos marketing encourageant l’adoption du produit. [Non commencé]
 
 ## Canaux de collaboration et de soutien
 Consultez notre page [s'impliquer]({{ links.getInvolved }}) pour savoir sur quoi nous travaillons et comment vous pouvez y contribuer.

--- a/src/fr/feuille-de-route.md
+++ b/src/fr/feuille-de-route.md
@@ -14,13 +14,13 @@ eleventyNavigation:
 ## Échéancier: T1 (avril à juin 2024) 
 
 ### Thème: Croissance du produit
-- **Prise en charge d’infrastructures pour le rendu côté serveur**
+#### Prise en charge d’infrastructures pour le rendu côté serveur
   - Permettre aux équipes utilisant NextJS (p. ex. : Formulaires GC, estimateur des prestations de la Sécurité de la vieillesse, soins dentaires, assurance-emploi) de coder à l’aide de Système de design GC. [Terminé]
   - Établir un plan d’intégration de Stencil une fois que le rendu côté serveur est déployé. [Dépriorisé]
 
-- **Bibliothèque de design bilingue**
+#### Bibliothèque de design bilingue
   - Produire et entretenir une bibliothèque Figma bilingue, où les ressources et les lignes directrices sont dans les deux langues officielles. [Terminé]
-- **Nouvelles fonctionnalités et améliorations**
+#### Nouvelles fonctionnalités et améliorations
   - Paquet VueJS complet. [Terminé]
   - Améliorations au paquet Angular (pour la gestion des évènements). [Terminé]
   - Version 2 du composant Carte. [Terminé]
@@ -30,33 +30,33 @@ eleventyNavigation:
   - Commencer les tests sur les services gérés de Canada.ca (AEM, Drupal). [Terminé]
 
 ### Thème: Recherche
-- **Accessibilité, utilisabilité et intégration**
+#### Accessibilité, utilisabilité et intégration
   - Recherche, entretiens et sondages pour améliorer l’intégration, l’utilisabilité et l’accessibilité. [Terminé]
 
 ### Thème: Mobilisation
-- **Modèle de contribution**
+#### Modèle de contribution
   - Définir et mettre en œuvre un modèle de contribution pour les équipes de conception du GC. [Terminé]
-- **Sensibilisation**
+#### Sensibilisation
   - Mettre en place des listes d’envoi régulières pour tenir la communauté informée. [Terminé]
   - Lancer les sondages post-démo. [Terminé]
 
 ## Échéancier: T2 (juillet à septembre 2024) 
 
 ### Thème: Croissance du produit
-- **Nouvelles fonctionnalités et améliorations**
+#### Nouvelles fonctionnalités et améliorations
   - 5 modèles standards. [En cours]
   - Cadre utilitaire (alpha). [En cours]
   - Nouveaux composants : champ de date, alerte/avis, étiquette (tag). [En cours]
   - Résoudre les conflits de style par rapport aux composants obligatoires de Canada.ca. [En cours]
 
 ### Thème: Recherche
-- **Accessibilité, utilisabilité et intégration**
+#### Accessibilité, utilisabilité et intégration
   - Mettre en place des indicateurs relatifs au produit. [En cours]
   - Repérer les sources de difficulté et planifier leur résolution, processus pour publier des changements au code non rétrocompatibles, accès à la bibliothèque de design Figma. [En cours]
   - Mener des tests d’utilisabilité et d’accessibilité avec des utilisatrices et utilisateurs. [En cours]
 
 ### Thème: Mobilisation
-- **Sensibilisation**
+#### Sensibilisation
   - Mettre en place un accord sur les niveaux de service (ANS). [En cours]
   - Mettre en place des démos récurrentes auxquelles les gens s’inscrivent. [En cours]
   - Établir des points de contact réguliers avec la communauté. [En cours]
@@ -64,43 +64,43 @@ eleventyNavigation:
 ## Échéancier: T3 (octobre à décembre 2024) 
 
 ### Thème: Croissance du produit
-- **Intégration technique**
+#### Intégration technique
   - Élaborer et tester une expérience d’intégration pour les développeur·euse·s qui comprend des applications de démarrage, de la documentation technique, et autres. [Non commencé]
   - Élaborer et tester une expérience d’intégration pour les concepteur·rice·s. [Non commencé]
 
-- **Fonctionnalité SGDC**
+#### Fonctionnalité SGDC
   - Fournir, en utilisant les modèles standards, une fonctionnalité complète de la Solution de gabarits à déploiement centralisé (SGDC) qui facilitera l’intégration et l’adoption. [Non commencé]
-- **Intégration avec Canada.ca**
+#### Intégration avec Canada.ca
   - Augmenter l’accès vers Système de design GC en offrant une voie d’accès à partir de conception.canada.ca. [Non commencé]
-- **Indicateurs et données analytiques**
+#### Indicateurs et données analytiques
   - Définir des façons claires de mesurer l’adoption et le rendement des investissements. [Non commencé]
     - Adoption, temps de développement, économies, satisfaction utilisateur, adéquation des stratégies d’adoption à disposition (cadres d’adoption, points de contact). [Non commencé]
 
 ### Thème: Recherche
-- **Recherche sur l’écosystème et les besoins utilisateurs relatifs à la conception au GC**
+#### Recherche sur l’écosystème et les besoins utilisateurs relatifs à la conception au GC
   - Comprendre les diverses offres et alternatives à Système de design au GC. [En cours]
   - Comprendre et catégoriser les besoins des différents groupes utilisateurs au GC. [Non commencé]
   - Montrer des preuves d’accessibilité et de conformité aux politiques sur le site Web de Système de design GC. [Non commencé]
 
 ### Thème: Mobilisation
-- **Démos ciblées**
+#### Démos ciblées
   - Tester des démos et des séances questions-réponses ciblant des « cas d’utilisation » précis pour une approche plus personnalisée. [Non commencé]
 
 ## Échéancier: T4 (janvier à mars 2025)
 
 ### Thème: Croissance du produit
-- **Nouvelles fonctionnalités et améliorations**
+#### Nouvelles fonctionnalités et améliorations
   - Viser une version bêta ou complète. [Non commencé]
   - Viser un processus standardisé pour l’intégration avec AEM et Drupal. [Non commencé]
   - Nouveaux modèles, patrons de conception et composants au besoin. [Non commencé]
 
 ### Thème: Recherche
-- **Tests**
+#### Tests
   - Tests d’accessibilité menés auprès de 30 personnes d’ici la fin du T4. [En cours]
   - 5 activités de recherche portant sur l’utilisabilité achevées d’ici la fin du T4. [Non commencé]
 
 ### Thème: Mobilisation
-- **Sensibilisation**
+#### Sensibilisation
   - Mettre en valeur les contributions ayant porté fruit par le biais du blogue ou d’autres supports. [Non commencé]
   - Créer et diffuser des vidéos marketing encourageant l’adoption du produit. [Non commencé]
 

--- a/src/fr/feuille-de-route.md
+++ b/src/fr/feuille-de-route.md
@@ -14,110 +14,97 @@ eleventyNavigation:
 ## Échéancier: T1 (avril à juin 2024) 
 
 ### Thème: Croissance du produit
-
-#### Sujet:
 - **Prise en charge d’infrastructures pour le rendu côté serveur**
-  - Permettre aux équipes utilisant NextJS (p. ex. : Formulaires GC, estimateur des prestations de la Sécurité de la vieillesse, soins dentaires, assurance-emploi) de coder à l’aide de Système de design GC.
-  - Établir un plan d’intégration de Stencil une fois que le rendu côté serveur est déployé.
+  - Permettre aux équipes utilisant NextJS (p. ex. : Formulaires GC, estimateur des prestations de la Sécurité de la vieillesse, soins dentaires, assurance-emploi) de coder à l’aide de Système de design GC. [Completed]
+  - Établir un plan d’intégration de Stencil une fois que le rendu côté serveur est déployé. [Completed]
 
 - **Bibliothèque de design bilingue**
-  - Produire et entretenir une bibliothèque Figma bilingue, où les ressources et les lignes directrices sont dans les deux langues officielles.
+  - Produire et entretenir une bibliothèque Figma bilingue, où les ressources et les lignes directrices sont dans les deux langues officielles. [Completed]
 - **Nouvelles fonctionnalités et améliorations**
-  - Paquet VueJS complet
-  - Améliorations au paquet Angular (pour la gestion des évènements)
-  - Version 2 du composant Carte
-  - Composant Jeu de champ dans la bibliothèque de design Figma
-  - Nouveaux composants : icône (développé à l’interne, pas d’un paquet tiers), carte v2
-  - Commencer les tests sur les services gérés de Canada.ca (AEM, Drupal)
+  - Paquet VueJS complet. [Completed]
+  - Améliorations au paquet Angular (pour la gestion des évènements). [Completed]
+  - Version 2 du composant Carte. [Completed]
+  - Version 2 du composant Indicateur d'étape. [Completed]
+  - Composant Jeu de champ dans la bibliothèque de design Figma. [Completed]
+  - Icône (développé à l’interne, pas d’un paquet tiers). [In progress]
+  - Commencer les tests sur les services gérés de Canada.ca (AEM, Drupal). [Completed]
 
 ### Thème: Recherche
-#### Sujet:
 - **Accessibilité, utilisabilité et intégration**
-  - Recherche, entretiens et sondages pour améliorer l’intégration, l’utilisabilité et l’accessibilité.
+  - Recherche, entretiens et sondages pour améliorer l’intégration, l’utilisabilité et l’accessibilité. [Completed]
 
 ### Thème: Mobilisation
 - **Modèle de contribution**
-  - Définir et mettre en œuvre un modèle de contribution pour les équipes de conception du GC.
+  - Définir et mettre en œuvre un modèle de contribution pour les équipes de conception du GC. [Completed]
 - **Sensibilisation**
-  - Mettre en place des listes d’envoi régulières pour tenir la communauté informée.
-  - Lancer les sondages post-démo.
+  - Mettre en place des listes d’envoi régulières pour tenir la communauté informée. [Completed]
+  - Lancer les sondages post-démo. [Completed]
 
 ## Échéancier: T2 (juillet à septembre 2024) 
 
 ### Thème: Croissance du produit
-
-#### Sujet:
 - **Nouvelles fonctionnalités et améliorations**
-  - 5 modèles standards
-  - Cadre utilitaire (alpha)
-  - Nouveaux composants : champ de date, alerte/avis, étiquette (tag)
-  - Résoudre les conflits de style par rapport aux composants obligatoires de Canada.ca.
+  - 5 modèles standards. [In progress]
+  - Cadre utilitaire (alpha). [In progress]
+  - Nouveaux composants : champ de date, alerte/avis, étiquette (tag). [In progress]
+  - Résoudre les conflits de style par rapport aux composants obligatoires de Canada.ca. [In progress]
 
 ### Thème: Recherche
-#### Sujet:
 - **Accessibilité, utilisabilité et intégration**
-  - Mettre en place des indicateurs relatifs au produit
-  - Repérer les sources de difficulté et planifier leur résolution, processus pour publier des changements au code non rétrocompatibles, accès à la bibliothèque de design Figma
-  - Mener des tests d’utilisabilité et d’accessibilité avec des utilisatrices et utilisateurs.
+  - Mettre en place des indicateurs relatifs au produit. [In progress]
+  - Repérer les sources de difficulté et planifier leur résolution, processus pour publier des changements au code non rétrocompatibles, accès à la bibliothèque de design Figma. [In progress]
+  - Mener des tests d’utilisabilité et d’accessibilité avec des utilisatrices et utilisateurs. [In progress]
 
 ### Thème: Mobilisation
-#### Sujet:
 - **Sensibilisation**
-  - Mettre en place un accord sur les niveaux de service (ANS)
-  - Mettre en place des démos récurrentes auxquelles les gens s’inscrivent
-  - Établir des points de contact réguliers avec la communauté.
+  - Mettre en place un accord sur les niveaux de service (ANS). [In progress]
+  - Mettre en place des démos récurrentes auxquelles les gens s’inscrivent. [In progress]
+  - Établir des points de contact réguliers avec la communauté. [In progress]
 
 ## Échéancier: T3 (octobre à décembre 2024) 
 
 ### Thème: Croissance du produit
-#### Sujet:
 - **Intégration technique**
-  - Élaborer et tester une expérience d’intégration pour les développeur·euse·s qui comprend des applications de démarrage, de la documentation technique, et autres.
-  - Élaborer et tester une expérience d’intégration pour les concepteur·rice·s.
+  - Élaborer et tester une expérience d’intégration pour les développeur·euse·s qui comprend des applications de démarrage, de la documentation technique, et autres. [Not started]
+  - Élaborer et tester une expérience d’intégration pour les concepteur·rice·s. [Not started]
 
 - **Fonctionnalité SGDC**
-  - Fournir, en utilisant les modèles standards, une fonctionnalité complète de la Solution de gabarits à déploiement centralisé (SGDC) qui facilitera l’intégration et l’adoption.
+  - Fournir, en utilisant les modèles standards, une fonctionnalité complète de la Solution de gabarits à déploiement centralisé (SGDC) qui facilitera l’intégration et l’adoption. [Not started]
 - **Intégration avec Canada.ca**
-  - Augmenter l’accès vers Système de design GC en offrant une voie d’accès à partir de conception.canada.ca.
+  - Augmenter l’accès vers Système de design GC en offrant une voie d’accès à partir de conception.canada.ca. [Not started]
 - **Indicateurs et données analytiques**
-  - Définir des façons claires de mesurer l’adoption et le rendement des investissements.
-    - Adoption, temps de développement, économies, satisfaction utilisateur, adéquation des stratégies d’adoption à disposition (cadres d’adoption, points de contact).
+  - Définir des façons claires de mesurer l’adoption et le rendement des investissements. [Not started]
+    - Adoption, temps de développement, économies, satisfaction utilisateur, adéquation des stratégies d’adoption à disposition (cadres d’adoption, points de contact). [Not started]
 
 ### Thème: Recherche
-#### Sujet:
 - **Recherche sur l’écosystème et les besoins utilisateurs relatifs à la conception au GC**
-  - Comprendre les diverses offres et alternatives à Système de design au GC
-  - Comprendre et catégoriser les besoins des différents groupes utilisateurs au GC
-  - Montrer des preuves d’accessibilité et de conformité aux politiques sur le site Web de Système de design GC.
+  - Comprendre les diverses offres et alternatives à Système de design au GC. [In progress]
+  - Comprendre et catégoriser les besoins des différents groupes utilisateurs au GC. [Not started]
+  - Montrer des preuves d’accessibilité et de conformité aux politiques sur le site Web de Système de design GC. [Not started]
 
 ### Thème: Mobilisation
-#### Sujet:
 - **Démos ciblées**
-  - Tester des démos et des séances questions-réponses ciblant des « cas d’utilisation » précis pour une approche plus personnalisée.
+  - Tester des démos et des séances questions-réponses ciblant des « cas d’utilisation » précis pour une approche plus personnalisée. [Not started]
 
 ## Échéancier: T4 (janvier à mars 2025)
 
 ### Thème: Croissance du produit
-#### Sujet:
 - **Nouvelles fonctionnalités et améliorations**
-  - Viser une version bêta ou complète
-  - Viser un processus standardisé pour l’intégration avec AEM et Drupal
-  - Nouveaux modèles, patrons de conception et composants au besoin.
+  - Viser une version bêta ou complète. [Not started]
+  - Viser un processus standardisé pour l’intégration avec AEM et Drupal. [Not started]
+  - Nouveaux modèles, patrons de conception et composants au besoin. [Not started]
 
 ### Thème: Recherche
-#### Sujet:
 - **Tests**
-  - Tests d’accessibilité menés auprès de 30 personnes d’ici la fin du T4
-  - 5 activités de recherche portant sur l’utilisabilité achevées d’ici la fin du T4.
+  - Tests d’accessibilité menés auprès de 30 personnes d’ici la fin du T4. [In progress]
+  - 5 activités de recherche portant sur l’utilisabilité achevées d’ici la fin du T4. [Not started]
 
 ### Thème: Mobilisation
-#### Sujet:
 - **Sensibilisation**
-  - Mettre en valeur les contributions ayant porté fruit par le biais du blogue ou d’autres supports
-  - Créer et diffuser des vidéos marketing encourageant l’adoption du produit
+  - Mettre en valeur les contributions ayant porté fruit par le biais du blogue ou d’autres supports. [Not started]
+  - Créer et diffuser des vidéos marketing encourageant l’adoption du produit. [Not started]
 
 ## Canaux de collaboration et de soutien
-
 Consultez notre page [s'impliquer]({{ links.getInvolved }}) pour savoir sur quoi nous travaillons et comment vous pouvez y contribuer.
 
 Visitez notre <gcds-link external href="{{ links.githubCompsIssues }}">référentiel GitHub</gcds-link> pour signaler un problème ou faire une suggestion.


### PR DESCRIPTION
# Summary | Résumé

Adding a new accessibility page.
Changes to the Roadmap pages in EN and FR: fixes, styling changes, adding status for each item.
