### PR TITLE
fix: grey screen when clicking external links in iframes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -300,7 +300,7 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addPairedShortcode(
     'baseComponentPreview',
-    (children, title, url) => {
+    (children, title, url, queryString = "") => {
       return `
       <div class="my-600 b-sm b-default component-preview">
         <h2 class="container-full font-text font-semibold m-0 px-225 py-150 bb-sm b-default bg-light">
@@ -309,7 +309,7 @@ module.exports = function (eleventyConfig) {
         <div>
           <iframe
             title="${title}"
-            src="${url.replace('/base', '/preview')}"
+            src="${url.replace('/base', '/preview/')}${queryString}"
             style="display: block; margin: 0 auto;"
             frameBorder="0"
             width="100%"

--- a/src/en/components/breadcrumbs/base.md
+++ b/src/en/components/breadcrumbs/base.md
@@ -15,5 +15,5 @@ Breadcrumbs is a path to the current page from each preceding level of the site'
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% baseComponentPreview "Breadcrumbs component preview" page.filePathStem %}
+{% baseComponentPreview "Breadcrumbs component preview" page.filePathStem "?externalLinks=true" %}
 {% endbaseComponentPreview %}

--- a/src/en/components/breadcrumbs/code.md
+++ b/src/en/components/breadcrumbs/code.md
@@ -31,7 +31,7 @@ Add a new breadcrumbs link to the breadcrumbs component by using the `<gcds-brea
 
 <iframe
   title="Overview of gcds-breadcrumbs properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&id=components-breadcrumbs--events-properties&lang=en"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&id=components-breadcrumbs--events-properties&lang=en&externalLinks=true"
   width="1200"
   height="1150"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/footer/base.md
+++ b/src/en/components/footer/base.md
@@ -15,5 +15,5 @@ The footer is the responsive Government of Canada branded footer landmark.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% baseComponentPreview "Footer component preview" page.filePathStem %}
+{% baseComponentPreview "Footer component preview" page.filePathStem "?externalLinks=true" %}
 {% endbaseComponentPreview %}

--- a/src/en/components/footer/code.md
+++ b/src/en/components/footer/code.md
@@ -68,7 +68,7 @@ Opt to include the contextual band to add up to three footer links for your prod
 
 <iframe
   title="Overview of gcds-footer properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties&lang=en"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties&lang=en&externalLinks=true"
   width="1200"
   height="2150"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/header/base.md
+++ b/src/en/components/header/base.md
@@ -15,5 +15,5 @@ The header is the responsive Government of Canada branded header landmark.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% baseComponentPreview "Header component preview" page.filePathStem %}
+{% baseComponentPreview "Header component preview" page.filePathStem "?externalLinks=true" %}
 {% endbaseComponentPreview %}

--- a/src/en/components/header/code.md
+++ b/src/en/components/header/code.md
@@ -41,7 +41,7 @@ Use this header landmark to communicate a Government of Canada digital service o
 
 <iframe
   title="Overview of gcds-header properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-header--events-properties&lang=en"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-header--events-properties&lang=en&externalLinks=true"
   width="1200"
   height="1600"
   style="display: block; margin: 0 auto;"

--- a/src/en/components/theme-and-topic-menu/base.md
+++ b/src/en/components/theme-and-topic-menu/base.md
@@ -14,5 +14,5 @@ The theme and topic menu is a navigation to the top tasks of Government of Canad
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% baseComponentPreview "Theme and topic menu component preview" page.filePathStem %}
+{% baseComponentPreview "Theme and topic menu component preview" page.filePathStem "?externalLinks=true" %}
 {% endbaseComponentPreview %}

--- a/src/en/components/theme-and-topic-menu/code.md
+++ b/src/en/components/theme-and-topic-menu/code.md
@@ -22,7 +22,7 @@ Add the theme and topic menu directly to the <gcds-link href="{{ links.header }}
 
 <iframe
   title="Overview of gcds-topic-menu properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-theme-and-topic-menu--events-properties&lang=en"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-theme-and-topic-menu--events-properties&lang=en&externalLinks=true"
   width="1200"
   height="1850"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/chemin-de-navigation/base.md
+++ b/src/fr/composants/chemin-de-navigation/base.md
@@ -15,5 +15,5 @@ Un chemin d'accès à la page actuelle à partir de chaque niveau précédent de
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% baseComponentPreview "Aperçu du composant de chemin de navigation" page.filePathStem %}
+{% baseComponentPreview "Aperçu du composant de chemin de navigation" page.filePathStem "?externalLinks=true" %}
 {% endbaseComponentPreview %}

