### PR TITLE
chore: add our cdn domain to the csp

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -20,7 +20,7 @@ customHeaders:
           report-uri https://csp-report-to.security.cdssandbox.xyz/report;
           default-src 'self' https://kit.fontawesome.com/ https://cdn.jsdelivr.net/npm/;
           font-src 'self' fonts.gstatic.com https://unpkg.com/font-awesome@4.7.0/ https://cdnjs.cloudflare.com/ajax/libs/font-awesome/;
-          script-src 'self' 'wasm-unsafe-eval' www.googletagmanager.com www.google-analytics.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/ 'unsafe-inline';
+          script-src 'self' 'wasm-unsafe-eval' https://cdn.design-system.alpha.canada.ca www.googletagmanager.com www.google-analytics.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/ 'unsafe-inline';
           frame-src www.googletagmanager.com www.google-analytics.com https://cds-snc.github.io/;
           connect-src 'self' www.googletagmanager.com www.google-analytics.com www.canada.ca;
           img-src 'self' data: https: www.w3.org;


### PR DESCRIPTION
# Summary | Résumé


The preview for the basic page templates aren't showing up, even if they're a subdomain. We need to add it explicitly.


[Basic Page Templates Preview FRENCH](https://pr-448.d35vdwuoev573o.amplifyapp.com/fr/modeles-de-page/basic/apercu/)
[Basic Page Templates Preview ENGLISH](https://pr-448.djtlis5vpn8jd.amplifyapp.com/en/page-templates/basic/preview/)