### PR TITLE
fix: Component preview iframe permissions

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -21,7 +21,7 @@ customHeaders:
           default-src 'self' https://kit.fontawesome.com/ https://cdn.jsdelivr.net/npm/;
           font-src 'self' fonts.gstatic.com https://unpkg.com/font-awesome@4.7.0/ https://cdnjs.cloudflare.com/ajax/libs/font-awesome/;
           script-src 'self' 'wasm-unsafe-eval' https://cdn.design-system.alpha.canada.ca www.googletagmanager.com www.google-analytics.com https://cdnjs.cloudflare.com/ajax/libs/font-awesome/ https://cdn.jsdelivr.net/npm/ 'unsafe-inline';
-          frame-src www.googletagmanager.com www.google-analytics.com https://cds-snc.github.io/;
+          frame-src www.googletagmanager.com www.google-analytics.com https://cds-snc.github.io/ https://design-system.alpha.canada.ca/ https://systeme-design.alpha.canada.ca/;
           connect-src 'self' www.googletagmanager.com www.google-analytics.com www.canada.ca;
           img-src 'self' data: https: www.w3.org;
           style-src 'unsafe-inline' https: 'strict-dynamic' 'self' https://fonts.googleapis.com;


### PR DESCRIPTION
# Summary | Résumé

Currently the component preview iframes are being blocked by the Content Security Policy. Adding the site's domains to the list to allow iframe.

See https://design-system.alpha.canada.ca/en/components/grid/code/ for error
