### PR TITLE
Feat: Update contact.md

### DIFF
--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -16,10 +16,8 @@ date: 'git Last Modified'
 
 
 <gcds-notice type="info" notice-title-tag="h2" notice-title="Support form on GitHub">
-  <gcds-text>With an <gcds-link external href="{{ links.githubGetStarted }}">account</gcds-link>, use our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub support form</gcds-link> to report bugs and get technical help. You’ll have access to the team’s direct responses, progress made on your issue, and issues raised by others.">.</gcds-text>
+  <gcds-text>With an <gcds-link external href="{{ links.githubGetStarted }}">account</gcds-link>, use our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub support form</gcds-link> to report bugs and get technical help. You’ll have access to the team’s direct responses, progress made on your issue, and issues raised by others." </gcds-text>
 </gcds-notice>
-
-<hr class="my-600" />
 
 ## Attend a demo or event 
 
@@ -33,6 +31,7 @@ We’ll soon be offering other events to our growing community.
   Find an upcoming event
 </gcds-button>
 
+<hr class="my-600" />
 
 ## Get in contact with the design system team
 

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -16,7 +16,7 @@ date: 'git Last Modified'
 
 
 <gcds-notice type="info" notice-title-tag="h2" notice-title="Support form on GitHub">
-  <gcds-text>With an <gcds-link external href="{{ links.githubGetStarted }}">account</gcds-link>, use our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub support form</gcds-link> to report bugs and get technical help. You’ll have access to the team’s direct responses, progress made on your issue, and issues raised by others." </gcds-text>
+  <gcds-text>With an <gcds-link external href="{{ links.githubGetStarted }}">account</gcds-link>, use our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub support form</gcds-link> to report bugs and get technical help. You’ll have access to the team’s direct responses, progress made on your issue, and issues raised by others. </gcds-text>
 </gcds-notice>
 
 ## Attend a demo or event 

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -27,7 +27,7 @@ Demos are an intro to prototyping and developing web experiences with the  desig
 
 We’ll soon be offering other events to our growing community.  
 
-<gcds-button type="link" button-role="secondary" href="{{ links.demo }}">
+<gcds-button type="link" button-role="secondary" href="{{ links.registerDemo }}">
   Find an upcoming event
 </gcds-button>
 

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -35,7 +35,7 @@ We’ll soon be offering other events to our growing community.
 
 ## Get in contact with the design system team
 
-This form is for people building government websites and digital products. You can give feedback, ask a question, or receive communications from the GC Design System team. If you help with a government service, go to <gcds-link href="https://www.canada.ca/en/contact.html" external>Government of Canada contacts</gcds-link>. 
+This form is for people building government websites and digital products. You can give feedback, ask a question, or receive communications from the GC Design System team. If you need help with a government service, go to <gcds-link href="https://www.canada.ca/en/contact.html" external>Government of Canada contacts</gcds-link>. 
 
 <form class="my-600 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactEN" />

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -14,15 +14,29 @@ date: 'git Last Modified'
 
 # Contact GC Design System
 
-## Support form on GitHub
 
-With an account, use our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub support form</gcds-link> to report bugs and get technical help. You’ll have access to past issues and updates on progress.
+<gcds-notice type="info" notice-title-tag="h2" notice-title="Support form on GitHub">
+  <gcds-text>With an <gcds-link external href="{{ links.githubGetStarted }}">account</gcds-link>, use our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub support form</gcds-link> to report bugs and get technical help. You’ll have access to the team’s direct responses, progress made on your issue, and issues raised by others.">.</gcds-text>
+</gcds-notice>
 
 <hr class="my-600" />
 
-## Give feedback, request support, or sign up
+## Attend a demo or event 
 
-Use this form to provide feedback or ask questions, get help using GC Design System, or sign up for our mailing list or demo.
+Want to learn more about GC Design System before trying it out?
+
+Demos are an intro to prototyping and developing web experiences with the  design system, followed by a Q&A.  
+
+We’ll soon be offering other events to our growing community.  
+
+<gcds-button type="link" button-role="secondary" href="{{ links.demo }}">
+  Find an upcoming event
+</gcds-button>
+
+
+## Get in contact with the design system team
+
+This form is for people building government websites and digital products. You can give feedback, ask a question, or receive communications from the GC Design System team. If you help with a government service, go to <gcds-link href="https://www.canada.ca/en/contact.html" external>Government of Canada contacts</gcds-link>. 
 
 <form class="my-600 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactEN" />
@@ -30,11 +44,10 @@ Use this form to provide feedback or ask questions, get help using GC Design Sys
 
 <gcds-input type="text" name="name" input-id="name" label="Full name" size="30" autocomplete="name" required></gcds-input>
 <gcds-input type="email" name="email" input-id="email" label="Email address" size="50" autocomplete="email" required></gcds-input>
-<gcds-textarea name="message" label="Provide your feedback or ask a question if you need help" textarea-id="message"></gcds-textarea>
+<gcds-textarea name="message" label="Provide your feedback or ask a question if you need help" hint="Never include personal (Protected) information." textarea-id="message"></gcds-textarea>
 
-  <gcds-fieldset fieldset-id="learnMore" legend="Learn more about GC Design System" hint="Choose as many options as you'd like.">
+  <gcds-fieldset fieldset-id="learnMore" legend="Receive communication from GC Design System" hint="If you’d like us to contact you, choose one or both options.">
     <gcds-checkbox checkbox-id="learnMoreMailingList" label="Sign me up for the mailing list." value="learn-more-mailing-list" name="learn-more-mailing-list"></gcds-checkbox>
