### PR TITLE
fix: Remove extra line from card description

### DIFF
--- a/src/en/components/card/base.md
+++ b/src/en/components/card/base.md
@@ -15,6 +15,6 @@ A card is a box containing structured, actionable content on a single topic.
 {% enddocLinks %}
 
 {% componentPreview "Card component preview" %}
-<gcds-card card-title="Card title link" badge="Tag" href="#" description="Description or supporting text relating to the headline. Longer text will be truncated with ...">
+<gcds-card card-title="Card title link" badge="Tag" href="#" description="Description or supporting text relating to the headline.">
 </gcds-card>
 {% endcomponentPreview %}

--- a/src/fr/composants/carte/base.md
+++ b/src/fr/composants/carte/base.md
@@ -15,6 +15,6 @@ La carte est un encadré contenant du contenu structuré et pratique sur un suje
 {% enddocLinks %}
 
 {% componentPreview "Aperçu du composant de carte" %}
-<gcds-card card-title="Titre de la carte" badge="Balise" description="Description destinée à accompagner le titre. Les textes plus longs seront tronqués avec ..." href="#">
+<gcds-card card-title="Titre de la carte" badge="Balise" description="Description destinée à accompagner le titre." href="#">
 </gcds-card>
 {% endcomponentPreview %}


### PR DESCRIPTION
# Summary | Résumé

Remove 'Longer text will be truncated with...' from card previews.
