### PR TITLE
fix: typo in signature's code display iframe src

### DIFF
--- a/src/en/components/signature/code.md
+++ b/src/en/components/signature/code.md
@@ -29,7 +29,7 @@ Use the signature type in the site's <gcds-link href="{{ links.header }}">header
 
 <iframe
   title="Overview of gcds-side-nav properties and events."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-signature--events-properties#events--properties&lang=en"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-signature--events-properties&lang=en"
   width="1200"
   height="1100"
   style="display: block; margin: 0 auto;"

--- a/src/fr/composants/signature/code.md
+++ b/src/fr/composants/signature/code.md
@@ -29,7 +29,7 @@ Utilisez la signature dans <gcds-link href="{{ links.header }}">l'en-tête</gcds
 
 <iframe
   title="Survol des propriétés et des évènements relatifs à gcds-signature."
-  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-signature--events-properties#events--properties&lang=fr"
+  src="https://cds-snc.github.io/gcds-components/iframe.html?viewMode=docs&demo=true&singleStory=true&id=components-signature--events-properties&lang=fr"
   width="1200"
   height="1100"
   style="display: block; margin: 0 auto;"


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/design-gc-conception/issues/1244, the code display on the signature page was not displaying the table header. Remove extra `#events--properties` in the iframe's `src` to allow the table header to display properly.