--- a/src/fr/composants/chemin-de-navigation/code.md
+++ b/src/fr/composants/chemin-de-navigation/code.md
@@ -31,7 +31,7 @@ Ajoutez un nouveau lien au composant Chemin de navigation à l'aide du composant
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-breadcrumbs."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&id=components-breadcrumbs--events-properties&lang=fr"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&id=components-breadcrumbs--events-properties&lang=fr&externalLinks=true"
   width="1200"
   height="1150"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/en-tete/base.md
+++ b/src/fr/composants/en-tete/base.md
@@ -15,5 +15,5 @@ L'en-tête porte l'image de marque réactive du gouvernement du Canada.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% baseComponentPreview "Aperçu du composant de l'en-tête" page.filePathStem %}
+{% baseComponentPreview "Aperçu du composant de l'en-tête" page.filePathStem "?externalLinks=true" %}
 {% endbaseComponentPreview %}

--- a/src/fr/composants/en-tete/code.md
+++ b/src/fr/composants/en-tete/code.md
@@ -41,7 +41,7 @@ Utilisez ce point de repère pour transmettre de l'information sur un service du
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-header."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-header--events-properties&lang=fr"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-header--events-properties&lang=fr&externalLinks=true"
   width="1200"
   height="1600"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/menu-thematique/base.md
+++ b/src/fr/composants/menu-thematique/base.md
@@ -14,5 +14,5 @@ Le menu thématique est un mécanisme de navigation vers les tâches les plus im
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% baseComponentPreview "Aperçu du composant de menu thématique" page.filePathStem %}
+{% baseComponentPreview "Aperçu du composant de menu thématique" page.filePathStem "?externalLinks=true" %}
 {% endbaseComponentPreview %}

--- a/src/fr/composants/menu-thematique/code.md
+++ b/src/fr/composants/menu-thematique/code.md
@@ -22,7 +22,7 @@ Remarque : Si vous souhaitez ajouter un menu de thèmes et sujets à la page d'a
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-topic-menu."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-theme-and-topic-menu--events-properties&lang=fr"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-theme-and-topic-menu--events-properties&lang=fr&externalLinks=true"
   width="1200"
   height="1850"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/pied-de-page/base.md
+++ b/src/fr/composants/pied-de-page/base.md
@@ -15,5 +15,5 @@ Le pied de page porte l'image de marque réactive du gouvernement du Canada.
 {% docLinks locale stage figma github %}
 {% enddocLinks %}
 
-{% baseComponentPreview "Aperçu du composant de pied de page" page.filePathStem %}
+{% baseComponentPreview "Aperçu du composant de pied de page" page.filePathStem "?externalLinks=true" %}
 {% endbaseComponentPreview %}

--- a/src/fr/composants/pied-de-page/code.md
+++ b/src/fr/composants/pied-de-page/code.md
@@ -68,7 +68,7 @@ Pour la bande de lien du pied de page, réglez l'élément `sub-links` en passan
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-footer."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties&lang=fr"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-footer--events-properties&lang=fr&externalLinks=true"
   width="1200"
   height="2150"
   style="display: block; margin: 0 auto;"

--- a/src/scripts/component-preview-iframe.js
+++ b/src/scripts/component-preview-iframe.js
@@ -99,4 +99,16 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }, 100);
   }
+  
+  // Logic to prevent only the iframe navigating with components that provide external links
+  const url = new URLSearchParams(window.location.search);
+
+  if (url.get('externalLinks')) {
+    document.addEventListener('gcdsClick', (ev) => {
+      if (ev.detail && ev.detail.includes('https://')) {
+        ev.preventDefault();
+        top.window.location.href = ev.detail;
+      }
+    });
+  }
 });


### PR DESCRIPTION
# Summary | Résumé

https://github.com/cds-snc/gcds-components/issues/771

To prevent the code/component preview iframes from navigating to new pages and becoming grey screens, add a new `externalLinks` query string to allow the browser to follow the clicked links.

## How to test

### Testing code display

1. On https://design-system.alpha.canada.ca/en/components/footer/code/ navigate to the code editor displaying the `gcds-footer. 
2. Click one of the links in the main or sub band.
3. Notice the iframe turns into a grey box.
4. On this branch locally or on the preview environment.
5. Navigate to the code page of footer.
6. Click one of the links in the main or sub band.
7. The browser should now navigate to the clicked link's `href`

### Testing component preview

1. On a local copy of `main` brain, navigate to http://localhost:8080/en/components/breadcrumbs/.
2. Click the Canada.ca breadcrumb link in the top component preview.
3. Notice the iframe turns into a grey box.
4. Switch to this branch
5. Navigate back to http://localhost:8080/en/components/breadcrumbs/.
6. Click the Canada.ca breadcrumb link in the top component preview.
7. The browser should now navigate to canada.ca
