### PR TITLE
chore: fix sass import warning

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -1,19 +1,19 @@
 // Utilities
-@import 'utilities/backgrounds';
+@use 'utilities/backgrounds';
 
 // Base
-@import 'typography';
-@import 'general';
+@use 'typography';
+@use 'general';
 
 // Components
-@import 'components/anatomy-list';
-@import 'components/code-showcase';
-@import 'components/copy-code';
-@import 'components/component-preview';
-@import 'components/component-preview-box';
-@import 'components/table';
-@import 'components/tabs';
+@use 'components/anatomy-list';
+@use 'components/code-showcase';
+@use 'components/copy-code';
+@use 'components/component-preview';
+@use 'components/component-preview-box';
+@use 'components/table';
+@use 'components/tabs';
 
 // Pages
-@import 'pages/home';
-@import 'pages/search';
+@use 'pages/home';
+@use 'pages/search';


### PR DESCRIPTION
# Summary | Résumé

Sass is deprecating the `@import` rule. This is part of a broader move towards using the `@use` and `@forward` rules, which are more powerful and maintainable in the long run.

Replacing `@import` with `@use` to align with the new standards.
