### PR TITLE
fix: remove size prop from contact us name and input field

### DIFF
--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -16,7 +16,7 @@ date: 'git Last Modified'
 
 
 <gcds-notice type="info" notice-title-tag="h2" notice-title="Support form on GitHub">
-  <gcds-text>With an <gcds-link external href="{{ links.githubGetStarted }}">account</gcds-link>, use our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub support form</gcds-link> to report bugs and get technical help. You'll have access to the team's direct responses, progress made on your issue, and issues raised by others. </gcds-text>
+  <gcds-text>With an <gcds-link external href="{{ links.githubGetStarted }}">account</gcds-link>, use our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub support form</gcds-link> to report bugs and get technical help. You’ll have access to the team’s direct responses, progress made on your issue, and issues raised by others. </gcds-text>
 </gcds-notice>
 
 ## Attend a demo or event
@@ -25,7 +25,7 @@ Want to learn more about GC Design System before trying it out?
 
 Demos are an intro to prototyping and developing web experiences with the  design system, followed by a Q&A.
 
-We'll soon be offering other events to our growing community.
+We’ll soon be offering other events to our growing community.
 
 <gcds-button type="link" button-role="secondary" href="{{ links.registerDemo }}">
   Find an upcoming event
@@ -35,7 +35,7 @@ We'll soon be offering other events to our growing community.
 
 ## Get in contact with the design system team
 
-This form is for people building government websites and digital products. You can give feedback, ask a question, or receive communications from the GC Design System team.If you need help with a government service, go to <gcds-link href="https://www.canada.ca/en/contact.html" external>Government of Canada contacts</gcds-link>.
+This form is for people building government websites and digital products. You can give feedback, ask a question, or receive communications from the GC Design System team. If you need help with a government service, go to <gcds-link href="https://www.canada.ca/en/contact.html" external>Government of Canada contacts</gcds-link>.
 
 <form class="my-600 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactEN" />
@@ -45,7 +45,7 @@ This form is for people building government websites and digital products. You c
 <gcds-input type="email" name="email" input-id="email" label="Email address" autocomplete="email" required></gcds-input>
 <gcds-textarea name="message" label="Provide your feedback or ask a question if you need help" hint="Never include personal (Protected) information." textarea-id="message"></gcds-textarea>
 
-  <gcds-fieldset fieldset-id="learnMore" legend="Receive communication from GC Design System" hint="If you'd like us to contact you, choose one or both options.">
+  <gcds-fieldset fieldset-id="learnMore" legend="Receive communication from GC Design System" hint="If you’d like us to contact you, choose one or both options.">
     <gcds-checkbox checkbox-id="learnMoreMailingList" label="Sign me up for the mailing list." value="learn-more-mailing-list" name="learn-more-mailing-list"></gcds-checkbox>
     <gcds-checkbox checkbox-id="learnMoreResearch" label="Contact me for usability research." value="learn-more-mailing-list" name="learn-more-research"></gcds-checkbox>
   </gcds-fieldset>

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -16,16 +16,16 @@ date: 'git Last Modified'
 
 
 <gcds-notice type="info" notice-title-tag="h2" notice-title="Support form on GitHub">
-  <gcds-text>With an <gcds-link external href="{{ links.githubGetStarted }}">account</gcds-link>, use our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub support form</gcds-link> to report bugs and get technical help. You’ll have access to the team’s direct responses, progress made on your issue, and issues raised by others. </gcds-text>
+  <gcds-text>With an <gcds-link external href="{{ links.githubGetStarted }}">account</gcds-link>, use our <gcds-link external href="{{ links.githubCompsIssues }}">GitHub support form</gcds-link> to report bugs and get technical help. You'll have access to the team's direct responses, progress made on your issue, and issues raised by others. </gcds-text>
 </gcds-notice>
 
-## Attend a demo or event 
+## Attend a demo or event
 
 Want to learn more about GC Design System before trying it out?
 