-    <gcds-checkbox checkbox-id="learnMoreDemo" label="Contact me for a demo." value="learn-more-demo" name="learn-more-demo"></gcds-checkbox>
     <gcds-checkbox checkbox-id="learnMoreResearch" label="Contact me for usability research." value="learn-more-mailing-list" name="learn-more-research"></gcds-checkbox>
   </gcds-fieldset>
 

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -26,7 +26,7 @@ Les démos présentent le prototypage et le développement d’expériences Web 
 
 Nous aurons bientôt d’autres évènements à proposer à notre communauté grandissante.  
 
-<gcds-button type="link" button-role="secondary" href="{{ links.demo }}">
+<gcds-button type="link" button-role="secondary" href="{{ links.registerDemo }}">
   Trouver une démo à venir
 </gcds-button>
 

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -14,15 +14,29 @@ date: 'git Last Modified'
 
 # Contacter Système de design GC
 
-## Formulaire de soutien GitHub
+<gcds-notice type="info" notice-title-tag="h2" notice-title="Formulaire de soutien sur GitHub">
+  <gcds-text>Avec un <gcds-link external href="{{ links.githubGetStarted }}">compte</gcds-link>, utilisez notre <gcds-link external href="{{ links.githubCompsIssues }}">Formulaire de soutien GitHub</gcds-link> pour signaler des bogues et obtenir un soutien technique. Vous pourrez accéder aux réponses de l’équipe, suivre les progrès réalisés concernant votre problèmes et voir les problèmes signalés par d’autres personnes.></gcds-text>
+</gcds-notice>
 
-Avec votre compte GitHub, utilisez notre <gcds-link external href="{{ links.githubCompsIssues }}">formulaire de soutien</gcds-link> pour signaler des bogues et obtenir un soutien technique. Vous aurez accès aux problèmes (issues) passés et verrez les progrès accomplis.
+## Participez à une démo ou à un évènement 
+
+Vous souhaitez en savoir plus sur Système de design GC avant de vous lancer?
+
+Les démos présentent le prototypage et le développement d’expériences Web à l’aide du système de design et sont suivies d’une séance de questions-réponses.  
+
+Nous aurons bientôt d’autres évènements à proposer à notre communauté grandissante.  
+
+<gcds-button type="link" button-role="secondary" href="{{ links.demo }}">
+  Trouver une démo à venir
+</gcds-button>
 
 <hr class="my-600" />
 
-## Envoyer des commentaires, demander de l’aide ou s’inscrire
+## Contactez l’équipe du système de design 
 
-Remplissez le formulaire suivant pour nous envoyer vos commentaires, demander de l’aide pour utiliser Système de design GC, ou vous inscrire à notre liste d’envoi ou à une démo.
+Ce formulaire est destiné aux personnes qui bâtissent les sites Web et services numériques gouvernementaux. Vous pouvez nous faire part de vos commentaires, poser une question ou recevoir des communications de la part de l’équipe Système de design GC.
+
+Pour obtenir de l’aide avec un service gouvernemental, aller à la page <gcds-link href="https://www.canada.ca/fr/contact.html" external>Coordonnées du Gouvernement du Canada</gcds-link>.   
 
 <form class="my-600 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactFR" />
@@ -30,11 +44,10 @@ Remplissez le formulaire suivant pour nous envoyer vos commentaires, demander de
 
 <gcds-input type="text" name="name" input-id="name" label="Nom complet" size="30" autocomplete="name" required></gcds-input>
 <gcds-input type="email" name="email" input-id="email" label="Adresse courriel" size="50" autocomplete="email" required></gcds-input>
-<gcds-textarea name="message" label="Fournissez vos commentaires ou posez une question si vous avez besoin d’aide" textarea-id="message"></gcds-textarea>
+<gcds-textarea name="message" label="Fournissez vos commentaires ou posez une question si vous avez besoin d’aide" hint="Incluez jamais de renseignement personnel (Protégé)." textarea-id="message"></gcds-textarea>
 
-  <gcds-fieldset fieldset-id="learnMore" legend="Apprenez-en plus sur Système de design GC" hint="Choisissez autant d'options que vous le souhaitez.">
+  <gcds-fieldset fieldset-id="learnMore" legend="Recevez des communications de la part de Système de design GC" hint="Si vous souhaitez que nous vous contactions, choisissez une option ou les deux options.">
     <gcds-checkbox checkbox-id="learnMoreMailingList" label="Ajoutez-moi à votre liste d'envoi." value="learn-more-mailing-list" name="learn-more-mailing-list"></gcds-checkbox>
-    <gcds-checkbox checkbox-id="learnMoreDemo" label="Contactez-moi pour une démo." value="learn-more-demo" name="learn-more-demo"></gcds-checkbox>
     <gcds-checkbox checkbox-id="learnMoreResearch" label="Contactez-moi pour les études sur l'utilisabilité." value="learn-more-research" name="learn-more-research"></gcds-checkbox>
   </gcds-fieldset>
 


### PR DESCRIPTION
# Summary | Résumé

> Update to EN and FR pages 
> Adding notice for GitHub support form 
> Removing sign up for demo checklist option from form and adding content for demo registration page ahead of contact flow
> Updating contact form description/intro to reflect actual/latest iteration of form content 
> Adding specific content about the intended audience and use of the form
> Adding link for a way out for people who need GC services 
> Hint text to remind not to submit personal (Protected) info
