### PR TITLE
Updating github token and version of workflow for evently build workflow

### DIFF
--- a/.github/workflows/build-eleventy.yaml
+++ b/.github/workflows/build-eleventy.yaml
@@ -25,8 +25,8 @@ jobs:
           mkdir -p ./_site/.github/workflows/
           cp -r ./.github/workflows/a11y-tests.yaml ./_site/.github/workflows/a11y-tests.yaml
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           publish_dir: ./_site
-          github_token: ${{ secrets.ACCESS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           exclude_assets: 'admin/index.html,admin/config.yml'


### PR DESCRIPTION
# Summary | Résumé

Updated the workflow to use the GITHUB_TOKEN and updated the peaceiris/actions-gh-pages github action to use the latest version. 