-Demos are an intro to prototyping and developing web experiences with the  design system, followed by a Q&A.  
+Demos are an intro to prototyping and developing web experiences with the  design system, followed by a Q&A.
 
-We’ll soon be offering other events to our growing community.  
+We'll soon be offering other events to our growing community.
 
 <gcds-button type="link" button-role="secondary" href="{{ links.registerDemo }}">
   Find an upcoming event
@@ -35,17 +35,17 @@ We’ll soon be offering other events to our growing community.
 
 ## Get in contact with the design system team
 
-This form is for people building government websites and digital products. You can give feedback, ask a question, or receive communications from the GC Design System team. If you need help with a government service, go to <gcds-link href="https://www.canada.ca/en/contact.html" external>Government of Canada contacts</gcds-link>. 
+This form is for people building government websites and digital products. You can give feedback, ask a question, or receive communications from the GC Design System team.If you need help with a government service, go to <gcds-link href="https://www.canada.ca/en/contact.html" external>Government of Canada contacts</gcds-link>.
 
 <form class="my-600 contact-us-form" name="contactEN" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactEN" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 
-<gcds-input type="text" name="name" input-id="name" label="Full name" size="30" autocomplete="name" required></gcds-input>
-<gcds-input type="email" name="email" input-id="email" label="Email address" size="50" autocomplete="email" required></gcds-input>
+<gcds-input type="text" name="name" input-id="name" label="Full name" autocomplete="name" required></gcds-input>
+<gcds-input type="email" name="email" input-id="email" label="Email address" autocomplete="email" required></gcds-input>
 <gcds-textarea name="message" label="Provide your feedback or ask a question if you need help" hint="Never include personal (Protected) information." textarea-id="message"></gcds-textarea>
 
-  <gcds-fieldset fieldset-id="learnMore" legend="Receive communication from GC Design System" hint="If you’d like us to contact you, choose one or both options.">
+  <gcds-fieldset fieldset-id="learnMore" legend="Receive communication from GC Design System" hint="If you'd like us to contact you, choose one or both options.">
     <gcds-checkbox checkbox-id="learnMoreMailingList" label="Sign me up for the mailing list." value="learn-more-mailing-list" name="learn-more-mailing-list"></gcds-checkbox>
     <gcds-checkbox checkbox-id="learnMoreResearch" label="Contact me for usability research." value="learn-more-mailing-list" name="learn-more-research"></gcds-checkbox>
   </gcds-fieldset>

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -15,16 +15,16 @@ date: 'git Last Modified'
 # Contacter Système de design GC
 
 <gcds-notice type="info" notice-title-tag="h2" notice-title="Formulaire de soutien sur GitHub">
-  <gcds-text>Avec un <gcds-link external href="{{ links.githubGetStarted }}">compte</gcds-link>, utilisez notre <gcds-link external href="{{ links.githubCompsIssues }}">Formulaire de soutien GitHub</gcds-link> pour signaler des bogues et obtenir un soutien technique. Vous pourrez accéder aux réponses de l'équipe, suivre les progrès réalisés concernant votre problèmes et voir les problèmes signalés par d'autres personnes.></gcds-text>
+  <gcds-text>Avec un <gcds-link external href="{{ links.githubGetStarted }}">compte</gcds-link>, utilisez notre <gcds-link external href="{{ links.githubCompsIssues }}">Formulaire de soutien GitHub</gcds-link> pour signaler des bogues et obtenir un soutien technique. Vous pourrez accéder aux réponses de l’équipe, suivre les progrès réalisés concernant votre problèmes et voir les problèmes signalés par d’autres personnes.></gcds-text>
 </gcds-notice>
 
 ## Participez à une démo ou à un évènement
 
 Vous souhaitez en savoir plus sur Système de design GC avant de vous lancer?
 
-Les démos présentent le prototypage et le développement d'expériences Web à l'aide du système de design et sont suivies d'une séance de questions-réponses.
+Les démos présentent le prototypage et le développement d’expériences Web à l’aide du système de design et sont suivies d’une séance de questions-réponses.
 
