### PR TITLE
Update footer.js - Change Contextual footer heading

### DIFF
--- a/src/_data/footer.js
+++ b/src/_data/footer.js
@@ -1,7 +1,7 @@
 module.exports = {
   en: {
     contextual: {
-      heading: 'Canadian Digital Service',
+      heading: 'GC Design System',
       list: 'Contact us',
       listurl: '/en/contact',
       issue: 'Report an issue',
@@ -23,7 +23,7 @@ module.exports = {
   },
   fr: {
     contextual: {
-      heading: 'Service numérique canadien',
+      heading: 'Système de design GC',
       list: "Contactez-nous",
       listurl: '/fr/contactez',
       issue: 'Signaler un problème',


### PR DESCRIPTION


# Summary | Résumé

Change contextual footer heading from "Canadian Digital Service" to "GC Design System" and "Service numérique canadien" to "Système de design GC"

The links direct to GC Design System pages; it was previously misleading with CDS as the Heading.  

For reference on appropriateness, "Digital Transformation Office" posts their team name in their contextual footer heading.

Ref to Github issue #1361

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
