### PR TITLE
chore: add additional instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ We are using [11ty](https://www.11ty.dev/docs/) to build our documentation websi
 
 - Clone the repo `git clone https://github.com/cds-snc/gcds-docs`.
 - Run `npm install` to install all Node.js dependencies.
+- Run `npm run build` to run the Eleventy build process.
 - Run `npm start` to start a hot-reloading local web server.
 - The site will be accessible on http://localhost:8080/en or http://localhost:8080/fr. You have to append the `/en` and `/fr` as there is no page available at the base url
   <br/>
@@ -91,7 +92,7 @@ Nous utilisons [11ty](https://www.11ty.dev/docs/) pour construire notre site Web
 - Exécutez ensuite `npm install` pour installer toutes les dépendances Node.js.
 - Exécutez `npm start` pour démarrer un serveur Web avec rechargement à chaud.
 - Le site sera accessible sur http://localhost:8080/fr or http://localhost:8080/en. Vous devrez ajouter `/fr` ou `/en` en suffixe car il n'y a pas de page disponible à l'URL de base.
-    
+
   <br/>
 
 ## Ajouter de nouvelles pages

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We are using [11ty](https://www.11ty.dev/docs/) to build our documentation websi
 
 - Clone the repo `git clone https://github.com/cds-snc/gcds-docs`.
 - Run `npm install` to install all Node.js dependencies.
-- Run `npm run build` to run the Eleventy build process.
+- Run `npm run build` to initiate the Eleventy build process.
 - Run `npm start` to start a hot-reloading local web server.
 - The site will be accessible on http://localhost:8080/en or http://localhost:8080/fr. You have to append the `/en` and `/fr` as there is no page available at the base url
   <br/>
@@ -90,6 +90,7 @@ Nous utilisons [11ty](https://www.11ty.dev/docs/) pour construire notre site Web
 
 - Copiez le référentiel `git clone https://github.com/cds-snc/gcds-docs`.
 - Exécutez ensuite `npm install` pour installer toutes les dépendances Node.js.
+- Exécutez `npm run build` pour lancer le processus de développement Eleventy.
 - Exécutez `npm start` pour démarrer un serveur Web avec rechargement à chaud.
 - Le site sera accessible sur http://localhost:8080/fr or http://localhost:8080/en. Vous devrez ajouter `/fr` ou `/en` en suffixe car il n'y a pas de page disponible à l'URL de base.
 


### PR DESCRIPTION
# Summary | Résumé

Adding a small addition to our installation instructions. After incorporating the templates into the documentation site, it is necessary to run `npm run build` before running `npm start` for the first time to ensure the application functions correctly.

## Changes

Updated the installation steps to include the `npm run build` command before `npm start`.

## Note

I'm still waiting for the French translation. I will update this PR once I hear back from the translation team.