### PR TITLE
style: remove default spacing values from headings and text

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -303,7 +303,7 @@ module.exports = function (eleventyConfig) {
     (children, title, url) => {
       return `
       <div class="my-600 b-sm b-default component-preview">
-        <h2 class="container-full font-text font-semibold px-225 py-150 bb-sm b-default bg-light">
+        <h2 class="container-full font-text font-semibold m-0 px-225 py-150 bb-sm b-default bg-light">
           ${title}
         </h2>
         <div>

--- a/examples/component-name/use-case.md
+++ b/examples/component-name/use-case.md
@@ -24,7 +24,7 @@ Use a {componentName}
 -
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">{relatedComponents}</h2>
+  <h2 class="mt-0">{relatedComponents}</h2>
 
 <a href="" class="link-light">component</a>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
         "@cdssnc/gcds-components": "^0.32.0",
         "@cdssnc/gcds-tokens": "^2.6.0",
-        "@cdssnc/gcds-utility": "^1.5.0",
+        "@cdssnc/gcds-utility": "^1.6.0",
         "@quasibit/eleventy-plugin-sitemap": "^2.1.4",
         "axe-core": "^4.10.2",
         "chroma-js": "^2.4.2",
@@ -2255,11 +2255,10 @@
       "license": "MIT"
     },
     "node_modules/@cdssnc/gcds-utility": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-utility/-/gcds-utility-1.5.0.tgz",
-      "integrity": "sha512-5KstsoxG0+J35s5dHWdkNrNlaIteAg6U5anfihmI0+AglftdszcxrLSjfidOyE9tZwgbcqVyGNf/TqQ+gWeUWQ==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-utility/-/gcds-utility-1.6.0.tgz",
+      "integrity": "sha512-U1rMj6xEBe2KEUBTRZBxDK7nlt43VUGTcLsEZbgWUUj7IIMp/LLHHPa/vBQST+NczGyNkOFO28rGfSXKOOutuw==",
+      "dev": true
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -13282,9 +13281,9 @@
       "dev": true
     },
     "@cdssnc/gcds-utility": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-utility/-/gcds-utility-1.5.0.tgz",
-      "integrity": "sha512-5KstsoxG0+J35s5dHWdkNrNlaIteAg6U5anfihmI0+AglftdszcxrLSjfidOyE9tZwgbcqVyGNf/TqQ+gWeUWQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@cdssnc/gcds-utility/-/gcds-utility-1.6.0.tgz",
+      "integrity": "sha512-U1rMj6xEBe2KEUBTRZBxDK7nlt43VUGTcLsEZbgWUUj7IIMp/LLHHPa/vBQST+NczGyNkOFO28rGfSXKOOutuw==",
       "dev": true
     },
     "@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0",
     "@cdssnc/gcds-components": "^0.32.0",
     "@cdssnc/gcds-tokens": "^2.6.0",
-    "@cdssnc/gcds-utility": "^1.5.0",
+    "@cdssnc/gcds-utility": "^1.6.0",
     "@quasibit/eleventy-plugin-sitemap": "^2.1.4",
     "axe-core": "^4.10.2",
     "chroma-js": "^2.4.2",

--- a/src/404.md
+++ b/src/404.md
@@ -7,10 +7,8 @@ nocrawl: true
 locale: en
 ---
 
-<h1 class="mt-0 mb-300">
-    Page could not be found <br/><span lang="fr">Page introuvable</span>
-</h1>
+<h1>Page could not be found <br/><span lang="fr">Page introuvable</span></h1>
 
 Check you’ve entered the correct web address.
 
-<p class="mb-300" lang="fr">Assurez-vous d’avoir saisi la bonne adresse Web.</p>
+<p lang="fr">Assurez-vous d’avoir saisi la bonne adresse Web.</p>

--- a/src/_includes/layouts/demo.njk
+++ b/src/_includes/layouts/demo.njk
@@ -2,14 +2,14 @@
 layout: "layouts/base.njk"
 ---
 
-<section class="py-900">
-  <h1 class="container-full text-center mb-600">{{ demo[locale].heading }}</h1>
+<section class="pb-600">
+  <h1 class="container-full">{{ demo[locale].heading }}</h1>
 
   <h2>{{ demo[locale].subheading }}</h2>
 
   {# ------------- Alerts ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].alerts.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].alerts.heading }}</h3>
   <gcds-alert heading="{{ demo[locale].alerts.content.heading }}" alert-role="success" container="xl">
     <p>{{ demo[locale].alerts.content.text }}</p>
   </gcds-alert>
@@ -25,7 +25,7 @@ layout: "layouts/base.njk"
 
   {# ------------- Breadcrumbs ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].breadcrumbs.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].breadcrumbs.heading }}</h3>
 
   <gcds-breadcrumbs slot="breadcrumb">
     <gcds-breadcrumbs-item href="{{ demo[locale].breadcrumbs.content.gcLink }}">
@@ -38,7 +38,7 @@ layout: "layouts/base.njk"
 
   {# ------------- Buttons ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].buttons.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].buttons.heading }}</h3>
   <gcds-button button-role="primary">
     {{ demo[locale].buttons.content.primary }}
   </gcds-button>
@@ -65,7 +65,7 @@ layout: "layouts/base.njk"
 
   {# ------------- Container ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].containers.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].containers.heading }}</h3>
   <gcds-container container="full">
     <div class="p-200 b-sm">{{ demo[locale].containers.content.full }}</div>
   </gcds-container>
@@ -80,19 +80,19 @@ layout: "layouts/base.njk"
 
   {# ------------- Date modified ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].dateModified.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].dateModified.heading }}</h3>
   <gcds-date-modified>2023-01-26</gcds-date-modified>
 
   {# ------------- Details ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].details.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].details.heading }}</h3>
   <gcds-details details-title="{{ demo[locale].details.content.heading }}">
     <p>{{ demo[locale].details.content.text }}</p>
   </gcds-details>
 
   {# ------------- Footer ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].footer.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].footer.heading }}</h3>
   <gcds-footer
     display="full"
     contextual-heading="{{ demo[locale].footer.content.contextualHeading }}"
@@ -178,7 +178,7 @@ layout: "layouts/base.njk"
 
   {# ------------- Grid ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].grid.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].grid.heading }}</h3>
   <gcds-grid
     tag="article"
     columns-desktop="1fr 1fr 1fr 1fr"
@@ -193,7 +193,7 @@ layout: "layouts/base.njk"
 
   {# ------------- Header ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].header.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].header.heading }}</h3>
   <gcds-header
     lang="{{ demo[locale].header.content.lang }}"
     lang-href="#"
@@ -221,7 +221,7 @@ layout: "layouts/base.njk"
 
   {# ------------- Icons ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].icons.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].icons.heading }}</h3>
   <gcds-icon name="tree" size="text-small" margin-right="200"></gcds-icon>
   <gcds-icon name="tree" size="text" margin-right="200"></gcds-icon>
   <gcds-icon name="tree" size="h6" margin-right="200"></gcds-icon>
@@ -231,7 +231,7 @@ layout: "layouts/base.njk"
   <gcds-icon name="tree" size="h2" margin-right="200"></gcds-icon>
   <gcds-icon name="tree" size="h1" margin-right="200"></gcds-icon>
 
-  <h4 class="mt-600 mb-300">{{ demo[locale].icons.content.fixed }}</h4>
+  <h4>{{ demo[locale].icons.content.fixed }}</h4>
   <gcds-icon name="tree" size="text-small" fixed-width></gcds-icon>
   <gcds-icon name="tree" size="text" fixed-width></gcds-icon>
   <gcds-icon name="tree" size="h6" fixed-width></gcds-icon>
@@ -241,7 +241,7 @@ layout: "layouts/base.njk"
   <gcds-icon name="tree" size="h2" fixed-width></gcds-icon>
   <gcds-icon name="tree" size="h1" fixed-width></gcds-icon>
 
-  <h4 class="mt-600 mb-300">{{ demo[locale].icons.content.variable }}</h4>
+  <h4>{{ demo[locale].icons.content.variable }}</h4>
   <gcds-icon name="tree" size="text-small"></gcds-icon>
   <gcds-icon name="tree" size="text"></gcds-icon>
   <gcds-icon name="tree" size="h6"></gcds-icon>
@@ -253,7 +253,7 @@ layout: "layouts/base.njk"
 
   {# ------------- Pagination ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].pagination.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].pagination.heading }}</h3>
 
   <p>{{ demo[locale].pagination.content.list }}:</p>
   <gcds-pagination
@@ -278,7 +278,7 @@ layout: "layouts/base.njk"
 
   {# ------------- Phase banner ------------- #}
 
-  <h3 class="container-full mt-600 mb-300 bb-sm">{{ demo[locale].phaseBanner.heading }}</h3>
+  <h3 class="container-full bb-sm">{{ demo[locale].phaseBanner.heading }}</h3>
   <gcds-phase-banner banner-role="primary">
     <gcds-icon name="tree" size="sm" slot="banner-icon-left"></gcds-icon>
     <p slot="banner-text">{{ demo[locale].phaseBanner.content.text }}</p>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -46,10 +46,10 @@
             <div class="md:py-1250 py-900 hero">
               <div class="container-xl mx-auto">
                 <article class="sm:py-750 py-450 xl:ps-0 sm:ps-600 ps-450 sm:pe-750 pe-300 bg-primary text-light hero__content">
-                  <h1 class="mb-300">
+                  <h1>
                     <span class="d-block">{{ homehero[locale].gcds }}</span>
                   </h1>
-                  <p class="mb-300">{{ homehero[locale].paragraph }}</p>
+                  <p>{{ homehero[locale].paragraph }}</p>
                   <a class="link-light" href="{{ homehero[locale].link }}">{{ homehero[locale].linkText }}</a>
                 </article>
               </div>

--- a/src/_includes/partials/components-tags.njk
+++ b/src/_includes/partials/components-tags.njk
@@ -1,5 +1,5 @@
-<h2 id="component-tags" class="mt-600 mb-300">{{ componenttags[locale].heading }}</h2>
+<h2 id="component-tags">{{ componenttags[locale].heading }}</h2>
 
 {% for value in componenttags[locale].paragraphs %}
-<p class="mb-300">{{ value }}</p>
+<p>{{ value }}</p>
 {% endfor %}

--- a/src/_includes/partials/givefeedback.njk
+++ b/src/_includes/partials/givefeedback.njk
@@ -1,8 +1,8 @@
-  <h2 class="mt-225 mb-300">
+  <h2>
     {{ givefeedback[locale].heading }}
   </h2>
 
-  <p class="mb-300">
+  <p>
     {{ givefeedback[locale].paragraph | safe }}
   </p>
 

--- a/src/_includes/partials/helpus.njk
+++ b/src/_includes/partials/helpus.njk
@@ -1,18 +1,13 @@
-<section data-pagefind-ignore class="pt-75 mt-300 mb-900 {% if removeBorder %} {% else %}bt-sm b-dark {% endif %}">
-  <h2 class="mt-225 mb-300">
-    {{ helpus[locale].heading }}
-  </h2>
-
-  <p class="mb-300">
-    {{ helpus[locale].paragraph }}
-  </p>
+<section data-pagefind-ignore class="my-600 {% if removeBorder %} {% else %}bt-sm b-dark {% endif %}">
+  <h2>{{ helpus[locale].heading }}</h2>
+  <p>{{ helpus[locale].paragraph }}</p>
 
   {% if locale == "en" %}
-  <p class="mb-300">
+  <p>
     Something's wrong? Raise it through GitHub with an <gcds-link href='{{ links.githubGetStarted }}' external>account</gcds-link>. You'll have access to the team's direct responses, progress made on your issue, and issues raised by others.
   </p>
   {% else %}
-  <p class="mb-300">
+  <p>
     Quelque chose ne va pas? Signalez-le sur GitHub en créant un <gcds-link href='{{ links.githubGetStarted }}' external>compte</gcds-link>. Vous pourrez accéder aux réponses de l'équipe, suivre les progrès réalisés concernant votre problèmes et voir les problèmes signalés par d'autres personnes.
   </p>
   {% endif %}

--- a/src/_includes/partials/installation/step-1.njk
+++ b/src/_includes/partials/installation/step-1.njk
@@ -1,6 +1,6 @@
-<div class="mt-750 pt-750 pb-450 bg-full-width bg-light">
-  <h2 class="mb-300">{{ installation[locale].step1.heading }}</h2>
-  <p class="mb-450">{{ installation[locale].step1.paragraph }}</p>
+<div class="mt-600 pt-600 pb-300 bg-full-width bg-light">
+  <h2 class="mt-0">{{ installation[locale].step1.heading }}</h2>
+  <p>{{ installation[locale].step1.paragraph }}</p>
   <gcds-select
     name="select-environment"
     select-id="select-environment"

--- a/src/_includes/partials/installation/step-2-angular.njk
+++ b/src/_includes/partials/installation/step-2-angular.njk
@@ -1,15 +1,15 @@
-<div id="step-2-angular" class="py-750 step-2-content">
-  <h2 class="mb-300">{{ installation[locale].step2.heading }}</h2>
-  <p class="mb-300">{{ installation[locale].step2.angular.paragraph }}</p>
+<div id="step-2-angular" class="pb-600 step-2-content">
+  <h2>{{ installation[locale].step2.heading }}</h2>
+  <p>{{ installation[locale].step2.angular.paragraph }}</p>
 
-  <h3 class="mt-600 mb-300">{{ installation[locale].step2.angular.heading }}</h3>
-  <p class="mb-300">{{ installation[locale].step2.angular.install }}</p>
+  <h3>{{ installation[locale].step2.angular.heading }}</h3>
+  <p>{{ installation[locale].step2.angular.install }}</p>
 
   {% highlight "js" %}
   npm install @cdssnc/gcds-components @cdssnc/gcds-components-angular
   {% endhighlight %}
 
-  <p class="mt-600 mb-300">{{ installation[locale].step2.angular.placeApp | safe }}</p>
+  <p class="mt-600">{{ installation[locale].step2.angular.placeApp | safe }}</p>
 
 {% highlight "js" %}
 import { GcdsComponentsModule } from '@cdssnc/gcds-components-angular';
@@ -29,7 +29,7 @@ import { GcdsComponentsModule } from '@cdssnc/gcds-components-angular';
 export class AppModule { }
 {% endhighlight %}
 
-  <p class="mt-600 mb-300">{{ installation[locale].step2.angular.placeStyles | safe }}</p>
+  <p class="mt-600">{{ installation[locale].step2.angular.placeStyles | safe }}</p>
 
   {% highlight "js" %}
   @import '../node_modules/@cdssnc/gcds-components/dist/gcds/gcds.css';

--- a/src/_includes/partials/installation/step-2-cdn.njk
+++ b/src/_includes/partials/installation/step-2-cdn.njk
@@ -1,10 +1,10 @@
-<div id="step-2-cdn" class="py-750 step-2-content">
-  <h2 class="mb-300">{{ installation[locale].step2.heading }}</h2>
-  <p class="mb-300">{{ installation[locale].step2.cdn.paragraph }}</p>
+<div id="step-2-cdn" class="pb-300 step-2-content">
+  <h2>{{ installation[locale].step2.heading }}</h2>
+  <p>{{ installation[locale].step2.cdn.paragraph }}</p>
 
-  <h3 class="mt-600 mb-300">{{ installation[locale].step2.cdn.heading }}</h3>
-  <p class="mb-300">{{ installation[locale].step2.cdn.version | safe }}</p>
-  <p class="mb-300">{{ installation[locale].step2.cdn.place | safe }}</p>
+  <h3>{{ installation[locale].step2.cdn.heading }}</h3>
+  <p>{{ installation[locale].step2.cdn.version | safe }}</p>
+  <p>{{ installation[locale].step2.cdn.place | safe }}</p>
 
 {% highlight "html" %}
 <!-- Icons Font Awesome ({{ installation[locale].step2.cdn.icons }}) -->
@@ -18,8 +18,8 @@
 
   <small>{{ installation[locale].step2.cdn.note | safe }}</small>
 
-  <h3 class="mt-600 mb-300">{{ installation[locale].step2.cdn.subheading | safe }}</h3>
-  <p class="mb-300">{{ installation[locale].step2.cdn.latest | safe }}</p>
+  <h3>{{ installation[locale].step2.cdn.subheading | safe }}</h3>
+  <p>{{ installation[locale].step2.cdn.latest | safe }}</p>
 </div>
 
 <script>

--- a/src/_includes/partials/installation/step-2-choose.njk
+++ b/src/_includes/partials/installation/step-2-choose.njk
@@ -1,4 +1,4 @@
-<div id="step-2-choose" class="py-750 step-2-content">
-  <h2 class="mb-300">{{ installation[locale].step2.heading }}</h2>
+<div id="step-2-choose" class="pb-300 step-2-content">
+  <h2>{{ installation[locale].step2.heading }}</h2>
   <p>{{ installation[locale].step2.choose.paragraph }}</p>
 </div>

--- a/src/_includes/partials/installation/step-2-figma.njk
+++ b/src/_includes/partials/installation/step-2-figma.njk
@@ -1,6 +1,6 @@
-<div id="step-2-figma" class="py-750 step-2-content">
-  <h2 class="mb-300">{{ installation[locale].step2.heading }}</h2>
-  <p class="mb-300">{{ installation[locale].step2.figma.paragraph }}</p>
+<div id="step-2-figma" class="pb-600 step-2-content">
+  <h2>{{ installation[locale].step2.heading }}</h2>
+  <p>{{ installation[locale].step2.figma.paragraph }}</p>
   <gcds-button
     type="link"
     button-role="secondary"

--- a/src/_includes/partials/installation/step-2-node.njk
+++ b/src/_includes/partials/installation/step-2-node.njk
@@ -1,15 +1,15 @@
-<div id="step-2-node" class="py-750 step-2-content">
-  <h2 class="mb-300">{{ installation[locale].step2.heading }}</h2>
-  <p class="mb-300">{{ installation[locale].step2.node.paragraph }}</p>
+<div id="step-2-node" class="pb-600 step-2-content">
+  <h2>{{ installation[locale].step2.heading }}</h2>
+  <p>{{ installation[locale].step2.node.paragraph }}</p>
 
-  <h3 class="mt-600 mb-300">{{ installation[locale].step2.node.heading }}</h3>
-  <p class="mb-300">{{ installation[locale].step2.node.install }}</p>
+  <h3 class="mt-600">{{ installation[locale].step2.node.heading }}</h3>
+  <p>{{ installation[locale].step2.node.install }}</p>
 
   {% highlight "js" %}
   npm install @cdssnc/gcds-components
   {% endhighlight %}
 
-  <p class="mt-600 mb-300">{{ installation[locale].step2.node.place | safe }}</p>
+  <p class="mt-600">{{ installation[locale].step2.node.place | safe }}</p>
 
 {% highlight "html" %}
 <!-- Icons Font Awesome ({{ installation[locale].step2.node.icons }}) -->

--- a/src/_includes/partials/installation/step-2-none.njk
+++ b/src/_includes/partials/installation/step-2-none.njk
@@ -1,6 +1,6 @@
-<div id="step-2-none" class="py-750 step-2-content">
-  <h2 class="mb-300">{{ installation[locale].step2.heading }}</h2>
-  <p class="mb-300">{{ installation[locale].step2.other.paragraph }}</p>
+<div id="step-2-none" class="pb-600 step-2-content">
+  <h2>{{ installation[locale].step2.heading }}</h2>
+  <p>{{ installation[locale].step2.other.paragraph }}</p>
   <gcds-button
     type="link"
     button-role="secondary"

--- a/src/_includes/partials/installation/step-2-react.njk
+++ b/src/_includes/partials/installation/step-2-react.njk
@@ -1,15 +1,15 @@
-<div id="step-2-react" class="py-750 step-2-content">
-  <h2 class="mb-300">{{ installation[locale].step2.heading }}</h2>
-  <p class="mb-300">{{ installation[locale].step2.react.paragraph }}</p>
+<div id="step-2-react" class="pb-600 step-2-content">
+  <h2>{{ installation[locale].step2.heading }}</h2>
+  <p>{{ installation[locale].step2.react.paragraph }}</p>
 
-  <h3 class="mt-600 mb-300">{{ installation[locale].step2.react.heading }}</h3>
-  <p class="mb-300">{{ installation[locale].step2.react.install }}</p>
+  <h3 class="mt-600">{{ installation[locale].step2.react.heading }}</h3>
+  <p>{{ installation[locale].step2.react.install }}</p>
 
   {% highlight "js" %}
     npm install @cdssnc/gcds-components @cdssnc/gcds-components-react
   {% endhighlight %}
 
-  <p class="mt-600 mb-300">{{ installation[locale].step2.react.place | safe }}</p>
+  <p class="mt-600">{{ installation[locale].step2.react.place | safe }}</p>
 
   {% highlight "js" %}
     import '@cdssnc/gcds-components-react/gcds.css'

--- a/src/_includes/partials/installation/step-2-vue.njk
+++ b/src/_includes/partials/installation/step-2-vue.njk
@@ -1,15 +1,15 @@
-<div id="step-2-vue" class="py-750 step-2-content">
-  <h2 class="mb-300">{{ installation[locale].step2.heading }}</h2>
-  <p class="mb-300">{{ installation[locale].step2.vue.paragraph }}</p>
+<div id="step-2-vue" class="pb-600 step-2-content">
+  <h2>{{ installation[locale].step2.heading }}</h2>
+  <p>{{ installation[locale].step2.vue.paragraph }}</p>
 
-  <h3 class="mt-600 mb-300">{{ installation[locale].step2.vue.heading }}</h3>
-  <p class="mb-300">{{ installation[locale].step2.vue.install }}</p>
+  <h3 class="mt-600">{{ installation[locale].step2.vue.heading }}</h3>
+  <p>{{ installation[locale].step2.vue.install }}</p>
 
   {% highlight "js" %}
   npm install @cdssnc/gcds-components-vue
   {% endhighlight %}
 
-  <p class="mt-600 mb-300">{{ installation[locale].step2.vue.place | safe }}</p>
+  <p class="mt-600">{{ installation[locale].step2.vue.place | safe }}</p>
 
   {% highlight "js" %}
   import { GcdsComponents } from '@cdssnc/gcds-components-vue';
@@ -17,16 +17,14 @@
 createApp(App).use(GcdsComponents).mount('#app');
   {% endhighlight %}
 
-  <p class="mt-600 mb-300">{{ installation[locale].step2.vue.globalStyles }}</p>
-
-  <p class="mt-600 mb-300">{{ installation[locale].step2.vue.styleOne | safe }}</p>
+  <p class="mt-600">{{ installation[locale].step2.vue.globalStyles }} {{ installation[locale].step2.vue.styleOne | safe }}</p>
 
   {% highlight "js" %}
   import '@cdssnc/gcds-components-vue/gcds.css';
 import './style.css';
   {% endhighlight %}
 
-  <p class="mt-600 mb-300">{{ installation[locale].step2.vue.styleTwo | safe }}</p>
+  <p class="mt-600">{{ installation[locale].step2.vue.styleTwo | safe }}</p>
 
   {% highlight "html" %}
   <style src='@cdssnc/gcds-components-vue/gcds.css'>

--- a/src/_includes/partials/installation/step-3.njk
+++ b/src/_includes/partials/installation/step-3.njk
@@ -1,7 +1,7 @@
-<div class="py-750 bg-full-width bg-light">
-  <h2 class="mb-300">{{ installation[locale].step3.heading }}</h2>
+<div class="py-600 bg-full-width bg-light">
+  <h2 class="mt-0">{{ installation[locale].step3.heading }}</h2>
   {% for value in installation[locale].step3.paragraphs %}
-    <p class="mb-300">{{ value }}</p>
+    <p>{{ value }}</p>
   {% endfor %}
   <gcds-button type="link" href="{{ installation[locale].step3.link }}">
     {{ installation[locale].step3.buttonText }}

--- a/src/_includes/partials/lookingfor.njk
+++ b/src/_includes/partials/lookingfor.njk
@@ -8,16 +8,10 @@
   {% set paragraph = lookingfor[locale]["coparagraph"] %}
 {% endif %}
 
-<section class="pt-75 mt-300">
-  <h2 class="mt-225 mb-300">
-    {{ lookingfor[locale].heading }}
-  </h2>
-
-  <p class="mb-300">
-    {{ paragraph | safe }}
-  </p>
-
-  <ul class="mb-900">
+<section class="mt-600 bt-sm">
+  <h2>{{ lookingfor[locale].heading }}</h2>
+  <p>{{ paragraph | safe }}</p>
+  <ul class="mb-600">
     <li class="md:d-inline sm:d-block me-150">
       <gcds-button
         type="link"
@@ -27,7 +21,6 @@
         {{ lookingfor[locale].feedback }}
       </gcds-button>
     </li>
-
     <li class="md:d-inline sm:d-block mt-100 md:mt-0">
       <gcds-button
         type="link"

--- a/src/en/components/breadcrumbs/use-case.md
+++ b/src/en/components/breadcrumbs/use-case.md
@@ -31,7 +31,7 @@ Use breadcrumbs to signal a visitor's current location and give them a sense of 
 - Organize websites in a hierarchy of more than two levels.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.footer }}" class="link-light">Footer</a> for placing the Government of Canada branded footer landmark.
 

--- a/src/en/components/button/use-case.md
+++ b/src/en/components/button/use-case.md
@@ -29,7 +29,7 @@ Use a button for important actions a person using your product can initiate to:
 - Move between steps in a sequence.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.link }}" class="link-light">Links</a> to provide navigation to a new page, website, or section on the current page or files for download.
 
@@ -81,7 +81,7 @@ A role is a button sub-type that has a specific use on a page.
   <gcds-button button-role="primary">Submit</gcds-button>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mb-300">Primary button uses</h3>
+    <h3>Primary button uses</h3>
     <ul class="list-disc mb-300">
       <li>The most important action on a page.</li>
       <li>Critical actions in a flow or as the default button.</li>
@@ -96,7 +96,7 @@ A role is a button sub-type that has a specific use on a page.
   <gcds-button button-role="secondary">Cancel</gcds-button>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mb-300">Secondary button uses</h3>
+    <h3>Secondary button uses</h3>
     <ul class="list-disc mb-300">
       <li>Supporting actions.</li>
       <li>To highlight an important, common action but not the most important one.</li>
@@ -110,7 +110,7 @@ A role is a button sub-type that has a specific use on a page.
   <gcds-button button-role="danger">Delete</gcds-button>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mb-300">Danger button uses</h3>
+    <h3>Danger button uses</h3>
     <ul class="list-disc mb-300">
       <li>To flag serious actions like removing, clearing, or deleting information.</li>
       <li>For actions when changes may be difficult to reverse.</li>

--- a/src/en/components/card/use-case.md
+++ b/src/en/components/card/use-case.md
@@ -32,7 +32,7 @@ Use a card to:
 Note: For Canada.ca, avoid using cards in place of the doormats with the templates for landing page and theme and topic page.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.details }}" class="link-light">Details</a> to hide secondary information that a person can expand on the same page.
 

--- a/src/en/components/checkbox/use-case.md
+++ b/src/en/components/checkbox/use-case.md
@@ -28,7 +28,7 @@ Use a checkbox with a [fieldset]({{ links.fieldset }}) to make a request for inf
 - Give a person the ability to answer without writing by selecting one or multiple items from a list.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.radioGroup }}" class="link-light">Radio groups</a> to give a single option from a larger set of options.
 

--- a/src/en/components/container/use-case.md
+++ b/src/en/components/container/use-case.md
@@ -31,7 +31,7 @@ Use containers to:
 - Centre content on a screen or within a viewport.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.grid }}" class="link-light">Grid</a> for a responsive, flexible column layout to position elements on a page.
 

--- a/src/en/components/data-table/use-case.md
+++ b/src/en/components/data-table/use-case.md
@@ -25,7 +25,7 @@ Use a Data table
 -
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="" class="link-light">component</a>
 

--- a/src/en/components/date-input/design.md
+++ b/src/en/components/date-input/design.md
@@ -24,7 +24,9 @@ date: "git Last Modified"
 ## Design and accessibility for date inputs
 
 ### Support task success with hint text
-- Use the hint text in the fieldset legend to help a person understand the format they can use to enter the date. For example, showing a single digit number without a leading zero, like September 7, rather than September 07 shows that a leading zero is not needed.
+
+Use the hint text in the fieldset legend to help a person understand the format they can use to enter the date. For example, showing a single digit number without a leading zero, like September 7, rather than September 07 shows that a leading zero is not needed.
 
 ### Write specific error messages
-- Write error messages for each field of the date input. Error messages must provide information on what is missing or on incorrect formatting. For example, if the year was input using 2 digits, state that the year should be 4 digits.
+
+Write error messages for each field of the date input. Error messages must provide information on what is missing or on incorrect formatting. For example, if the year was input using 2 digits, state that the year should be 4 digits.

--- a/src/en/components/date-input/use-case.md
+++ b/src/en/components/date-input/use-case.md
@@ -29,7 +29,7 @@ Use a date input to gather a date from a person when you're expecting them to wr
 - Avoid using a date input for the selection of an unknown date. Use a date picker instead.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
   <a href="{{ links.input }}" class="link-light">Input</a> when you want someone to input only a year or only a day of the month.
 

--- a/src/en/components/date-modified/use-case.md
+++ b/src/en/components/date-modified/use-case.md
@@ -27,7 +27,7 @@ Use date modified to:
 - Identify an application’s current version.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.footer }}" class="link-light">Footer</a> for placing the Government of Canada branded footer landmark.
 
@@ -36,29 +36,28 @@ Use date modified to:
 ## Component types
 
 <div class="remove-empty-p">
-<gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
+<gcds-grid class="mb-300" columns="1fr" columns-tablet="1fr 2fr" align-items="start">
   {% componentPreview "Date type preview" "px-225 py-300" "" %}
   <gcds-date-modified>2023-08-22</gcds-date-modified>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mb-300">Date type</h3>
-    <p class="mb-300">Use the date type to:</p>
+    <h3 class="mt-0">Date type</h3>
+    <p>Use the date type to:</p>
     <ul class="list-disc mb-300">
       <li>Identify the date a web page or website was last changed.</li>
     </ul>
   </div>
 </gcds-grid>
-<br/>
+
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
   {% componentPreview "Version type preview" "px-225 py-300" "" %}
   <gcds-date-modified type="version">1.0.0</gcds-date-modified>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mb-300">Version type</h3>
-    <p class="mb-300">Use the Version type to:</p>
+    <h3 class="mt-0">Version type</h3>
+    <p>Use the Version type to:</p>
     <ul class="list-disc mb-300">
       <li>Identify the current version of an application.</li>
     </ul>
   </div>
 </gcds-grid>
-</br>

--- a/src/en/components/details/use-case.md
+++ b/src/en/components/details/use-case.md
@@ -29,7 +29,7 @@ Use the details component to give a person a summary of more detailed content yo
 - Give readers the option to control content for subjects that may cause distress to some readers. They can access certain content when they are ready and hide content once they've reviewed it.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 Tabs when you want to replace the entire content of a section or a page.
 

--- a/src/en/components/error-message/use-case.md
+++ b/src/en/components/error-message/use-case.md
@@ -30,7 +30,7 @@ Use an error message for your own component instances when you need to interrupt
 - You need to specify an incorrect response type or format and let a person know exactly what to do to fix the problem and move on.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.errorSummary }}" class="link-light">Error summary</a> for listing all problems to address for response submission.
 

--- a/src/en/components/error-summary/use-case.md
+++ b/src/en/components/error-summary/use-case.md
@@ -28,7 +28,7 @@ Use an error summary to interrupt a person who's submitting a form when there is
 - List <gcds-link href="{{ links.errorMessage }}">error messages</gcds-link> when a person needs to add information or make a correction to two or more components before they can submit a form.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.errorMessage }}" class="link-light">Error message</a> for describing a problem blocking a user action, related to a single component.
 

--- a/src/en/components/fieldset/use-case.md
+++ b/src/en/components/fieldset/use-case.md
@@ -28,7 +28,7 @@ Use a fieldset to group together related form elements or components so they're 
 - Logically grouping form elements or components helps support understanding and usability.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.input }}" class="link-light">Inputs</a> or <a href="{{ links.textarea }}" class="link-light">text areas</a> when you are requesting a written response from a person.
 

--- a/src/en/components/file-uploader/use-case.md
+++ b/src/en/components/file-uploader/use-case.md
@@ -25,7 +25,7 @@ Use the file uploader to:
 - Review selected files to be uploaded.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.textarea }}" class="link-light">Text areas</a> for multi-line freeform responses.
 

--- a/src/en/components/footer/code.md
+++ b/src/en/components/footer/code.md
@@ -20,18 +20,18 @@ Choose the **compact display** to include:
 
 1. The footer links band and the Government of Canada wordmark.
 
-<img class="b-sm b-default mt-300 mb-600 p-300" src="/images/en/components/example/example-footer-compact.svg" alt=""/>
+<img class="b-sm b-default mb-300 p-300" src="/images/en/components/example/example-footer-compact.svg" alt=""/>
 
 Include the **full display** if you need to include:
 
 1. The main band with a large selection of Government of Canada corporate links.
 2. The footer links band and the Government of Canada wordmark.
 
-<img class="b-sm b-default mt-300 mb-600 p-300" src="/images/en/components/example/example-footer-full.svg" alt=""/>
+<img class="b-sm b-default mb-300 p-300" src="/images/en/components/example/example-footer-full.svg" alt=""/>
 
 Opt to include the contextual band to add up to three footer links for your product.
 
-<img class="b-sm b-default mt-300 mb-600 p-300" src="/images/en/components/example/example-footer-full-with-contextual-links.svg" alt=""/>
+<img class="b-sm b-default mb-300 p-300" src="/images/en/components/example/example-footer-full-with-contextual-links.svg" alt=""/>
 
 ### Include the footer links band for Government of Canada sites and products
 

--- a/src/en/components/footer/use-case.md
+++ b/src/en/components/footer/use-case.md
@@ -30,7 +30,7 @@ Use this footer landmark – as part of a trusted brand – for apps, forms, or 
 - The Government of Canada identity through the wordmark.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.header }}" class="link-light">Header</a> for placing the Government of Canada branded header landmark.
 

--- a/src/en/components/grid/use-case.md
+++ b/src/en/components/grid/use-case.md
@@ -33,7 +33,7 @@ Use grids to:
 - Limit the width of content displayed to ensure lines wrap and are more readable.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.container }}" class="link-light">Container</a> for applying a basic, single column layout across all viewports.
 

--- a/src/en/components/header/design.md
+++ b/src/en/components/header/design.md
@@ -14,7 +14,7 @@ date: 'git Last Modified'
   <li>The <strong>language toggle</strong> component is a switch for French and English content. When the site language is set using the <code>lang</code> attribute, the toggle will be available in the other Official Language.</li>
 </ol>
 
-<img class="b-sm b-default mb-600 p-300" src="/images/en/components/anatomy/gcds-header-anatomy-recommended.svg" alt="Home link Taxonomy has three parts. The skip to content - indicated by a bright blue double white lined box with label of Skip to main content. GC header banner with a Canadian Flag with Government of Canada  and Government du Canada. Language toggle pointing at Français to use to toggle to French. Top bar pointing at Home link in a light grey banner with Site menu link outlined by a dark grey link to indicate the selected link with unselected Site menu link with no line underneath it."/>
+<img class="b-sm b-default p-300" src="/images/en/components/anatomy/gcds-header-anatomy-recommended.svg" alt="Home link Taxonomy has three parts. The skip to content - indicated by a bright blue double white lined box with label of Skip to main content. GC header banner with a Canadian Flag with Government of Canada  and Government du Canada. Language toggle pointing at Français to use to toggle to French. Top bar pointing at Home link in a light grey banner with Site menu link outlined by a dark grey link to indicate the selected link with unselected Site menu link with no line underneath it."/>
 
 ## Optional header elements – with H1 title
 
@@ -30,7 +30,7 @@ date: 'git Last Modified'
 
 The **search** element supports including a search form that is local or global.
 
-<img class="b-sm b-default mb-600 p-300" src="/images/en/components/anatomy/gcds-header-anatomy-optional.svg" alt="Home link Taxonomy has five parts. The skip to content - indicated by a bright blue double white lined box with label of Skip to main content. The Phase banner - indicated by a navy blue lined box with label of stages of the site. The stage 'pilot' is in a white navy blue outlined box. GC header banner with a Canadian Flag with Government of Canada  and Government du Canada. Language toggle pointing at Français to use to toggle to French. Top bar pointing at Home link in a light grey banner with Site menu link outlined by a dark grey link to indicate the selected link with unselected Site menu link with no line underneath it."/>
+<img class="b-sm b-default p-300" src="/images/en/components/anatomy/gcds-header-anatomy-optional.svg" alt="Home link Taxonomy has five parts. The skip to content - indicated by a bright blue double white lined box with label of Skip to main content. The Phase banner - indicated by a navy blue lined box with label of stages of the site. The stage 'pilot' is in a white navy blue outlined box. GC header banner with a Canadian Flag with Government of Canada  and Government du Canada. Language toggle pointing at Français to use to toggle to French. Top bar pointing at Home link in a light grey banner with Site menu link outlined by a dark grey link to indicate the selected link with unselected Site menu link with no line underneath it."/>
 
 ## Design and accessibility for headers
 

--- a/src/en/components/header/use-case.md
+++ b/src/en/components/header/use-case.md
@@ -30,7 +30,7 @@ Use this header landmark – as part of a trusted brand – for apps, forms, or 
 - The Federal Identity Program Government of Canada signature.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.footer }}" class="link-light">Footer</a> for placing the Government of Canada branded footer landmark.
 

--- a/src/en/components/heading/use-case.md
+++ b/src/en/components/heading/use-case.md
@@ -30,7 +30,7 @@ Use headings to:
 - Apply consistent typography styles and sizes throughout a website to create a cohesive and user-friendly design.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.text }}" class="link-light">Text</a> for paragraphs displaying non-heading content with matching GC Design System styles.
 

--- a/src/en/components/image/use-case.md
+++ b/src/en/components/image/use-case.md
@@ -26,7 +26,7 @@ Use a Image
 -
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="" class="link-light">component</a>
 

--- a/src/en/components/input/use-case.md
+++ b/src/en/components/input/use-case.md
@@ -32,7 +32,7 @@ Use an input to gather single-line information from a person when you're expecti
 Note: Only collect information you're authorized to handle and be sure to safeguard it to Government of Canada standards.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.textarea }}" class="link-light">Text areas</a> for multi-line freeform responses.
 

--- a/src/en/components/language-toggle/use-case.md
+++ b/src/en/components/language-toggle/use-case.md
@@ -29,7 +29,7 @@ Use the language toggle to:
 - Support Official Languages by offering equitable access in French and English.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.header }}" class="link-light">Header</a> for placing the Government of Canada branded header landmark.
 

--- a/src/en/components/link/design.md
+++ b/src/en/components/link/design.md
@@ -12,7 +12,7 @@ date: 'git Last Modified'
   <li>The <strong>link text</strong> navigates to a new page, website, or section on the current page. It specifies the link's destination or, for downloads, identifies the file type, and size. Note: Opening links in a new tab or window can be disorienting for people and can cause accessibility issues.</li>
   <li>
     The <strong>link icon</strong> is attached to certain link types, like download, phone, and email. Otherwise, it’s optional to add an icon.
-    <ul class="mt-400 ms-0">
+    <ul class="mt-300 ms-0">
       <li>The download icon lets a person know that selecting the link will initiate a download.</li>
       <li>The phone icon identifies the phone number and selecting it initiates a phone call.</li>
       <li>The email icon identifies the email address and initiates a message from the default email application.</li>

--- a/src/en/components/link/use-case.md
+++ b/src/en/components/link/use-case.md
@@ -31,7 +31,7 @@ Use links to:
 - Skip past navigational elements to get to main content.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.button }}" class="link-light">Buttons</a> when a person modifies data, changes a state, or initiates a specific action.
 

--- a/src/en/components/notice/design.md
+++ b/src/en/components/notice/design.md
@@ -21,18 +21,18 @@ date: "git Last Modified"
 
 ### Choose the appropriate notice type
 
-- Refer to the use case tab for guidelines on when to use each notice type.
+Refer to the use case tab for guidelines on when to use each notice type.
 
 ### Write concise and descriptive headings and messages
 
 - Write a meaningful heading that’s short and simple to highlight the goal of the notice.
-- In the heading, use words like “warning” and “success” that match the meaning conveyed by the icon and colour of the notice type you selected.  
-- Craft the message (below the heading) to be brief and impactful, ideally within three sentences.  
+- In the heading, use words like “warning” and “success” that match the meaning conveyed by the icon and colour of the notice type you selected.
+- Craft the message (below the heading) to be brief and impactful, ideally within three sentences.
 - Save the details for the main content area of a page. The notice is meant to attract attention and create an information trail for anyone who needs to know more.
 
 ### Use links to guide people to additional details if necessary
 
-- Use links to connect to additional details for a person who wants to read more.  
+- Use links to connect to additional details for a person who wants to read more.
 - Opt to create a dedicated page for more detailed content and use a short message in a notice to draw interested people to that page.
 - Avoid long notices. They can be distracting and frustrating.
 

--- a/src/en/components/notice/use-case.md
+++ b/src/en/components/notice/use-case.md
@@ -23,10 +23,10 @@ Use notice to:
 
 - Communicate updates, warnings, and confirmations about the tasks on a page or about an activity or event that could affect people using the service.
 - Make key messages stand out within page content, through sparing use.
-- Provide context or additional information on the page content for better understanding. 
+- Provide context or additional information on the page content for better understanding.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{links.errorMessage}}" class="link-light">Error message</a> or <a href="{{links.errorSummary}}" class="link-light">error summary</a> for errors in a form field, on a page, or in a flow.
 
@@ -89,8 +89,8 @@ Use the warning notice type to:
 
 Use the danger notice type to:
 
-- Highlight content that people must be aware of due to its severity and that could have major negative impacts if ignored. 
-- Emphasize an issue or news that has serious implications to health and safety, security, and laws. Include a link to the most current information.  
+- Highlight content that people must be aware of due to its severity and that could have major negative impacts if ignored.
+- Emphasize an issue or news that has serious implications to health and safety, security, and laws. Include a link to the most current information.
 - Flag when a person needs to take action right away and provide a means to do so, like a link.
 
 <gcds-notice

--- a/src/en/components/pagination/use-case.md
+++ b/src/en/components/pagination/use-case.md
@@ -29,7 +29,7 @@ Use pagination for very lengthy content on a single page that might be difficult
 - Highlight the reader’s position in a sequence of content.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.stepper }}" class="link-light">Stepper</a> to track progress in a multi-step process.
 

--- a/src/en/components/radio-group/use-case.md
+++ b/src/en/components/radio-group/use-case.md
@@ -28,7 +28,7 @@ Use radio groups with a [fieldset]({{ links.fieldset }}). Use a radio group to r
 - Give a person the ability to answer without writing by selecting one item from a list.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.checkbox }}" class="link-light">Checkboxes</a> when you are expecting the user to select multiple options from a list of items.
 

--- a/src/en/components/screenreader-only/use-case.md
+++ b/src/en/components/screenreader-only/use-case.md
@@ -27,8 +27,8 @@ Use screenreader-only to:
 - Communicate effectively without adding more text to the main content. This helps reduce cognitive load for everyone by only providing content when and where it’s needed.
 - Improve the assistive tech experience when there are no other suitable options in semantic HTML.
 
-<article class="bg-full-width bg-primary text-light pt-500 pb-400 my-500">
-  <h2 class="mt-0 mb-400">Related components</h2>
+<article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.heading }}" class="link-light">Headings</a> for structuring content by creating levels of hierarchy that organize page content visually and mentally, using GC Design System styles.
 

--- a/src/en/components/search/use-case.md
+++ b/src/en/components/search/use-case.md
@@ -27,7 +27,7 @@ Use search to help a person on your website or page find information:
 - From a subset of content you have locally indexed, using your own data set.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
   <a href="{{ links.header }}" class="link-light">Header</a> for placing the Government of Canada branded header landmark.
 

--- a/src/en/components/select/use-case.md
+++ b/src/en/components/select/use-case.md
@@ -26,7 +26,7 @@ Use select within a form to:
 - Give a person the ability to answer without writing, by selecting one item from a list.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.checkbox }}" class="link-light">Checkboxes</a> when you are expecting the user to select 1 or more options from a list of items.
 

--- a/src/en/components/side-navigation/use-case.md
+++ b/src/en/components/side-navigation/use-case.md
@@ -29,7 +29,7 @@ It’s optional to use side navigation in products for:
 - Enabling contextual navigation for a person using the product by displaying their current location within the product.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.topNav }}" class="link-light">Top navigation</a> for websites with up to 2 levels in their information architecture.
 

--- a/src/en/components/signature/design.md
+++ b/src/en/components/signature/design.md
@@ -31,18 +31,18 @@ Display the French-first signature on French pages and the English-first on Engl
 - Always apply the same colour combination in the signature and wordmark. For example, if one is black and white, the other needs to be as well.
 - For single colour, check the contrast ratio between the signature elements for, at minimum, WCAG AA compliance.
 
-<img class="b-sm b-default p-300 mt-300 mb-300" src="/images/en/components/example/example-signature-side-by-side-en.svg" alt="An image presenting both variations of the signature component. The signature type is on the left and the wordmark type is on the right." />
+<img class="b-sm b-default p-300 mb-300" src="/images/en/components/example/example-signature-side-by-side-en.svg" alt="An image presenting both variations of the signature component. The signature type is on the left and the wordmark type is on the right." />
 
 The standard colour style uses black text and a red flag applied to a white backdrop.
 
-<img class="b-sm b-default p-300 mt-600 mb-300" src="/images/en/components/example/example-signature-side-by-side-reversed-en.svg" alt="An image presenting both variations of the signature component. The signature type is on the left and the wordmark type is on the right. This variation has white text on a black back drop" />
+<img class="b-sm b-default p-300 mb-300" src="/images/en/components/example/example-signature-side-by-side-reversed-en.svg" alt="An image presenting both variations of the signature component. The signature type is on the left and the wordmark type is on the right. This variation has white text on a black back drop" />
 
 The reversed colour style uses white text and a red flag applied to a black backdrop.
 
-<img class="b-sm b-default p-300 mt-600 mb-300" src="/images/en/components/example/example-signature-bw-en.svg" alt="An image presenting two signature and wordmark pairings. One where the signature and wordmark are all black on a white backdrop and the second where the signature and wordmark are all white on a black backdrop." />
+<img class="b-sm b-default p-300 mb-300" src="/images/en/components/example/example-signature-bw-en.svg" alt="An image presenting two signature and wordmark pairings. One where the signature and wordmark are all black on a white backdrop and the second where the signature and wordmark are all white on a black backdrop." />
 
 The black and white style uses all black or all white. All black is the more common use.
 
-<img class="b-sm b-default p-300 mt-600 mb-300" src="/images/en/components/example/example-signature-single-colour-style-en.svg" alt="An image showing the the signature and wordmark in dark purple on a light purple backdrop. There are bars and boxes simulating text and pictures, you are to assume this is a mock webpage. The text and pictures boxes are also dark purple." />
+<img class="b-sm b-default p-300 mb-300" src="/images/en/components/example/example-signature-single-colour-style-en.svg" alt="An image showing the the signature and wordmark in dark purple on a light purple backdrop. There are bars and boxes simulating text and pictures, you are to assume this is a mock webpage. The text and pictures boxes are also dark purple." />
 
 Single colour style uses another colour if that colour is the only colour used in the product.

--- a/src/en/components/signature/use-case.md
+++ b/src/en/components/signature/use-case.md
@@ -30,7 +30,7 @@ Use the signature landmark as part of a trusted brand to:
 - Offer a global link to the site’s home page in both Official Languages.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.header }}" class="link-light">Header</a> for placing the Government of Canada branded header landmark.
 
@@ -49,7 +49,7 @@ Use the **signature** type in the header beside the language toggle component to
 - Present the corporate signature of the Government of Canada.
 - Provide users with a landmark for navigating back to the site’s homepage.
 
-<img class="b-sm b-default mt-300 mb-75 p-300" src="/images/en/components/example/example-signature-signature-type-en.svg" alt="The Government of Canada signature. The signature includes the red Canada flag, followed by the text “Government of Canada / Gouvernement du Canada”." />
+<img class="b-sm b-default p-300" src="/images/en/components/example/example-signature-signature-type-en.svg" alt="The Government of Canada signature. The signature includes the red Canada flag, followed by the text “Government of Canada / Gouvernement du Canada”." />
 
 ### Wordmark type
 
@@ -58,4 +58,4 @@ Use the **wordmark** type in the in the bottom right corner of the footer to:
 - Accompany the signature or another approved corporate signature of the Government of Canada on public-facing and internal sites and products.
 - Present this official symbol and global identifier of the Government of Canada.
 
-<img class="b-sm b-default mt-300 mb-225 p-300" src="/images/en/components/example/example-signature-wordmark-type-en.svg" alt="The Canada Wordmark. The wordmark includes the word “Canada” with a red Canada flag just above the final “a”." />
+<img class="b-sm b-default p-300" src="/images/en/components/example/example-signature-wordmark-type-en.svg" alt="The Canada Wordmark. The wordmark includes the word “Canada” with a red Canada flag just above the final “a”." />

--- a/src/en/components/stepper/use-case.md
+++ b/src/en/components/stepper/use-case.md
@@ -27,7 +27,7 @@ Use a stepper for a logical sequence split over more than one page to:
 - Make the structure of a path clear by showing the total number of steps.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.pagination }}" class="link-light">Pagination</a> when a user needs to navigate a range of pages that are not part of a multi-step process. It provides controls to select the next or previous page.
 

--- a/src/en/components/text/use-case.md
+++ b/src/en/components/text/use-case.md
@@ -28,7 +28,7 @@ Use the text component to:
 - Divide content into understandable sections with vertical and horizontal margins. Breaking up content supports readability, simplifies site navigation, and reduces task abandonment.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.heading }}" class="link-light">Headings</a> for structuring content by creating levels of hierarchy that organize page content visually and mentally, using GC Design System styles.
 

--- a/src/en/components/textarea/use-case.md
+++ b/src/en/components/textarea/use-case.md
@@ -29,7 +29,7 @@ Use a text area to collect multi-line information when you're expecting a person
 Note: Only collect information you're authorized to handle and be sure to safeguard it to Government of Canada standards.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.input }}" class="link-light">Input</a> for short, single-line responses.
 

--- a/src/en/components/theme-and-topic-menu/use-case.md
+++ b/src/en/components/theme-and-topic-menu/use-case.md
@@ -24,7 +24,7 @@ Use theme and topic menu to:
 - Provide global navigation across Government of Canada web pages, when people commonly need to access these pages from your website.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
   <a href="{{ links.header }}" class="link-light">Header</a> for placing the Government of Canada branded header landmark.
 

--- a/src/en/components/top-navigation/use-case.md
+++ b/src/en/components/top-navigation/use-case.md
@@ -29,7 +29,7 @@ The top navigation helps give visitors a sense of a site's structure, purpose, a
 - Signal the active page and give a cue to the person's current position on the site.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Related components</h2>
+  <h2 class="mt-0">Related components</h2>
 
 <a href="{{ links.sideNav }}" class="link-light">Side navigation</a> for products with up to three levels of navigation when the main content fits a narrow page width.
 

--- a/src/en/get-involved.md
+++ b/src/en/get-involved.md
@@ -19,7 +19,7 @@ Right now, we're testing GC Design System in alpha, the first usable phase of a 
 
 ## Find out about GC Design System
 
-<div class="d-grid lg:grid-cols-3 mb-400 gap-400">
+<gcds-grid columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
   <gcds-card
     card-title="Subscribe to newsletter"
     href="{{ links.contact }}"
@@ -30,13 +30,13 @@ Right now, we're testing GC Design System in alpha, the first usable phase of a 
     href="{{ links.registerDemo }}"
     description="Get an intro to prototyping and developing web experiences using the design system, followed by a Q&A."
   ></gcds-card>
-</div>
+</gcds-grid>
 
-<hr/>
+<hr class="mt-600" />
 
-<gcds-heading tag="h2" margin-top="225">Contribute to our next priorities</gcds-heading>
+## Contribute to our next priorities
 
-You can contribute to upcoming GC Design System work. 
+You can contribute to upcoming GC Design System work.
 
 We’re actively seeking contributions for the following items:
 
@@ -56,9 +56,9 @@ Provide any of the following for each component or pattern:
 <gcds-button button-role="secondary" type="link" href="{{ links.githubCompsPriority }}" external>Contribute in Github</gcds-button>
 <gcds-button button-role="secondary" type="link" href="{{ links.contact }}" external>Contact us</gcds-button>
 
-<hr />
+<hr class="mt-600" />
 
-<gcds-heading tag="h2" margin-top="225">What else is coming soon</gcds-heading>
+## What else is coming soon
 
 ### Upcoming components and templates
 

--- a/src/en/page-templates/basic/basic.md
+++ b/src/en/page-templates/basic/basic.md
@@ -33,7 +33,7 @@ The basic page template is for non-specialized pages across Canada.ca and is an 
 <gcds-button class="md:d-inline-block d-block md:me-300 me-0 md:mb-0 mb-300" button-role="secondary" type="link" href="{{ links.pageTemplatesBasicPreview }}" target="_blank">Open demo in new tab</gcds-button>
 <gcds-button class="md:d-inline-block d-block" button-role="secondary" type="link" href="{{ links.pageTemplatesBasicCode }}" target="_blank">Get code in new tab</gcds-button>
 
-<img class="max-width-content b-sm b-default mb-300 p-300" src="/images/en/templates/basic-page-preview.png" alt="A basic page template includes the Government of Canada header and footer, H1, H2 and H3 heading sections with text underneath each section."/>
+<img class="max-width-content b-sm b-default p-300" src="/images/en/templates/basic-page-preview.png" alt="A basic page template includes the Government of Canada header and footer, H1, H2 and H3 heading sections with text underneath each section."/>
 
 ## How to implement
 
@@ -48,7 +48,7 @@ To prototype in Figma, find the <gcds-link external href="{{ links.pageTemplates
 
 ### Improve navigation on longer pages
 
-- Include an "On this page" section with bulleted anchor links for pages with four or more sections. 
+- Include an "On this page" section with bulleted anchor links for pages with four or more sections.
 - Anchor links to improve navigation and help people find relevant content.
 
 ### Preview "On this page"
@@ -56,7 +56,7 @@ To prototype in Figma, find the <gcds-link external href="{{ links.pageTemplates
 <gcds-button class="md:d-inline-block d-block md:me-300 me-0 md:mb-0 mb-300" button-role="secondary" type="link" href="{{ links.pageTemplatesBasicExtOTPPreview }}" target="_blank">Open demo in new tab</gcds-button>
 <gcds-button  button-role="secondary" type="link" href="{{ links.pageTemplatesBasicExtOTPCode }}" target="_blank">Get code in new tab</gcds-button>
 
-<img class="max-width-content b-sm b-default mb-300 p-300" src="/images/en/templates/basic-page-on-this-page-preview.png" alt='A basic page template with a "On this page" section includes the Government of Canada header and footer, a "On this page" section with three sections listed underneath.'/>
+<img class="max-width-content b-sm b-default p-300" src="/images/en/templates/basic-page-on-this-page-preview.png" alt='A basic page template with a "On this page" section includes the Government of Canada header and footer, a "On this page" section with three sections listed underneath.'/>
 
 ### Maintain a logical heading structure
 

--- a/src/en/pages/index.md
+++ b/src/en/pages/index.md
@@ -7,14 +7,14 @@ redirect_from: /
 date: 'git Last Modified'
 ---
 
-<h2 class="py-450">Start using GC Design System</h2>
+<h2 class="my-450">Start using GC Design System</h2>
 
 <article class="py-600 bg-primary text-light bg-full-width">
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr">
     <li class="list-none md:mb-0 mb-600">
       <img class="mb-300" src="../../images/common/home/icon-design.svg" alt="" />
-      <h3 class="mb-300">Design experiences</h3>
-      <p class="mb-300">Visit our Figma library to explore design assets.</p>
+      <h3 class="mt-0">Design experiences</h3>
+      <p>Visit our Figma library to explore design assets.</p>
       <a class="link-light" href="{{ links.figma }}" target="_blank">
         Start designing
         <gcds-icon name="external-link" label="Opens in a new tab." margin-left="25" />
@@ -22,43 +22,43 @@ date: 'git Last Modified'
     </li>
     <li class="list-none">
       <img class="mb-300" src="../../images/common/home/icon-develop.svg" alt="" />
-      <h3 class="mb-300">Develop products</h3>
-      <p class="mb-300">Install the component package.</p>
+      <h3 class="mt-0">Develop products</h3>
+      <p>Install the component package.</p>
       <a class="link-light" href="{{ links.installation }}">Start developing</a>
     </li>
   </gcds-grid>
 </article>
 
-<article class="py-450">
-  <h2 class="mb-300">A design system just for you</h2>
+<article class="pb-600">
+  <h2>A design system just for you</h2>
   <p class="mb-600">Take a look around. <gcds-link href="{{ links.contact }}">Tell us what you think</gcds-link>.</p>
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
     <li class="list-none">
       <img class="mb-150" src="../../images/common/home/icon-components.svg" alt="" />
-      <h3 class="mb-300">Components</h3>
-      <p class="mb-300">User interface building blocks address different user objectives.</p>
-      <p class="mb-300">Select reusable code for common components, paired with best practice advice, for the framework you're using.</p>
+      <h3 class="mt-0">Components</h3>
+      <p>User interface building blocks address different user objectives.</p>
+      <p>Select reusable code for common components, paired with best practice advice, for the framework you're using.</p>
       <gcds-link href="{{ links.components }}">View components</gcds-link>
     </li>
     <li class="list-none">
       <img class="mb-150" src="../../images/common/home/icon-template.svg" alt="" />
-      <h3 class="mb-300">Page templates</h3>
-      <p class="mb-300">Reusable page layouts combine components into common page types.</p>
-      <p class="mb-300">Start your project with basic, pre-built pages that provide a consistent, recognizable Canada.ca experience.</p>
+      <h3 class="mt-0">Page templates</h3>
+      <p>Reusable page layouts combine components into common page types.</p>
+      <p>Start your project with basic, pre-built pages that provide a consistent, recognizable Canada.ca experience.</p>
       <gcds-link href="{{ links.pageTemplates }}">Browse page templates</gcds-link>
     </li>
     <li class="list-none">
       <img class="mb-150" src="../../images/common/home/icon-tokens.svg" alt="" />
-      <h3 class="mb-300">Design tokens</h3>
-      <p class="mb-300">Brand and design decisions built into code.</p>
-      <p class="mb-300">Learn how encoded decisions shape the design of government services for a consistent visual experience.</p>
+      <h3 class="mt-0">Design tokens</h3>
+      <p>Brand and design decisions built into code.</p>
+      <p>Learn how encoded decisions shape the design of government services for a consistent visual experience.</p>
       <gcds-link href="{{ links.styles }}">View tokens</gcds-link>
     </li>
   </gcds-grid>
 </article>
 
 <article class="py-600 bg-light bg-full-width">
-  <h2 class="mb-300">What's new</h2>
+  <h2 class="mt-0">What's new</h2>
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr">
     <gcds-card
       href="{{ links.registerDemo }}"
@@ -91,9 +91,8 @@ date: 'git Last Modified'
   </gcds-grid>
 </article>
 
-<article class="py-450">
-  <h2 class="mb-300">Featured components</h2>
-
+<article class="pb-600">
+  <h2>Featured components</h2>
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
     <gcds-card
       href="{{ links.notice }}"

--- a/src/en/styles/typography/typography.md
+++ b/src/en/styles/typography/typography.md
@@ -111,6 +111,4 @@ The font family contains fallback values. The fallback is a substitute value for
 
 <br/>
 
-{% assign removeBorder = true %}
-
 {% include "partials/helpus.njk" %}

--- a/src/fr/composants/avis/cas-dutilisation.md
+++ b/src/fr/composants/avis/cas-dutilisation.md
@@ -26,11 +26,11 @@ Utilisez les avis pour :
 - Fournir du contexte ou des renseignements supplémentaires concernant le contenu de la page pour une meilleure compréhension.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
-<a href="{{ links.errorMessage }}" class="link-light">Message d’erreur</a> ou <a href="{{ links.errorSummary }}" class="link-light">résumé des erreurs</a> pour des erreurs au sein d’un champ de formulaire, d’une page ou d’un flux. 
- 
-Bannière pour un message s’appliquant à une partie ou à l’ensemble du site ou du produit.  
+<a href="{{ links.errorMessage }}" class="link-light">Message d’erreur</a> ou <a href="{{ links.errorSummary }}" class="link-light">résumé des erreurs</a> pour des erreurs au sein d’un champ de formulaire, d’une page ou d’un flux.
+
+Bannière pour un message s’appliquant à une partie ou à l’ensemble du site ou du produit.
 
 </article>
 
@@ -90,7 +90,7 @@ Utilisez les avis de type « Avertissement » pour :
 Utilisez le type d’avis « Danger » pour :
 
 - Mettre en évidence du contenu dont les gens doivent prendre connaissance compte tenu de sa gravité, sous peine de s’exposer à des incidences négatives majeures.
-- Mettre l’accent sur une question ou des nouvelles ayant de graves répercussions dans les domaines de la santé, de la sécurité et de la loi. Inclure un lien vers les renseignements les plus récents.  
+- Mettre l’accent sur une question ou des nouvelles ayant de graves répercussions dans les domaines de la santé, de la sécurité et de la loi. Inclure un lien vers les renseignements les plus récents.
 - Signaler à une personne qu’elle doit agir immédiatement et lui donner les moyens de le faire, par exemple en lui fournissant un lien.
 
 <gcds-notice

--- a/src/fr/composants/avis/design.md
+++ b/src/fr/composants/avis/design.md
@@ -21,18 +21,18 @@ date: "git Last Modified"
 
 ### Choisir le type d’avis approprié
 
-- Référez-vous aux cas d’utilisation pour savoir quand utiliser chaque type d’avis.
+Référez-vous aux cas d’utilisation pour savoir quand utiliser chaque type d’avis.
 
 ### Rédigez des titres et des messages concis et descriptifs
 
 - Rédigez un titre significatif, court et simple pour souligner l’objectif de l’avis.
-- Dans le titre, utilisez des titres comme « Avertissement » et « Succès » correspondant au sens transmis par l’icône et la couleur du type d’avis sélectionné.  
-- Rédigez un message (en dessous du titre) bref et percutant. Idéalement, faites en sorte qu’il ne dépasse pas trois phrases.  
+- Dans le titre, utilisez des titres comme « Avertissement » et « Succès » correspondant au sens transmis par l’icône et la couleur du type d’avis sélectionné.
+- Rédigez un message (en dessous du titre) bref et percutant. Idéalement, faites en sorte qu’il ne dépasse pas trois phrases.
 - Enregistrez les détails pour la zone de contenu principale d’une page. L’avis doit attirer l’attention et créer une « piste d’information » pour toute personne ayant besoin d’en savoir plus.
 
 ### Au besoin, utilisez des liens pour guider les gens vers des renseignements supplémentaires
 
-- Utilisez des liens pour guider les personnes souhaitant en savoir plus vers des renseignements supplémentaires.  
+- Utilisez des liens pour guider les personnes souhaitant en savoir plus vers des renseignements supplémentaires.
 - Choisissez de créer une page particulière destinée à du contenu plus détaillé et utilisez un message bref dans un avis pour attirer les personnes intéressées vers cette page.
 - Évitez les longs avis. Ils peuvent distraire et frustrer les gens.
 
@@ -41,7 +41,7 @@ date: "git Last Modified"
 - Limitez le nombre d’avis par page. Plus les gens rencontrent des avis et messages d’avertissement, moins ils y sont réceptifs.
 - Veillez à retirer les avis une fois qu’ils ne servent plus.
 
-### Placez les avis à l’endroit où vous placeriez un paragraphe  
+### Placez les avis à l’endroit où vous placeriez un paragraphe
 
 - Ajoutez un avis à l’endroit où vous ajouteriez un paragraphe important (ou une section importante) sur la page.
 - Envisagez de placer un avis au haut de la page ou de la section de contenu pour éviter qu’il ne soit négligé.

--- a/src/fr/composants/barre-de-navigation-laterale/cas-dutilisation.md
+++ b/src/fr/composants/barre-de-navigation-laterale/cas-dutilisation.md
@@ -29,7 +29,7 @@ L'utilisation d'une barre de navigation latérale dans un produit est optionnell
 - lorsque vous cherchez à offrir aux utilisateur·rice·s d'un produit une navigation contextuelle en affichant leur emplacement actuel au sein du produit.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.topNav }}" class="link-light">Barre de navigation supérieure</a> pour les sites Web dont l'architecture d'information comporte 1 à 2 niveaux.
 

--- a/src/fr/composants/barre-de-navigation-superieure/cas-dutilisation.md
+++ b/src/fr/composants/barre-de-navigation-superieure/cas-dutilisation.md
@@ -29,7 +29,7 @@ La barre de navigation supérieure permet aux visiteur·se·s d'avoir une idée 
 - Signaler la page active et la localisation actuelle de la personne sur le site.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.sideNav }}" class="link-light">Barre de navigation latérale</a> : pour les produits avec jusqu'à trois niveaux de navigation, lorsque le contenu principal correspond à une largeur de page étroite.
 

--- a/src/fr/composants/bascule-de-langue/cas-dutilisation.md
+++ b/src/fr/composants/bascule-de-langue/cas-dutilisation.md
@@ -29,7 +29,7 @@ Utilisez la bascule de langue pour :
 - soutenir les langues officielles en proposant un contenu tout aussi accessible en français qu’en anglais.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.header }}" class="link-light">En-tête</a> : lorsque vous cherchez à placer l'image de marque du gouvernement du Canada dans l'en-tête de la page.
 

--- a/src/fr/composants/boite/cas-dutilisation.md
+++ b/src/fr/composants/boite/cas-dutilisation.md
@@ -31,7 +31,7 @@ Utilisez les boîtes pour :
 - Centrer le contenu dans le contexte d’un écran ou d’une clôture.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.grid }}" class="link-light">Grille</a> pour une colonne réactive et flexible permettant de positionner du contenu sur une page.
 

--- a/src/fr/composants/bouton/cas-dutilisation.md
+++ b/src/fr/composants/bouton/cas-dutilisation.md
@@ -29,7 +29,7 @@ Utilisez un bouton pour les actions importantes qu'une personne utilisant votre 
 - Naviguer entre les différentes étapes d'une séquence;
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.link }}" class="link-light">Liens</a> : pour permettre de naviguer à une nouvelle page, à un autre site Web, à un fichier ou à une nouvelle section de la page actuelle et de lancer un téléchargement de fichiers.
 
@@ -76,13 +76,13 @@ Remarque : Utilisez le [composant lien]({{ links.link }}) lorsque vous devez ins
 Un rôle est un sous-type de bouton à usage spécifique sur une page.
 
 <div class="remove-empty-p">
-<gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Aperçu du bouton principal" "px-300 py-400" "" %}
+<gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
+  {% componentPreview "Aperçu du bouton principal" "px-225 py-300" "" %}
   <gcds-button button-role="primary">Soumettre</gcds-button>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mb-400">Utilisations du bouton principal</h3>
-    <ul class="list-disc mb-400">
+    <h3 class="mt-0">Utilisations du bouton principal</h3>
+    <ul class="list-disc mb-300">
       <li>L'action la plus importante d'une page.</li>
       <li>Actions cruciales au sein d'un processus ou en tant que bouton par défaut.</li>
       <li>Limitation à une seule utilisation.</li>
@@ -91,13 +91,13 @@ Un rôle est un sous-type de bouton à usage spécifique sur une page.
   </div>
 </gcds-grid>
 <br/>
-<gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Aperçu du bouton secondaire" "px-300 py-400" "" %}
+<gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
+  {% componentPreview "Aperçu du bouton secondaire" "px-225 py-300" "" %}
   <gcds-button button-role="secondary">Annuler</gcds-button>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mb-400">Utilisations du bouton secondaire</h3>
-    <ul class="list-disc mb-400">
+    <h3 class="mt-0">Utilisations du bouton secondaire</h3>
+    <ul class="list-disc mb-300">
       <li>Pour les actions secondaires.</li>
       <li>Pour mettre en avant une action commune et importante, sans qu'il s'agisse de la plus importante.</li>
       <li>Pour souligner des options de tâches alternatives importantes, au besoin plus d'une fois par page.</li>
@@ -105,13 +105,13 @@ Un rôle est un sous-type de bouton à usage spécifique sur une page.
   </div>
 </gcds-grid>
 <br/>
-<gcds-grid columns="1fr" columns-tablet="1fr 2fr" gap="500" align-items="start">
-  {% componentPreview "Aperçu du bouton « Danger »" "px-300 py-400" "" %}
+<gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
+  {% componentPreview "Aperçu du bouton « Danger »" "px-225 py-300" "" %}
   <gcds-button button-role="danger">Supprimer</gcds-button>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mb-400">Utilisations du bouton « Danger »</h3>
-    <ul class="list-disc mb-400">
+    <h3 class="mt-0">Utilisations du bouton « Danger »</h3>
+    <ul class="list-disc mb-300">
       <li>Pour signaler des actions sérieuses comme le retrait ou la suppression de renseignements.</li>
       <li>Pour les actions entraînant des changements difficiles à inverser.</li>
     </ul>

--- a/src/fr/composants/carte/cas-dutilisation.md
+++ b/src/fr/composants/carte/cas-dutilisation.md
@@ -32,7 +32,7 @@ Utilisez une carte pour :
 Remarque : Pour Canada.ca, évitez d'utiliser des cartes au lieu du menu d'accueil thématique inclu dans les modèles de page d'accueil et de page de thème et de sujet.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.details }}" class="link-light">Détails</a> pour dissimuler des renseignements secondaires qu'une personne peut développer sur la même page.
 

--- a/src/fr/composants/case-a-cocher/cas-dutilisation.md
+++ b/src/fr/composants/case-a-cocher/cas-dutilisation.md
@@ -28,8 +28,7 @@ Utilisez la case à cocher avec un [jeu de champs]({{ links.fieldset }}) pour po
 - Donner à la personne la possibilité de répondre à la question sans écrire en sélectionnant un ou plusieurs éléments dans une liste.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 Utilisez les <a href="{{ links.radioGroup }}" class="link-light">groupes de boutons radio</a> pour solliciter un choix unique parmi un plus grand ensemble d’options.
 

--- a/src/fr/composants/champ-de-date/cas-dutilisation.md
+++ b/src/fr/composants/champ-de-date/cas-dutilisation.md
@@ -29,7 +29,7 @@ Utilisez un champ de date pour recueillir une date lorsque vous attendez d’une
 - Évitez d’utiliser un champ de date si la date n’est pas connue de la personne. Utilisez alors un sélecteur de date.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
   <a href="{{ links.input }}" class="link-light">Champs de saisie</a> : lorsque vous voulez que la personne saisisse seulement une année ou un jour du mois.
 

--- a/src/fr/composants/champ-de-date/design.md
+++ b/src/fr/composants/champ-de-date/design.md
@@ -23,7 +23,9 @@ date: "git Last Modified"
 ## Accessibilité et design des champ de date
 
 ### Favorisez la réussite de la tâche à l’aide d’un texte explicatif
-- Utilisez un texte explicatif dans la légende du jeu de champs pour aider une personne à comprendre le format de date qu’elle peut utiliser. Par exemple, le texte explicatif « 7 septembre » plutôt que « 07 septembre » indique qu’un chiffre unique, non précédé d’un zéro, suffit.
+
+Utilisez un texte explicatif dans la légende du jeu de champs pour aider une personne à comprendre le format de date qu’elle peut utiliser. Par exemple, le texte explicatif « 7 septembre » plutôt que « 07 septembre » indique qu’un chiffre unique, non précédé d’un zéro, suffit.
 
 ### Rédigez des messages d’erreur précis
-- Rédigez des messages d’erreur pour chaque champ de la date. Ces messages doivent renseigner sur les informations manquantes ou les erreurs de format. Par exemple, si une personne a saisi une année de 2 chiffres, indiquez que l’année doit comporter 4 chiffres.
+
+Rédigez des messages d’erreur pour chaque champ de la date. Ces messages doivent renseigner sur les informations manquantes ou les erreurs de format. Par exemple, si une personne a saisi une année de 2 chiffres, indiquez que l’année doit comporter 4 chiffres.

--- a/src/fr/composants/champ-de-saisie/cas-dutilisation.md
+++ b/src/fr/composants/champ-de-saisie/cas-dutilisation.md
@@ -32,7 +32,7 @@ Utilisez un champ de saisie lorsque vous attendez de l'utilisateur·rice une ré
 Remarque : Ne recueillez que les renseignements que vous êtes autorisé·e à traiter et veillez à les protéger conformément aux normes du gouvernement du Canada.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.textarea }}" class="link-light">Zone de texte</a> : lorsque vous cherchez à obtenir une réponse libre de plusieurs lignes.
 

--- a/src/fr/composants/chemin-de-navigation/cas-dutilisation.md
+++ b/src/fr/composants/chemin-de-navigation/cas-dutilisation.md
@@ -31,7 +31,7 @@ En plus de signaler à un·e visiteur·se son emplacement actuel sur le site et 
 - Organiser les sites Web selon une hiérarchie à plus de deux niveaux.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.footer }}" class="link-light">Pied de page</a> : pour placer le pied de page portant l'image de marque du gouvernement du Canada.
 

--- a/src/fr/composants/date-de-modification/cas-dutilisation.md
+++ b/src/fr/composants/date-de-modification/cas-dutilisation.md
@@ -27,7 +27,7 @@ Utilisez la date de modification pour :
 - Identifier la version actuelle d'une application.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.footer }}" class="link-light">Pied de page</a> : pour placer le pied de page portant l'image de marque du gouvernement du Canada.
 
@@ -36,30 +36,29 @@ Utilisez la date de modification pour :
 ## Types de composants
 
 <div class="remove-empty-p">
-<gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
+<gcds-grid class="mb-300" columns="1fr" columns-tablet="1fr 2fr" align-items="start">
   {% componentPreview "Aperçu du le type date" "px-225 py-300" "" %}
   <gcds-date-modified>2023-08-22</gcds-date-modified>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mb-300">Type « Date »</h3>
-    <p class="mb-300">Utilisez le type « date » pour :</p>
+    <h3 class="mt-0">Type « Date »</h3>
+    <p>Utilisez le type « date » pour :</p>
     <ul class="list-disc mb-300">
       <li>Indiquer la date de la dernière modification apportée à une page ou à un site Web.</li>
     </ul>
   </div>
 </gcds-grid>
-<br/>
+
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
   {% componentPreview "Aperçu du le type version" "px-225 py-300" "" %}
   <gcds-date-modified type="version">1.0.0</gcds-date-modified>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mb-300">Type « Version »</h3>
-    <p class="mb-300">Utilisez le type « version » pour :</p>
+    <h3 class="mt-0">Type « Version »</h3>
+    <p>Utilisez le type « version » pour :</p>
     <ul class="list-disc mb-300">
       <li>Identifier la version actuelle d'une application.</li>
     </ul>
   </div>
 </gcds-grid>
 </div>
-</br>

--- a/src/fr/composants/details/cas-dutilisation.md
+++ b/src/fr/composants/details/cas-dutilisation.md
@@ -29,7 +29,7 @@ Utilisez le composant Détails pour offrir un aperçu du contenu plus détaillé
 - donner au lectorat la possibilité de contrôler le contenu pour les sujets pouvant bouleverser certaines personnes. Celles-ci peuvent accéder au contenu une fois qu'elles se sentent prêtes et le dissimuler une fois qu'elles l'ont vu.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes </h2>
+  <h2 class="mt-0">Composants connexes </h2>
 
 Onglets : lorsque vous souhaitez remplacer tout le contenu d'une section ou d'une page.
 

--- a/src/fr/composants/en-tete/cas-dutilisation.md
+++ b/src/fr/composants/en-tete/cas-dutilisation.md
@@ -30,7 +30,7 @@ Pour les applications, formulaires et autres services numériques transactionnel
 - La signature du Programme fédéral de l'image de marque du gouvernement du Canada.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.footer }}" class="link-light">Pied de page</a> : lorsque vous cherchez à placer l'image de marque du gouvernement du Canada en pied de page.
 

--- a/src/fr/composants/en-tete/design.md
+++ b/src/fr/composants/en-tete/design.md
@@ -14,7 +14,7 @@ date: 'git Last Modified'
   <li>Le composant de la <strong>bascule de langue</strong> est un commutateur du contenu en français et en anglais. Utilisez l'attribut <code>lang</code> pour définir la langue du site; le bouton à bascule proposera l'autre langue officielle.</li>
 </ol>
 
-<img class="b-sm b-default mb-600 p-300" src="/images/fr/components/anatomy/gcds-header-anatomy-recommended.svg" alt="L'anatomie des composants entête et menu du site identifiants le lien passer au contenu, et l'entête du gouvernement du Canada."/>
+<img class="b-sm b-default p-300" src="/images/fr/components/anatomy/gcds-header-anatomy-recommended.svg" alt="L'anatomie des composants entête et menu du site identifiants le lien passer au contenu, et l'entête du gouvernement du Canada."/>
 
 ## Éléments facultatifs de l'en-tête — avec titre H1
 
@@ -30,7 +30,7 @@ date: 'git Last Modified'
 
 L'élément de **recherche** permet d'inclure un champ de recherche locale ou générale.
 
-<img class="b-sm b-default mb-600 p-300" src="/images/fr/components/anatomy/gcds-header-anatomy-optional.svg" alt="L'anatomie des composants entête et menu du site identifiants le lien passer au contenu, la bannière de phase, l'entête du gouvernement du Canada et le menu du site."/>
+<img class="b-sm b-default p-300" src="/images/fr/components/anatomy/gcds-header-anatomy-optional.svg" alt="L'anatomie des composants entête et menu du site identifiants le lien passer au contenu, la bannière de phase, l'entête du gouvernement du Canada et le menu du site."/>
 
 ## Design et accessibilité de l'en-tête
 

--- a/src/fr/composants/grille/cas-dutilisation.md
+++ b/src/fr/composants/grille/cas-dutilisation.md
@@ -33,7 +33,7 @@ Utilisez des grilles pour :
 - Limiter la largeur du contenu affiché pour veiller à ce que le texte soit renvoyé à la ligne et plus lisible.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.container }}" class="link-light">Boîte</a> : pour appliquer une disposition de base à une seule colonne sur toutes les fenêtres d'affichage.
 

--- a/src/fr/composants/groupe-de-boutons-radio/cas-dutilisation.md
+++ b/src/fr/composants/groupe-de-boutons-radio/cas-dutilisation.md
@@ -30,7 +30,7 @@ Utilisez un groupe de boutons radio avec un [jeu de champs]({{ links.fieldset }}
 - Lui donner la capacité de répondre sans avoir à écrire en sélectionnant une option parmi une liste.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.checkbox }}" class="link-light">Cases à cocher</a> lorsque vous prévoyez que l’utilisateur·rice sélectionne plusieurs options parmi une liste d’éléments.
 

--- a/src/fr/composants/image/cas-dutilisation.md
+++ b/src/fr/composants/image/cas-dutilisation.md
@@ -26,7 +26,7 @@ Use a Image
 -
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="" class="link-light">component</a>
 

--- a/src/fr/composants/indicateur-detape/cas-dutilisation.md
+++ b/src/fr/composants/indicateur-detape/cas-dutilisation.md
@@ -27,7 +27,7 @@ Utilisez un indicateur d'étape pour une séquence logique répartie sur plus d'
 - Préciser la structure d'un chemin en indiquant le nombre total d'étapes.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.pagination }}" class="link-light">Le composant Pagination</a> est utilisé lorsqu'une personne doit parcourir une liste de pages qui ne font pas partie d'un processus à plusieurs étapes. Il permet de sélectionner la page suivante ou précédente.
 

--- a/src/fr/composants/jeu-de-champs/cas-dutilisation.md
+++ b/src/fr/composants/jeu-de-champs/cas-dutilisation.md
@@ -28,7 +28,7 @@ Utilisez un jeu de champs pour regrouper les éléments ou composants d’un for
 - Lorsque le regroupement logique des éléments ou composants du formulaire aide à favoriser la compréhension et l’utilisabilité.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.input }}" class="link-light">Champs de saisie</a> ou <a href="{{ links.textarea }}" class="link-light">zones de texte</a> : lorsqu’une réponse écrite est demandée.
 

--- a/src/fr/composants/lien/cas-dutilisation.md
+++ b/src/fr/composants/lien/cas-dutilisation.md
@@ -31,7 +31,7 @@ Utilisez des liens pour :
 - Sauter les éléments de navigation pour passer au contenu principal.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.button }}" class="link-light">Boutons</a> : pour modifier des données, changer d'état ou lancer une action spécifique.
 

--- a/src/fr/composants/lien/design.md
+++ b/src/fr/composants/lien/design.md
@@ -12,7 +12,7 @@ date: 'git Last Modified'
   <li>Le <strong>texte du lien</strong> mène à une nouvelle page, à une section de la page actuelle ou à un autre site Web. Le texte indique la destination du lien ou, pour les téléchargements, le type et la taille du fichier. Remarque : L'ouverture de liens dans un nouvel onglet ou une nouvelle fenêtre peut être désorientant et causer des problèmes d'accessibilité. </li>
   <li>
     L'<strong>icône du lien</strong> est liée à certains types de liens, comme les liens de téléchargement, téléphoniques et courriels.
-    <ul class="mt-400 ms-0">
+    <ul class="mt-300 ms-0">
       <li>L'icône de téléchargement, ainsi que le texte du lien de téléchargement, informe une personne que sélectionner le lien déclenchera un téléchargement.</li>
       <li>Le lien téléphonique identifie le numéro de téléphone et le sélectionner déclenche un appel téléphonique.</li>
       <li>Le lien courriel identifie l'adresse courriel et lance un message à partir de l'application de messagerie par défaut.</li>

--- a/src/fr/composants/masquage-accessible/case-dusage.md
+++ b/src/fr/composants/masquage-accessible/case-dusage.md
@@ -27,7 +27,7 @@ Utilisez le masquage accessible pour :
 - Améliorer l'expérience d'utilisation d'une technologie d'assistance quand il n'y a pas d'autre option adéquate dans le HTML sémantique.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.heading }}" class="link-light">Titre</a> pour structurer le contenu en créant des niveaux hiérarchiques qui permettent l'organisation visuelle et mentale du contenu de la page à l'aide des styles de Système de design GC.
 

--- a/src/fr/composants/menu-thematique/cas-dutilisation.md
+++ b/src/fr/composants/menu-thematique/cas-dutilisation.md
@@ -24,7 +24,7 @@ Utilisez le menu thématique pour :
 - Permettre aux utilisateur·rice·s de naviguer dans l’ensemble des pages Web du gouvernement du Canada, notamment pour les pages accédées fréquemment à partir de votre site Web.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.header }}" class="link-light">En-tête</a> : permet de placer l’image de marque du gouvernement du Canada dans l’en-tête.
 

--- a/src/fr/composants/message-derreur/cas-dutilisation.md
+++ b/src/fr/composants/message-derreur/cas-dutilisation.md
@@ -30,7 +30,7 @@ Utilisez un message d'erreur pour vos propres composants lorsque l'une des situa
 - Vous devez spécifier un type ou un format de réponse incorrect et préciser à une personne ce qu'il faut faire pour résoudre le problème et passer à la tâche suivante.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes </h2>
+  <h2 class="mt-0">Composants connexes </h2>
 
 <a href="{{ links.errorSummary }}" class="link-light">Résumé des erreurs</a> pour répertorier tous les problèmes à résoudre pour la soumission de la réponse.
 

--- a/src/fr/composants/pagination/cas-dutilisation.md
+++ b/src/fr/composants/pagination/cas-dutilisation.md
@@ -29,7 +29,7 @@ Utilisez la pagination pour réduire la charge cognitive lorsqu’un contenu tr�
 - Mettre en évidence la position de la personne dans une séquence de contenu.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.stepper }}" class="link-light">Indicateur d’étape</a> pour suivre l’avancement dans un processus à plusieurs étapes.
 

--- a/src/fr/composants/pied-de-page/cas-dutilisation.md
+++ b/src/fr/composants/pied-de-page/cas-dutilisation.md
@@ -30,7 +30,7 @@ Pour les applications, formulaires et autres services numériques transactionnel
 - Le mot-symbole pour représenter l'identité du gouvernement du Canada.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.header }}" class="link-light">En-tête</a> : lorsque vous cherchez à placer l'image de marque du gouvernement du Canada dans l'en-tête de la page.
 

--- a/src/fr/composants/pied-de-page/code.md
+++ b/src/fr/composants/pied-de-page/code.md
@@ -20,18 +20,18 @@ Choisissez l'affichage compact pour inclure :
 
 1. La bande de liens du pied de page et le mot-symbole du gouvernement du Canada.
 
-<img class="b-sm b-default mt-300 mb-600 p-300" src="/images/fr/components/example/example-footer-compact.svg" alt=""/>
+<img class="b-sm b-default mb-300 p-300" src="/images/fr/components/example/example-footer-compact.svg" alt=""/>
 
 Choisissez l'affichage complet si vous devez inclure :
 
 1. La bande principale avec une grande sélection de liens institutionnels du gouvernement du Canada;
 2. La bande de liens du pied de page et le mot-symbole du gouvernement du Canada.
 
-<img class="b-sm b-default mt-300 mb-600 p-300" src="/images/fr/components/example/example-footer-full.svg" alt=""/>
+<img class="b-sm b-default mb-300 p-300" src="/images/fr/components/example/example-footer-full.svg" alt=""/>
 
 Choisissez d'inclure la bande contextuelle pour ajouter jusqu'à trois liens de pied de page pour votre produit.
 
-<img class="b-sm b-default mt-300 mb-600 p-300" src="/images/fr/components/example/example-footer-full-with-contextual-links.svg" alt=""/>
+<img class="b-sm b-default mb-300 p-300" src="/images/fr/components/example/example-footer-full-with-contextual-links.svg" alt=""/>
 
 ### Inclure la bande de liens du pied de page pour les sites et produits du gouvernement du Canada
 

--- a/src/fr/composants/recherche/cas-dutilisation.md
+++ b/src/fr/composants/recherche/cas-dutilisation.md
@@ -27,7 +27,7 @@ Utilisez le composant recherche pour aider les personnes utilisant votre site We
 - À partir d’un sous-ensemble de contenu publié, en utilisant votre propre ensemble de données.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.header }}" class="link-light">En-tête</a> : utilisé pour le placement de l'en-tête portant l'image de marque du gouvernement du Canada.
 

--- a/src/fr/composants/resume-de-erreurs/cas-dutilisation.md
+++ b/src/fr/composants/resume-de-erreurs/cas-dutilisation.md
@@ -29,7 +29,7 @@ Utilisez le résumé des erreurs pour interrompre l'envoi d'un formulaire lorsqu
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
 
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.errorMessage }}" class="link-light">Message d'erreur</a> lorsque vous cherchez à décrire un problème représentant un obstacle à une action menée par l'utilisateur·rice, lié à un seul composant.
 

--- a/src/fr/composants/selection/cas-dutilisation.md
+++ b/src/fr/composants/selection/cas-dutilisation.md
@@ -26,7 +26,7 @@ Utilisez la sélection dans un formulaire afin de :
 - Permettre à une personne de répondre à une question sans devoir rédiger une réponse, en sélectionnant un élément à partir d'une liste.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.checkbox }}" class="link-light">Cases à cocher</a> : lorsque vous prévoyez que l'utilisateur·rice sélectionne une ou plusieurs options parmi une liste d'éléments.
 

--- a/src/fr/composants/signature/cas-dutilisation.md
+++ b/src/fr/composants/signature/cas-dutilisation.md
@@ -29,6 +29,15 @@ La signature, qui constitue un élément d'une image de marque, est utilisée po
 - Informer une personne que le contenu qu'elle est en train de lire a été publié par le gouvernement du Canada;
 - Servir de lien général vers la page d'accueil du site dans les deux langues officielles.
 
+<article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
+  <h2 class="mt-0">Composants connexes</h2>
+
+<a href="{{ links.header }}" class="link-light">En-tête :</a> utilisé pour le placement de l'en-tête portant l'image de marque du gouvernement du Canada;
+
+<a href="{{ links.footer }}" class="link-light">Pied de page :</a> for placing the Government of Canada branded footer landmark.
+
+</article>
+
 ## Types de composants
 
 La signature et le mot-symbole apparaissent ensemble sur les sites et produits du gouvernement du Canada.
@@ -40,7 +49,7 @@ Placez la **signature** dans l'en-tête à côté de la bascule de langue pour :
 - Afficher la signature de marque du gouvernement du Canada;
 - Fournir un point de repère aux utilisateur·rice·s qui souhaiteraient retourner à la page d'accueil du site.
 
-<img class="b-sm b-default mt-300 mb-75 p-300" src="/images/fr/components/example/example-signature-signature-type-fr.svg" alt="La signature du gouvernement du Canada. La signature comprend l'unifolié rouge, suivi par le texte « Gouvernement du Canada / Government of Canada »" />
+<img class="b-sm b-default p-300" src="/images/fr/components/example/example-signature-signature-type-fr.svg" alt="La signature du gouvernement du Canada. La signature comprend l'unifolié rouge, suivi par le texte « Gouvernement du Canada / Government of Canada »" />
 
 ### Type de mot-symbole
 
@@ -49,13 +58,4 @@ Insérez le **mot-symbole** dans le coin inférieur droit du pied de page pour :
 - Accompagner la signature ou toute autre signature organisationnelle approuvée du gouvernement du Canada sur les sites et produits internes et destinés au public;
 - Afficher ce symbole officiel qui est l'identificateur mondial du gouvernement du Canada.
 
-<img class="b-sm b-default mt-300 mb-225 p-300" src="/images/fr/components/example/example-signature-wordmark-type-fr.svg" alt="Le mot-symbole « Canada ». Le mot-symbole comprend le mot « Canada » avec l'unifolié rouge juste au-dessus de la dernière lettre « a »." />
-
-<article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
-
-<a href="{{ links.header }}" class="link-light">En-tête :</a> utilisé pour le placement de l'en-tête portant l'image de marque du gouvernement du Canada;
-
-<a href="{{ links.footer }}" class="link-light">Pied de page :</a> for placing the Government of Canada branded footer landmark.
-
-</article>
+<img class="b-sm b-default p-300" src="/images/fr/components/example/example-signature-wordmark-type-fr.svg" alt="Le mot-symbole « Canada ». Le mot-symbole comprend le mot « Canada » avec l'unifolié rouge juste au-dessus de la dernière lettre « a »." />

--- a/src/fr/composants/signature/design.md
+++ b/src/fr/composants/signature/design.md
@@ -31,18 +31,18 @@ Affichez d'abord la signature en français sur les pages en français. De même,
 - Utilisez toujours la même combinaison de couleurs dans la signature et le mot-symbole. Par exemple, si la signature est en noir et blanc, alors le mot-symbole doit également l'être;
 - Lorsqu'une seule couleur est utilisée, vérifiez le rapport de contraste entre les éléments de la signature pour vous assurer que le ratio est à tout le moins conforme à la norme WCAG, niveau AA.
 
-<img class="b-sm b-default p-300 mt-300 mb-300" src="/images/fr/components/example/example-signature-side-by-side-fr.svg" alt="Une image représentant les deux versions de la signature. La signature se trouve à gauche et le mot-symbole est placé à droite." />
+<img class="b-sm b-default p-300 mb-300" src="/images/fr/components/example/example-signature-side-by-side-fr.svg" alt="Une image représentant les deux versions de la signature. La signature se trouve à gauche et le mot-symbole est placé à droite." />
 
 Le style de couleur standard utilise un texte noir et un drapeau rouge sur fond blanc.
 
-<img class="b-sm b-default p-300 mt-600 mb-300" src="/images/fr/components/example/example-signature-side-by-side-reversed-fr.svg" alt="Une image représentant les deux versions de la signature. La signature se trouve à gauche et le mot-symbole est placé à droite. Cette version utilise du texte blanc sur un fond noir." />
+<img class="b-sm b-default p-300 mb-300" src="/images/fr/components/example/example-signature-side-by-side-reversed-fr.svg" alt="Une image représentant les deux versions de la signature. La signature se trouve à gauche et le mot-symbole est placé à droite. Cette version utilise du texte blanc sur un fond noir." />
 
 Le style de couleur inversé utilise un texte blanc et un drapeau rouge sur fond noir.
 
-<img class="b-sm b-default p-300 mt-600 mb-300" src="/images/fr/components/example/example-signature-bw-fr.svg" alt="Une image présentant deux combinaisons de signature et de mot-symbole. Dans un cas, la signature et le mot-symbole sont noirs sur fond blanc. Dans l'autre cas, la signature et le mot-symbole sont blancs sur fond noir." />
+<img class="b-sm b-default p-300 mb-300" src="/images/fr/components/example/example-signature-bw-fr.svg" alt="Une image présentant deux combinaisons de signature et de mot-symbole. Dans un cas, la signature et le mot-symbole sont noirs sur fond blanc. Dans l'autre cas, la signature et le mot-symbole sont blancs sur fond noir." />
 
 Le style noir et blanc utilise un fond soit entièrement noir, soit entièrement blanc. Le style entièrement noir est le plus fréquemment employé.
 
-<img class="b-sm b-default p-300 mt-600 mb-300" src="/images/fr/components/example/example-signature-single-colour-style-fr.svg" alt="Une image montrant la signature et le mot-symbole en violet foncé sur un fond violet pâle. Des barres et des cases simulent du texte et des images sur une page web fictive. Les cases de texte et d'images sont également violet foncé." />
+<img class="b-sm b-default p-300 mb-300" src="/images/fr/components/example/example-signature-single-colour-style-fr.svg" alt="Une image montrant la signature et le mot-symbole en violet foncé sur un fond violet pâle. Des barres et des cases simulent du texte et des images sur une page web fictive. Les cases de texte et d'images sont également violet foncé." />
 
 Le style couleur unique utilise une couleur autre que le noir ou le blanc si uniquement cette couleur est utilisée pour le produit.

--- a/src/fr/composants/tableau-de-donnees/cas-dutilisation.md
+++ b/src/fr/composants/tableau-de-donnees/cas-dutilisation.md
@@ -25,7 +25,7 @@ Use a Tableau de données
 -
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="" class="link-light">component</a>
 

--- a/src/fr/composants/televerseur-de-fichiers/cas-dutilisation.md
+++ b/src/fr/composants/televerseur-de-fichiers/cas-dutilisation.md
@@ -25,7 +25,7 @@ Utilisez le téléverseur de fichiers pour :
 - Vérifier les fichiers sélectionnés à téléverser.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.textarea }}" class="link-light">Zones de texte</a> : permettent la saisie de réponses libres de plusieurs lignes.
 

--- a/src/fr/composants/texte/cas-dutilisation.md
+++ b/src/fr/composants/texte/cas-dutilisation.md
@@ -28,7 +28,7 @@ Utilisez le composant texte pour :
 - Diviser le contenu en sections compréhensibles avec des marges verticales et horizontales. La décomposition de votre contenu favorise la lisibilité, simplifie la navigation sur le site et réduit le risque que les gens abandonnent leur tâche.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.heading }}" class="link-light">Titre</a> pour structurer le contenu en créant des niveaux hiérarchiques qui permettent l'organisation visuelle et mentale du contenu de la page à l'aide des styles de Système de design GC.
 

--- a/src/fr/composants/titre/cas-dutilisation.md
+++ b/src/fr/composants/titre/cas-dutilisation.md
@@ -30,7 +30,7 @@ Utilisez des titres pour :
 - Appliquer des styles et des tailles de typographie cohérents sur l'ensemble d'un site Web pour créer un design cohérent et convivial.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.text }}" class="link-light">Texte</a> pour des paragraphes affichant du contenu autre qu'un titre avec les styles correspondants de Système de design GC.
 

--- a/src/fr/composants/zone-de-texte/cas-dutilisation.md
+++ b/src/fr/composants/zone-de-texte/cas-dutilisation.md
@@ -29,7 +29,7 @@ Utilisez une zone de texte pour obtenir des renseignements multilignes :
 Note : Ne recueillez que les renseignements que vous êtes autorisé·e à traiter et veillez à les protéger conformément aux normes du gouvernement du Canada.
 
 <article class="bg-full-width bg-primary text-light pt-600 pb-300 my-600">
-  <h2 class="mt-0 mb-300">Composants connexes</h2>
+  <h2 class="mt-0">Composants connexes</h2>
 
 <a href="{{ links.input }}" class="link-light">Champs de saisie</a> : lorsque vous cherchez à obtenir des réponses courtes d'une seule ligne.
 

--- a/src/fr/pages/index.md
+++ b/src/fr/pages/index.md
@@ -6,14 +6,14 @@ translationKey: 'index'
 date: 'git Last Modified'
 ---
 
-<h2 class="py-450">Commencez à utiliser Système de design GC</h2>
+<h2 class="my-450">Commencez à utiliser Système de design GC</h2>
 
 <article class="py-600 bg-primary text-light bg-full-width">
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr">
     <li class="list-none md:mb-0 mb-600">
       <img class="mb-300" src="../../images/common/home/icon-design.svg" alt="" />
-      <h3 class="mb-300">Concevoir des expériences</h3>
-      <p class="mb-300">Visitez notre bibliothèque Figma pour explorer nos ressources de conception.</p>
+      <h3 class="mt-0">Concevoir des expériences</h3>
+      <p>Visitez notre bibliothèque Figma pour explorer nos ressources de conception.</p>
       <a class="link-light" href="{{ links.figma }}" target="_blank">
         Commencer à concevoir
         <gcds-icon name="external-link" label="S'ouvre dans un nouvel onglet." margin-left="50" />
@@ -21,43 +21,43 @@ date: 'git Last Modified'
     </li>
     <li class="list-none">
       <img class="mb-300" src="../../images/common/home/icon-develop.svg" alt="" />
-      <h3 class="mb-300">Développer des produits</h3>
-      <p class="mb-300">Installez l'ensemble de composants.</p>
+      <h3 class="mt-0">Développer des produits</h3>
+      <p>Installez l'ensemble de composants.</p>
       <a class="link-light" href="{{ links.installation }}">Commencer à développer</a>
     </li>
   </gcds-grid>
 </article>
 
-<article class="py-450">
-  <h2 class="mb-300">Un système de design rien que pour vous</h2>
+<article class="pb-600">
+  <h2>Un système de design rien que pour vous</h2>
   <p class="mb-600">Explorez notre outil de conception. <gcds-link href="{{ links.contact }}">Donnez-nous votre avis</gcds-link>.</p>
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
     <li class="list-none">
       <img class="mb-150" src="../../images/common/home/icon-components.svg" alt="" />
-      <h3 class="mb-300">Composants</h3>
-      <p class="mb-300">Les blocs de construction de l'interface utilisateur servent différents objectifs.</p>
-      <p class="mb-300">Sélectionnez du code réutilisable pour les composants courants et obtenez des conseils relatifs aux meilleures pratiques pour l'infrastructure que vous utilisez.</p>
+      <h3 class="mt-0">Composants</h3>
+      <p>Les blocs de construction de l'interface utilisateur servent différents objectifs.</p>
+      <p>Sélectionnez du code réutilisable pour les composants courants et obtenez des conseils relatifs aux meilleures pratiques pour l'infrastructure que vous utilisez.</p>
       <gcds-link href="{{ links.components }}">Découvrez les composants</gcds-link>
     </li>
     <li class="list-none">
       <img class="mb-150" src="../../images/common/home/icon-template.svg" alt="" />
-      <h3 class="mb-300">Modèles de page</h3>
-      <p class="mb-300">Les mises en page réutilisables sont des agencements de composants propres à des types de page communs.</p>
-      <p class="mb-300">Entamez votre projet à l'aide de pages de base préfabriquées pour offrir une expérience Canada.ca uniforme et reconnaissable.</p>
+      <h3 class="mt-0">Modèles de page</h3>
+      <p>Les mises en page réutilisables sont des agencements de composants propres à des types de page communs.</p>
+      <p>Entamez votre projet à l'aide de pages de base préfabriquées pour offrir une expérience Canada.ca uniforme et reconnaissable.</p>
       <gcds-link href="{{ links.pageTemplates }}">Découvrez les modèle des page</gcds-link>
     </li>
     <li class="list-none">
       <img class="mb-150" src="../../images/common/home/icon-tokens.svg" alt="" />
-      <h3 class="mb-300">Unités de style</h3>
-      <p class="mb-300">Des décisions en matière d'image de marque et de conception directement intégrées dans le code.</p>
-      <p class="mb-300">Découvrez comment les décisions encodées façonnent la conception des services offerts par le gouvernement du Canada et permettent d'offrir une expérience visuelle uniforme.</p>
+      <h3 class="mt-0">Unités de style</h3>
+      <p>Des décisions en matière d'image de marque et de conception directement intégrées dans le code.</p>
+      <p>Découvrez comment les décisions encodées façonnent la conception des services offerts par le gouvernement du Canada et permettent d'offrir une expérience visuelle uniforme.</p>
       <gcds-link href="{{ links.styles }}">Découvrez les unités de style</gcds-link>
     </li>
   </gcds-grid>
 </article>
 
 <article class="py-600 bg-light bg-full-width">
-  <h2 class="mb-300">Nouveautés</h2>
+  <h2 class="mt-0">Nouveautés</h2>
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr">
     <gcds-card
       href="{{ links.registerDemo }}"
@@ -90,9 +90,8 @@ date: 'git Last Modified'
   </gcds-grid>
 </article>
 
-<article class="py-450">
-  <h2 class="mb-300">Composant vedette</h2>
-
+<article class="pb-600">
+  <h2>Composant vedette</h2>
   <gcds-grid tag="ul" columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
     <gcds-card
       href="{{ links.notice }}"

--- a/src/fr/simpliquer.md
+++ b/src/fr/simpliquer.md
@@ -19,7 +19,7 @@ Nous testons actuellement la version alpha de Système de design GC, ce qui corr
 
 ## Découvrez Système de design GC
 
-<div class="d-grid lg:grid-cols-3 mb-400 gap-400">
+<gcds-grid columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
   <gcds-card
     card-title="Recevez nos communications"
     href="{{ links.contact }}"
@@ -30,18 +30,18 @@ Nous testons actuellement la version alpha de Système de design GC, ce qui corr
     href="{{ links.registerDemo }}"
     description="Assistez à une présentation du prototypage et du développement d’expériences Web à l’aide du système de design et participez à une séance de questions-réponses."
   ></gcds-card>
-</div>
+</gcds-grid>
 
-<hr/>
+<hr class="mt-600"/>
 
-<gcds-heading tag="h2" margin-top="225">Contribuez à nos prochaines priorités</gcds-heading>
+## Contribuez à nos prochaines priorités
 
-Vous pouvez contribuer à l’avenir de Système de design GC. 
+Vous pouvez contribuer à l’avenir de Système de design GC.
 
 Nous recherchons activement des contributions pour les éléments suivants :
 
-- **Des tableaux de données** pour organiser et afficher une grande quantité de données dans des rangées et des colonnes.</li>
-- **Des balises** pour étiqueter, catégoriser et organiser des éléments à l’aide de mots-clés descriptifs. </li>
+- **Des tableaux de données** pour organiser et afficher une grande quantité de données dans des rangées et des colonnes.
+- **Des balises** pour étiqueter, catégoriser et organiser des éléments à l’aide de mots-clés descriptifs.
 
 Nous nous intéressons également aux problèmes concernant les interactions avec les utilisateurs et utilisatrice ou aux solutions qui peuvent s’appliquer aux différents services du GC.
 
@@ -56,9 +56,9 @@ Fournissez l'un des éléments suivants pour chaque composant ou modèle de page
 <gcds-button button-role="secondary" type="link" href="{{ links.githubCompsPriority }}" external>Contribuer sur GitHub</gcds-button>
 <gcds-button button-role="secondary" type="link" href="{{ links.contact }}" external>Contactez-nous</gcds-button>
 
-<hr/>
+<hr class="mt-600" />
 
-<gcds-heading tag="h2" margin-top="225">Autres nouveautés à venir</gcds-heading>
+## Autres nouveautés à venir
 
 Voici ce que nous allons bientôt publier. Plus de renseignements sur notre <gcds-link href="{{ links.roadmap }}" >feuille de route</gcds-link>.
 

--- a/src/fr/styles/typographie/typographie.md
+++ b/src/fr/styles/typographie/typographie.md
@@ -112,6 +112,4 @@ La famille de police comprend des valeurs de rechange. Les valeurs de rechange s
 
 <br/>
 
-{% assign removeBorder = true %}
-
 {% include "partials/helpus.njk" %}

--- a/src/scripts/search.js
+++ b/src/scripts/search.js
@@ -38,9 +38,9 @@ if (searchTerm) {
       noresults: 'No results',
       loading: 'Loading search results.',
       noresultsbody: `
-        <p class="mb-300">No pages were found that match your search terms.</p>
+        <p>No pages were found that match your search terms.</p>
 
-        <p class="mb-300">Suggestions:</p>
+        <p>Suggestions:</p>
 
         <ul class="list-disc mb-300">
           <li>Make sure all search terms are spelled correctly</li>
@@ -55,9 +55,9 @@ if (searchTerm) {
       noresults: 'Aucun résultat',
       loading: 'Chargement des résultats de recherche.',
       noresultsbody: `
-        <p class="mb-300">Aucun résultat ne correspond à vos critères de recherche.</p>
+        <p>Aucun résultat ne correspond à vos critères de recherche.</p>
 
-        <p class="mb-300">Suggestions:</p>
+        <p>Suggestions:</p>
 
         <ul class="list-disc mb-300">
           <li>Assurez-vous que tous vos termes de recherches sont bien orthographiés</li>

--- a/utils/anchor.js
+++ b/utils/anchor.js
@@ -12,13 +12,13 @@ const anchor = (md, options) => {
     const slug = slugify(contentToken.content);
 
     if (tokens[index].tag === 'h1') {
-      return `<${tokens[index].tag} id="${slug}" class="mb-300">`;
+      return `<${tokens[index].tag} id="${slug}">`;
     } else if (tokens[index].tag === 'h2') {
-      return `<${tokens[index].tag} id="${slug}" class="mt-600 mb-300">`;
+      return `<${tokens[index].tag} id="${slug}">`;
     } else if (tokens[index].tag === 'h3') {
-      return `<${tokens[index].tag} id="${slug}" class="mt-600 mb-300">`;
+      return `<${tokens[index].tag} id="${slug}">`;
     } else if (tokens[index].tag === 'h4') {
-      return `<${tokens[index].tag} id="${slug}" class="mt-600 mb-300">`;
+      return `<${tokens[index].tag} id="${slug}">`;
     } else {
       return `<${tokens[index].tag} id="${slug}">`;
     }
@@ -29,10 +29,6 @@ const anchor = (md, options) => {
   };
   md.renderer.rules.bullet_list_open = function (tokens, index) {
     return `<${tokens[index].tag} class="list-disc mb-300">`;
-  };
-
-  md.renderer.rules.paragraph_open = function (tokens, index) {
-    return `<${tokens[index].tag} class="mb-300">`;
   };
 };
 


### PR DESCRIPTION
# Summary | Résumé

After updating the GCDS CSS Utility Framework to include default `margin-top` and `margin-bottom` values for headings and text, we can remove those extra utility classes from the code for our documentation site.

## Changes

- Removed `mt-0` and `mb-300` classes  from  h1's.
- Removed `mt-600` and `mb-300` classes  from  h2 - h6's.
- Removed `mb-300` classes  from  p's.
- Adjusted overall spacing classes to be more aligned.

## Zenhub ticket

The Zenhub ticket for this change can be found [here](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1460).