-Nous aurons bientôt d'autres évènements à proposer à notre communauté grandissante.
+Nous aurons bientôt d’autres évènements à proposer à notre communauté grandissante.
 
 <gcds-button type="link" button-role="secondary" href="{{ links.registerDemo }}">
   Trouver une démo à venir
@@ -32,11 +32,11 @@ Nous aurons bientôt d'autres évènements à proposer à notre communauté gran
 
 <hr class="my-600" />
 
-## Contactez l'équipe du système de design
+## Contactez l’équipe du système de design
 
-Ce formulaire est destiné aux personnes qui bâtissent les sites Web et services numériques gouvernementaux. Vous pouvez nous faire part de vos commentaires, poser une question ou recevoir des communications de la part de l'équipe Système de design GC.
+Ce formulaire est destiné aux personnes qui bâtissent les sites Web et services numériques gouvernementaux. Vous pouvez nous faire part de vos commentaires, poser une question ou recevoir des communications de la part de l’équipe Système de design GC.
 
-Pour obtenir de l'aide avec un service gouvernemental, aller à la page <gcds-link href="https://www.canada.ca/fr/contact.html" external>Coordonnées du Gouvernement du Canada</gcds-link>.
+Pour obtenir de l’aide avec un service gouvernemental, aller à la page <gcds-link href="https://www.canada.ca/fr/contact.html" external>Coordonnées du Gouvernement du Canada</gcds-link>.
 
 <form class="my-600 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactFR" />
@@ -44,7 +44,7 @@ Pour obtenir de l'aide avec un service gouvernemental, aller à la page <gcds-li
 
 <gcds-input type="text" name="name" input-id="name" label="Nom complet" autocomplete="name" required></gcds-input>
 <gcds-input type="email" name="email" input-id="email" label="Adresse courriel" autocomplete="email" required></gcds-input>
-<gcds-textarea name="message" label="Fournissez vos commentaires ou posez une question si vous avez besoin d'aide" hint="Incluez jamais de renseignement personnel (Protégé)." textarea-id="message"></gcds-textarea>
+<gcds-textarea name="message" label="Fournissez vos commentaires ou posez une question si vous avez besoin d’aide" hint="Incluez jamais de renseignement personnel (Protégé)." textarea-id="message"></gcds-textarea>
 
   <gcds-fieldset fieldset-id="learnMore" legend="Recevez des communications de la part de Système de design GC" hint="Si vous souhaitez que nous vous contactions, choisissez une option ou les deux options.">
     <gcds-checkbox checkbox-id="learnMoreMailingList" label="Ajoutez-moi à votre liste d'envoi." value="learn-more-mailing-list" name="learn-more-mailing-list"></gcds-checkbox>

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -15,16 +15,16 @@ date: 'git Last Modified'
 # Contacter Système de design GC
 
 <gcds-notice type="info" notice-title-tag="h2" notice-title="Formulaire de soutien sur GitHub">
-  <gcds-text>Avec un <gcds-link external href="{{ links.githubGetStarted }}">compte</gcds-link>, utilisez notre <gcds-link external href="{{ links.githubCompsIssues }}">Formulaire de soutien GitHub</gcds-link> pour signaler des bogues et obtenir un soutien technique. Vous pourrez accéder aux réponses de l’équipe, suivre les progrès réalisés concernant votre problèmes et voir les problèmes signalés par d’autres personnes.></gcds-text>
+  <gcds-text>Avec un <gcds-link external href="{{ links.githubGetStarted }}">compte</gcds-link>, utilisez notre <gcds-link external href="{{ links.githubCompsIssues }}">Formulaire de soutien GitHub</gcds-link> pour signaler des bogues et obtenir un soutien technique. Vous pourrez accéder aux réponses de l'équipe, suivre les progrès réalisés concernant votre problèmes et voir les problèmes signalés par d'autres personnes.></gcds-text>
 </gcds-notice>
 
