### PR TITLE
feat: Add register for demo page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -354,7 +354,7 @@ module.exports = function (eleventyConfig) {
                   }
                 </time>`;
 
-                return `<li>${datelink} - ${time}</li>`;
+                return `<li>${datelink} – ${time}</li>`;
               }
             })
             .join('')}

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -309,44 +309,60 @@ module.exports = function (eleventyConfig) {
           enDemo: 'English demo',
           frDemo: 'French demo',
           timezone: 'Eastern time',
+          nodates: 'No upcoming dates.',
         },
         fr: {
           enDemo: 'Démonstration en anglais',
           frDemo: 'Démonstration en français',
           timezone: 'HAE',
+          nodates: 'Aucune date à venir.',
         },
       };
 
-      return `
-      <ul class="mb-300">
-        ${demoDates
-          .map(date => {
-            const options = {
-              weekday: 'long',
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-              timeZone: 'UTC',
-            };
-            const prnDt = new Date(date.date).toLocaleString(locale, options);
+      let validDates = [];
 
-            const datelink = `<gcds-link external href="${date.link}">${date.lang === 'en' ? langStrings[locale].enDemo : langStrings[locale].frDemo}</gcds-link>`;
-            const time = `<time>
-              ${
-                locale === 'en'
-                  ? `${prnDt}, ${convertTime(date.starttime)} - ${convertTime(date.endtime)} ${langStrings[locale].timezone}`
-                  : `${prnDt}, de ${date.starttime.replace(':', 'h')} à ${date.endtime.replace(':', 'h')} ${langStrings[locale].timezone}`
+      demoDates.map(date => {
+        if (new Date() < new Date(date.date)) {
+          validDates.push(date.date);
+        }
+      });
+
+      if (validDates.length > 0) {
+        return `
+        <ul class="mb-300">
+          ${demoDates
+            .map(date => {
+              if (validDates.includes(date.date)) {
+                const options = {
+                  weekday: 'long',
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                  timeZone: 'UTC',
+                };
+                const prnDt = new Date(date.date).toLocaleString(
+                  locale,
+                  options,
+                );
+
+                const datelink = `<gcds-link external href="${date.link}">${date.lang === 'en' ? langStrings[locale].enDemo : langStrings[locale].frDemo}</gcds-link>`;
+                const time = `<time>
+                  ${
+                    locale === 'en'
+                      ? `${prnDt}, ${convertTime(date.starttime)} - ${convertTime(date.endtime)} ${langStrings[locale].timezone}`
+                      : `${prnDt}, de ${date.starttime.replace(':', 'h')} à ${date.endtime.replace(':', 'h')} ${langStrings[locale].timezone}`
+                  }
+                </time>`;
+
+                return `<li>${datelink} - ${time}</li>`;
               }
-            </time>`;
-
-            // Don't render link if date has passed
-            if (new Date() < new Date(date.date)) {
-              return `<li>${datelink} - ${time}</li>`;
-            }
-          })
-          .join('')}
-      </ul>
-    `;
+            })
+            .join('')}
+        </ul>
+      `;
+      } else {
+        return `<p>${langStrings[locale].nodates}</p>`;
+      }
     },
   );
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -349,7 +349,7 @@ module.exports = function (eleventyConfig) {
                 const time = `<time>
                   ${
                     locale === 'en'
-                      ? `${prnDt}, ${convertTime(date.starttime)} - ${convertTime(date.endtime)} ${langStrings[locale].timezone}`
+                      ? `${prnDt}, ${convertTime(date.starttime)} – ${convertTime(date.endtime)} ${langStrings[locale].timezone}`
                       : `${prnDt}, de ${date.starttime.replace(':', 'h')} à ${date.endtime.replace(':', 'h')} ${langStrings[locale].timezone}`
                   }
                 </time>`;

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -314,7 +314,7 @@ module.exports = function (eleventyConfig) {
         fr: {
           enDemo: 'Démo en anglais',
           frDemo: 'Démonstration en français',
-          timezone: 'HAE',
+          timezone: 'heure de l'Est',
           nodates: 'Aucune date à venir.',
         },
       };

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -313,7 +313,7 @@ module.exports = function (eleventyConfig) {
         },
         fr: {
           enDemo: 'Démo en anglais',
-          frDemo: 'Démonstration en français',
+          frDemo: 'Démo en français',
           timezone: 'heure de l\'Est',
           nodates: 'Aucune date à venir.',
         },

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -312,7 +312,7 @@ module.exports = function (eleventyConfig) {
           nodates: 'No upcoming dates.',
         },
         fr: {
-          enDemo: 'Démonstration en anglais',
+          enDemo: 'Démo en anglais',
           frDemo: 'Démonstration en français',
           timezone: 'HAE',
           nodates: 'Aucune date à venir.',

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -330,7 +330,7 @@ module.exports = function (eleventyConfig) {
             };
             const prnDt = new Date(date.date).toLocaleString(locale, options);
 
-            const datelink = `<a href="${date.link}">${date.lang === 'en' ? langStrings[locale].enDemo : langStrings[locale].frDemo}</a>`;
+            const datelink = `<gcds-link external href="${date.link}">${date.lang === 'en' ? langStrings[locale].enDemo : langStrings[locale].frDemo}</gcds-link>`;
             const time = `<time>
               ${
                 locale === 'en'

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -314,7 +314,7 @@ module.exports = function (eleventyConfig) {
         fr: {
           enDemo: 'Démo en anglais',
           frDemo: 'Démonstration en français',
-          timezone: 'heure de l'Est',
+          timezone: 'heure de l\'Est',
           nodates: 'Aucune date à venir.',
         },
       };

--- a/src/_data/registerdemos.js
+++ b/src/_data/registerdemos.js
@@ -1,0 +1,16 @@
+module.exports = [
+  {
+    date: "2025-01-21",
+    starttime: "13:00",
+    endtime: "14:00",
+    lang: 'en',
+    link: 'https://events.teams.microsoft.com/event/1edc84d5-f075-4615-b7c1-b968a15dad9e@9ed55846-8a81-4246-acd8-b1a01abfc0d1'
+  },
+  {
+    date: "2025-01-28",
+    starttime: "13:00",
+    endtime: "14:00",
+    lang: 'fr',
+    link: 'https://events.teams.microsoft.com/event/a9bfe87d-4692-465c-a6db-a9c5ef377175@9ed55846-8a81-4246-acd8-b1a01abfc0d1'
+  }
+]

--- a/src/en/en.json
+++ b/src/en/en.json
@@ -56,6 +56,7 @@
     "contactMail": "mailto:cds-snc@servicecanada.gc.ca",
     "getInvolved": "/en/get-involved",
     "roadmap": "/en/roadmap",
+    "regsterDemo": "/en/register-for-a-demo",
 
     "comingSoon": "/en/coming-soon",
     "demo": "/en/demo",

--- a/src/en/en.json
+++ b/src/en/en.json
@@ -56,7 +56,7 @@
     "contactMail": "mailto:cds-snc@servicecanada.gc.ca",
     "getInvolved": "/en/get-involved",
     "roadmap": "/en/roadmap",
-    "regsterDemo": "/en/register-for-a-demo",
+    "registerDemo": "/en/register-for-a-demo",
 
     "comingSoon": "/en/coming-soon",
     "demo": "/en/demo",

--- a/src/en/register-for-a-demo.md
+++ b/src/en/register-for-a-demo.md
@@ -23,9 +23,9 @@ Can’t find a time that works for you? [Contact us]({{ links.contact }}).
 - Learn how you can use GC Design System to prototype and develop web experiences.
 - Get answers to your questions directly from the GC Design System team.
 
-<div>
+## Available demos
+
 {% registerForDemoLinks locale %}
 {% endregisterForDemoLinks %}
-</div>
 
 {% include "partials/givefeedback.njk" %}

--- a/src/en/register-for-a-demo.md
+++ b/src/en/register-for-a-demo.md
@@ -19,7 +19,7 @@ Can’t find a time that works for you? [Contact us]({{ links.contact }}).
 
 ## What to expect
 
-- Explore GC Design System components, templates and design tokens
+- Explore GC Design System components, templates, and design tokens
 - Learn how you can use GC Design System to prototype and develop web experiences.
 - Get answers to your questions directly from the GC Design System team.
 

--- a/src/en/register-for-a-demo.md
+++ b/src/en/register-for-a-demo.md
@@ -1,0 +1,31 @@
+---
+title: Register for a demo
+translationKey: registerfordemo
+layout: 'layouts/base.njk'
+eleventyNavigation:
+  key: registerfordemoEN
+  title: Register for a demo
+  locale: en
+  order: 5
+  hideMain: true
+templateEngineOverride: njk,md
+---
+
+# Register for a Demo
+
+Looking to learn more about GC Design System before trying it out? Register to one of the GC Design System upcoming demos.
+
+Can’t find a time that works for you? [Contact us]({{ links.contact }}).
+
+## What to expect
+
+- Explore GC Design System components, templates and design tokens
+- Learn how you can use GC Design System to prototype and develop web experiences.
+- Get answers to your questions directly from the GC Design System team.
+
+<div>
+{% registerForDemoLinks locale %}
+{% endregisterForDemoLinks %}
+</div>
+
+{% include "partials/givefeedback.njk" %}

--- a/src/en/register-for-a-demo.md
+++ b/src/en/register-for-a-demo.md
@@ -13,7 +13,7 @@ templateEngineOverride: njk,md
 
 # Register for a Demo
 
-Looking to learn more about GC Design System before trying it out? Register to one of the GC Design System upcoming demos.
+Looking to learn more about GC Design System before trying it out? Attend an upcoming demo.
 
 Can’t find a time that works for you? [Contact us]({{ links.contact }}).
 

--- a/src/en/register-for-a-demo.md
+++ b/src/en/register-for-a-demo.md
@@ -19,7 +19,7 @@ Can’t find a time that works for you? [Contact us]({{ links.contact }}).
 
 ## What to expect
 
-- Explore GC Design System components, templates, and design tokens
+- Explore GC Design System components, templates, and design tokens.
 - Learn how you can use GC Design System to prototype and develop web experiences.
 - Get answers to your questions directly from the GC Design System team.
 

--- a/src/en/register-for-a-demo.md
+++ b/src/en/register-for-a-demo.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 templateEngineOverride: njk,md
 ---
 
-# Register for a Demo
+# Register for a demo
 
 Looking to learn more about GC Design System before trying it out? Attend an upcoming demo.
 

--- a/src/fr/fr.json
+++ b/src/fr/fr.json
@@ -56,7 +56,7 @@
     "contactMail": "mailto:cds-snc@servicecanada.gc.ca",
     "getInvolved": "/fr/simpliquer",
     "roadmap": "/fr/feuille-de-route",
-    "regsterDemo": "/fr/inscrivez-vous-a-une-demonstration",
+    "registerDemo": "/fr/inscrivez-vous-a-une-demonstration",
 
     "comingSoon": "/fr/developpement-en-cours",
     "demo": "/fr/demo",

--- a/src/fr/fr.json
+++ b/src/fr/fr.json
@@ -56,6 +56,7 @@
     "contactMail": "mailto:cds-snc@servicecanada.gc.ca",
     "getInvolved": "/fr/simpliquer",
     "roadmap": "/fr/feuille-de-route",
+    "regsterDemo": "/fr/inscrivez-vous-a-une-demonstration",
 
     "comingSoon": "/fr/developpement-en-cours",
     "demo": "/fr/demo",

--- a/src/fr/inscrivez-vous-a-une-demonstration.md
+++ b/src/fr/inscrivez-vous-a-une-demonstration.md
@@ -23,9 +23,9 @@ Vous ne trouvez pas un horaire qui vous convient? [Contactez-nous]({{ links.cont
 - Apprenez comment utiliser le Système de design GC pour créer des prototypes et développer des expériences web.
 - Obtenez des réponses à vos questions directement de l'équipe du Système de design GC.
 
-<div>
+## Démos disponibles
+
 {% registerForDemoLinks locale %}
 {% endregisterForDemoLinks %}
-</div>
 
 {% include "partials/givefeedback.njk" %}

--- a/src/fr/inscrivez-vous-a-une-demonstration.md
+++ b/src/fr/inscrivez-vous-a-une-demonstration.md
@@ -13,7 +13,7 @@ templateEngineOverride: njk,md
 
 # Inscrivez-vous à une démonstration
 
-Vous souhaitez en savoir plus sur le Système de design GC avant de l'essayer? Inscrivez-vous à l'une des prochaines démonstrations du Système de design GC.
+Vous souhaitez en savoir plus sur le Système de design GC avant de l'essayer? Participez à l'une des prochaines démos.
 
 Vous ne trouvez pas un horaire qui vous convient? [Contactez-nous]({{ links.contact }}).
 

--- a/src/fr/inscrivez-vous-a-une-demonstration.md
+++ b/src/fr/inscrivez-vous-a-une-demonstration.md
@@ -1,0 +1,31 @@
+---
+title: Inscrivez-vous à une démonstration
+translationKey: registerfordemo
+layout: 'layouts/base.njk'
+eleventyNavigation:
+  key: registerfordemoFR
+  title: Inscrivez-vous à une démonstration
+  locale: fr
+  order: 5
+  hideMain: true
+templateEngineOverride: njk,md
+---
+
+# Inscrivez-vous à une démonstration
+
+Vous souhaitez en savoir plus sur le Système de design GC avant de l'essayer? Inscrivez-vous à l'une des prochaines démonstrations du Système de design GC.
+
+Vous ne trouvez pas un horaire qui vous convient? [Contactez-nous]({{ links.contact }}).
+
+## À quoi s'attendre
+
+- Découvrez les composants, modèles de page et unités de style du Système de design GC.
+- Apprenez comment utiliser le Système de design GC pour créer des prototypes et développer des expériences web.
+- Obtenez des réponses à vos questions directement de l'équipe du Système de design GC.
+
+<div>
+{% registerForDemoLinks locale %}
+{% endregisterForDemoLinks %}
+</div>
+
+{% include "partials/givefeedback.njk" %}

--- a/src/fr/inscrivez-vous-a-une-demonstration.md
+++ b/src/fr/inscrivez-vous-a-une-demonstration.md
@@ -11,7 +11,7 @@ eleventyNavigation:
 templateEngineOverride: njk,md
 ---
 
-# Inscrivez-vous à une démonstration
+# Inscrivez-vous à une démo
 
 Vous souhaitez en savoir plus sur le Système de design GC avant de l'essayer? Participez à l'une des prochaines démos.
 


### PR DESCRIPTION
# Summary | Résumé

Add register for demo page (/en/register-for-a-demo/) to allow visitors to our site to see upcoming demos and register to attend the demos.

The demos are generated using the `/src/_data/registerdemos.js` data file.

## Example of demo object

```js
  {
    date: "2025-01-21", // YYYY-MM-DD format
    starttime: "13:00",   // 24h hour format
    endtime: "14:00",    // 24h hour format
    lang: 'en',         // en or fr
    link: 'https://examplelink.link/' 
 },
```

[English page](https://pr-455.djtlis5vpn8jd.amplifyapp.com/en/register-for-a-demo)
[French page](https://pr-455.d35vdwuoev573o.amplifyapp.com/fr/inscrivez-vous-a-une-demonstration/)