### PR TITLE
docs: fix font weight table position on typography page

### DIFF
--- a/src/en/styles/typography/typography.md
+++ b/src/en/styles/typography/typography.md
@@ -97,6 +97,8 @@ The font family contains fallback values. The fallback is a substitute value for
 - Be mindful in establishing emphasis in an accessible way, many assistive technologies ignore font weights.
 - Instead of font weights, consider using bullets or increasing white space to break up text.
 
+{% include "partials/token_table.njk", token: 'fontWeights', type: 'fontWeights' %}
+
 ### Bold text
 
 - Maintain the default bold setting for headings.
@@ -106,8 +108,6 @@ The font family contains fallback values. The fallback is a substitute value for
 
 - Use italics when referencing a Canadian law, as in _Accessible Canada Act_.
 - Limit your use of italics to short strings of text. Long passages in italics can create cognitive processing difficulties for sighted readers.
-
-{% include "partials/token_table.njk", token: 'fontWeights', type: 'fontWeights' %}
 
 <br/>
 

--- a/src/fr/styles/typographie/typographie.md
+++ b/src/fr/styles/typographie/typographie.md
@@ -98,6 +98,8 @@ La famille de police comprend des valeurs de rechange. Les valeurs de rechange s
 - Veillez à accentuer des éléments de façon accessible, car plusieurs technologies d'assistance ne tiennent pas compte de l'épaisseur de la police.
 - Plutôt que de modifier l'épaisseur de la police, envisagez d'utiliser des puces ou des alinéas pour découper le texte.
 
+{% include "partials/token_table.njk", token: 'fontWeights', type: 'fontWeights' %}
+
 ### Caractères gras
 
 - Conservez le réglage des caractères gras par défaut pour les en-têtes.
@@ -107,8 +109,6 @@ La famille de police comprend des valeurs de rechange. Les valeurs de rechange s
 
 - Mettez toute référence à un projet de loi canadien en caractères italiques, par example, _Loi canadienne sur l'accessibilité_.
 - N'utilisez les caractères en italiques que pour de courts passages. Un gros volume de texte en caractères italiques peut rendre difficile le traitement cognitif pour certains lecteurs.
-
-{% include "partials/token_table.njk", token: 'fontWeights', type: 'fontWeights' %}
 
 <br/>
 


### PR DESCRIPTION
# Summary | Résumé

When checking something on our typography page, I noticed that the font weights table was positioned below the "Italics" content section instead of the "Font weights" content section. I moved the table in EN and FR to be placed right below the "Font weight" content.

## Screenshots

Before:

![Screenshot 2025-01-30 at 11 42 03 AM](https://github.com/user-attachments/assets/8a9c0b70-fcdb-4cf2-b929-a3ad7960399d)

After:

![Screenshot 2025-01-30 at 11 42 36 AM](https://github.com/user-attachments/assets/d39586c4-3de1-4d7b-a0b6-ac7563eb0656)

