### PR TITLE
Fix: remove bold from fieldset's design section

### DIFF
--- a/src/en/components/fieldset/design.md
+++ b/src/en/components/fieldset/design.md
@@ -27,12 +27,12 @@ A fieldset combines the `<fieldset>` and `<legend>` elements to accessibly group
 
 ### Write fieldset content to support task success
 
-- Write a short descriptive statement or a call to action for the **legend** caption.
-- Use the **legend** as a signpost to let a person know the kind of information the fieldset group is asking them for.
-- Identify the subtask in the **legend** to help people understand the relationship between the information you're requesting and the task they're completing.
+- Write a short descriptive statement or a call to action for the legend caption.
+- Use the legend as a signpost to let a person know the kind of information the fieldset group is asking them for.
+- Identify the subtask in the legend to help people understand the relationship between the information you're requesting and the task they're completing.
 
 ### Clarify the question or instruction for radios and checkboxes
 
-- For [radios]({{ links.radio }}) and [checkboxes]({{ links.checkbox }}), the **legend** sits where the [input]({{ links.input }}) label usually is on other form components. Replace a question in the **legend** with a statement for a shorter, clearer caption.
-- Use the fieldset **hint** text to give additional context to a person on how to respond. For a checkbox, the fieldset **hint** text could state, "Select all applicable options". For a radio, **hint** text could state "Select the response that best applies".
+- For [radios]({{ links.radio }}) and [checkboxes]({{ links.checkbox }}), the legend sits where the [input]({{ links.input }}) label usually is on other form components. Replace a question in the legend with a statement for a shorter, clearer caption.
+- Use the fieldset hint text to give additional context to a person on how to respond. For a checkbox, the fieldset hint text could state, "Select all applicable options". For a radio, hint text could state "Select the response that best applies".
 - Avoid using a fieldset when a form component has a single option for response and no selection is required.

--- a/src/fr/composants/jeu-de-champs/design.md
+++ b/src/fr/composants/jeu-de-champs/design.md
@@ -27,12 +27,12 @@ Un jeu de champs combine les éléments `<fieldset>` et `<legend>` afin de regro
 
 ### Rédiger le contenu du jeu de champs pour favoriser la réussite de la tâche
 
-- Utilisez la **légende** pour informer une personne sur l'endroit où elle se trouve dans un flux ou une tâche en incluant des repères comme le nom de la section et le numéro de l'étape.
-- Aidez les répondant·e·s à comprendre la relation entre l'information que vous demandez et la tâche ou la sous-tâche qu'ils et elles réalisent en incluant un résumé dans la **légende**.
-- Remplacez les questions par des énoncés afin de réduire le texte de la **légende**.
+- Utilisez la légende pour informer une personne sur l'endroit où elle se trouve dans un flux ou une tâche en incluant des repères comme le nom de la section et le numéro de l'étape.
+- Aidez les répondant·e·s à comprendre la relation entre l'information que vous demandez et la tâche ou la sous-tâche qu'ils et elles réalisent en incluant un résumé dans la légende.
+- Remplacez les questions par des énoncés afin de réduire le texte de la légende.
 
 ### Clarifier la question pour les boutons radio et les cases à cocher
 
-- Pour les [boutons radio]({{ links.radio }}) et les [cases à cocher]({{ links.checkbox }}), la **légende** se situe là ou on retrouve le libellé de champ dans les autres composants.
-- Utilisez le **texte explicatif** du jeu de champs pour donner plus de précisions à une personne sur la façon de répondre. Dans le cas d'une case à cocher, le **texte explicatif** pourrait indiquer : « Sélectionner toutes les options qui s'appliquent ». Dans le cas d'un bouton radio, le **texte explicatif** pourrait indiquer : « Sélectionnez la réponse qui convient le mieux ».
+- Pour les [boutons radio]({{ links.radio }}) et les [cases à cocher]({{ links.checkbox }}), la légende se situe là ou on retrouve le libellé de champ dans les autres composants.
+- Utilisez le texte explicatif du jeu de champs pour donner plus de précisions à une personne sur la façon de répondre. Dans le cas d'une case à cocher, le texte explicatif pourrait indiquer : « Sélectionner toutes les options qui s'appliquent ». Dans le cas d'un bouton radio, le texte explicatif pourrait indiquer : « Sélectionnez la réponse qui convient le mieux ».
 - Évitez d'utiliser un jeu de champs lorsqu'un composant de formulaire ne propose qu'une seule option de réponse et qu'aucune sélection n'est requise.


### PR DESCRIPTION
the words "legend" and "hint" were bolded. Removed that formatting.
