### PR TITLE
fix: typo in main navigation

### DIFF
--- a/src/_data/nav.js
+++ b/src/_data/nav.js
@@ -1,6 +1,6 @@
 module.exports = {
   en: {
-    title: 'GC Design system',
+    title: 'GC Design System',
     url: '/en',
     label: 'Main menu',
   },


### PR DESCRIPTION
# Summary | Résumé

The 's' in GC Design System in the main navigation should be 'S'