-## Participez à une démo ou à un évènement 
+## Participez à une démo ou à un évènement
 
 Vous souhaitez en savoir plus sur Système de design GC avant de vous lancer?
 
-Les démos présentent le prototypage et le développement d’expériences Web à l’aide du système de design et sont suivies d’une séance de questions-réponses.  
+Les démos présentent le prototypage et le développement d'expériences Web à l'aide du système de design et sont suivies d'une séance de questions-réponses.
 
-Nous aurons bientôt d’autres évènements à proposer à notre communauté grandissante.  
+Nous aurons bientôt d'autres évènements à proposer à notre communauté grandissante.
 
 <gcds-button type="link" button-role="secondary" href="{{ links.registerDemo }}">
   Trouver une démo à venir
@@ -32,19 +32,19 @@ Nous aurons bientôt d’autres évènements à proposer à notre communauté gr
 
 <hr class="my-600" />
 
-## Contactez l’équipe du système de design 
+## Contactez l'équipe du système de design
 
-Ce formulaire est destiné aux personnes qui bâtissent les sites Web et services numériques gouvernementaux. Vous pouvez nous faire part de vos commentaires, poser une question ou recevoir des communications de la part de l’équipe Système de design GC.
+Ce formulaire est destiné aux personnes qui bâtissent les sites Web et services numériques gouvernementaux. Vous pouvez nous faire part de vos commentaires, poser une question ou recevoir des communications de la part de l'équipe Système de design GC.
 
-Pour obtenir de l’aide avec un service gouvernemental, aller à la page <gcds-link href="https://www.canada.ca/fr/contact.html" external>Coordonnées du Gouvernement du Canada</gcds-link>.   
+Pour obtenir de l'aide avec un service gouvernemental, aller à la page <gcds-link href="https://www.canada.ca/fr/contact.html" external>Coordonnées du Gouvernement du Canada</gcds-link>.
 
 <form class="my-600 contact-us-form" name="contactFR" method="post" style="min-height: 32rem;" action="/api/submission">
   <input type="hidden" name="form-name" value="contactFR" />
   <input name="honeypot" type="text" aria-label="bot" hidden/>
 
-<gcds-input type="text" name="name" input-id="name" label="Nom complet" size="30" autocomplete="name" required></gcds-input>
-<gcds-input type="email" name="email" input-id="email" label="Adresse courriel" size="50" autocomplete="email" required></gcds-input>
-<gcds-textarea name="message" label="Fournissez vos commentaires ou posez une question si vous avez besoin d’aide" hint="Incluez jamais de renseignement personnel (Protégé)." textarea-id="message"></gcds-textarea>
+<gcds-input type="text" name="name" input-id="name" label="Nom complet" autocomplete="name" required></gcds-input>
+<gcds-input type="email" name="email" input-id="email" label="Adresse courriel" autocomplete="email" required></gcds-input>
+<gcds-textarea name="message" label="Fournissez vos commentaires ou posez une question si vous avez besoin d'aide" hint="Incluez jamais de renseignement personnel (Protégé)." textarea-id="message"></gcds-textarea>
 
   <gcds-fieldset fieldset-id="learnMore" legend="Recevez des communications de la part de Système de design GC" hint="Si vous souhaitez que nous vous contactions, choisissez une option ou les deux options.">
     <gcds-checkbox checkbox-id="learnMoreMailingList" label="Ajoutez-moi à votre liste d'envoi." value="learn-more-mailing-list" name="learn-more-mailing-list"></gcds-checkbox>


### PR DESCRIPTION
# Summary | Résumé

This change removes the `size` prop from both the `name` and `email` fields in the contact us form.

- The size prop on the email field was previously set to a value larger than the default maximum field width, causing it to be overwritten and inconsistent with the rest of the form’s design.
- The size prop on the name field was removed to prevent unnecessary limitations on field width, as some names may exceed the default maximum width.

This ensures that both fields maintain a consistent, flexible width for better user experience.