### PR TITLE
chore: fix TypeError from component preview

### DIFF
--- a/src/scripts/component-preview.js
+++ b/src/scripts/component-preview.js
@@ -2,7 +2,7 @@
 window.addEventListener("message", ev => {
   const iframe = document.getElementById('component-preview');
 
-  if (iframe.height !== ev.data.height && ev.data.height > 60) {
+  if (iframe && iframe.height !== ev.data.height && ev.data.height > 60) {
     iframe.height = ev.data.height;
   }
 });


### PR DESCRIPTION
# Summary | Résumé

The current implementation of the component-preview.js script triggers a `TypeError (Cannot read properties of null (reading 'height'))` when a page does not contain an iframe with the ID `component-preview`. This occurs because the script attempts to access the height property of a non-existent iframe.

This update adds a check to ensure the iframe element is present before attempting to read or modify its properties, preventing the error when the iframe is missing from the page.