### PR TITLE
chore: update contact us form

### DIFF
--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -22,7 +22,11 @@ With an account, use our <gcds-link external href="{{ links.githubCompsIssues }}
 
 ## Give feedback, request support, or sign up
 
+We support government employees using GC Design System. We cannot answer questions from members of the public.
+
 Use this form to provide feedback or ask questions, get help using GC Design System, or sign up for our mailing list or demo.
+
+For other enquiries, go to the [Government of Canada contacts page](https://www.canada.ca/en/contact.html) to find the department or agency that can help.
 
 <form class="my-600 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactEN" />
@@ -30,7 +34,7 @@ Use this form to provide feedback or ask questions, get help using GC Design Sys
 
 <gcds-input type="text" name="name" input-id="name" label="Full name" size="30" autocomplete="name" required></gcds-input>
 <gcds-input type="email" name="email" input-id="email" label="Email address" size="50" autocomplete="email" required></gcds-input>
-<gcds-textarea name="message" label="Provide your feedback or ask a question if you need help" textarea-id="message"></gcds-textarea>
+<gcds-textarea name="message" label="Provide your feedback or ask a question if you need help" textarea-id="message" hint="Do not include protected or personal information."></gcds-textarea>
 
   <gcds-fieldset fieldset-id="learnMore" legend="Learn more about GC Design System" hint="Choose as many options as you'd like.">
     <gcds-checkbox checkbox-id="learnMoreMailingList" label="Sign me up for the mailing list." value="learn-more-mailing-list" name="learn-more-mailing-list"></gcds-checkbox>

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -22,7 +22,11 @@ Avec votre compte GitHub, utilisez notre <gcds-link external href="{{ links.gith
 
 ## Envoyer des commentaires, demander de l’aide ou s’inscrire
 
-Remplissez le formulaire suivant pour nous envoyer vos commentaires, demander de l’aide pour utiliser Système de design GC, ou vous inscrire à notre liste d’envoi ou à une démo.
+Nous soutenons les fonctionnaires qui utilisent le Système de design GC. Nous ne sommes pas en mesure de répondre aux questions provenant des membres du public.
+
+Utilisez ce formulaire pour fournir de la rétroaction, pour poser des questions, pour obtenir de l’aide avec le Système de design GC, pour vous inscrire à notre infolettre et pour demander une démo.
+
+Pour toute autre demande, allez à la page [Coordonnées du Gouvernement du Canada](https://www.canada.ca/fr/contact.html) pour trouver le ministère ou l'organisme qui peut vous aider.
 
 <form class="my-600 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactFR" />
@@ -30,7 +34,7 @@ Remplissez le formulaire suivant pour nous envoyer vos commentaires, demander de
 
 <gcds-input type="text" name="name" input-id="name" label="Nom complet" size="30" autocomplete="name" required></gcds-input>
 <gcds-input type="email" name="email" input-id="email" label="Adresse courriel" size="50" autocomplete="email" required></gcds-input>
-<gcds-textarea name="message" label="Fournissez vos commentaires ou posez une question si vous avez besoin d’aide" textarea-id="message"></gcds-textarea>
+<gcds-textarea name="message" label="Fournissez vos commentaires ou posez une question si vous avez besoin d’aide" textarea-id="message" hint="Veuillez ne pas inclure de renseignement protégé ou personnel."></gcds-textarea>
 
   <gcds-fieldset fieldset-id="learnMore" legend="Apprenez-en plus sur Système de design GC" hint="Choisissez autant d'options que vous le souhaitez.">
     <gcds-checkbox checkbox-id="learnMoreMailingList" label="Ajoutez-moi à votre liste d'envoi." value="learn-more-mailing-list" name="learn-more-mailing-list"></gcds-checkbox>


### PR DESCRIPTION
# Summary | Résumé
Content updates to the contact us form, from this ticket
- https://github.com/cds-snc/design-gc-conception/issues/1388

## To test
Here are the preview links for the new text on the contact us page:
English - https://pr-494.djtlis5vpn8jd.amplifyapp.com/en/contact/
French - https://pr-494.d35vdwuoev573o.amplifyapp.com/fr/contactez/

On the original issue, the hint text contains links, but our textarea only supports plaintext.