### PR TITLE
fix: Random accessibility test failures

### DIFF
--- a/cypress/e2e/a11y-en.cy.js
+++ b/cypress/e2e/a11y-en.cy.js
@@ -41,7 +41,7 @@ describe(`A11Y test English documentation site`, () => {
   for (const page of pagesEn) {
     it(`${page.name}: ${page.url}`, () => {
       cy.visit(page.url, { timeout: 30000 });
-      cy.get('.hydrated').then(() => {
+      cy.get('gcds-header.hydrated').then(() => {
         cy.injectAxe();
         cy.checkA11y(null, null, cy.terminalLog);
         // skip theme and topic menu since links are pulled from external source

--- a/cypress/e2e/a11y-fr.cy.js
+++ b/cypress/e2e/a11y-fr.cy.js
@@ -42,7 +42,7 @@ describe(`A11Y test French documentation site`, () => {
   for (const page of pagesFr) {
     it(`${page.name}: ${page.url}`, () => {
       cy.visit(page.url, { timeout: 30000 });
-      cy.get('.hydrated').then(() => {
+      cy.get('gcds-header.hydrated').then(() => {
         cy.injectAxe();
         cy.checkA11y(null, null, cy.terminalLog);
         // skip theme and topic menu since links are pulled from external source


### PR DESCRIPTION
# Summary | Résumé

Closes https://github.com/cds-snc/gcds-docs/issues/528

Update accessibility tests to wait until the `gcds-header` has hydrated. This will hopefully stop the basic page preview pages from randomly failing when tests are run on GitHub workflows. My theory as to why it was failing is the component JS files are being loaded in by CDN causing slower hydration of all components so when the accessibility tests run, not all components are fully rendered.
