### PR TITLE
fix: update help us improve partial to use two secondary btns

### DIFF
--- a/src/_includes/partials/helpus.njk
+++ b/src/_includes/partials/helpus.njk
@@ -14,7 +14,7 @@
 
   <gcds-button
     type="link"
-    button-role="primary"
+    button-role="secondary"
     href="{{ helpus[locale].feedbackHref }}"
     class="mb-300"
   >


### PR DESCRIPTION
# Summary | Résumé

Change the "Help us improve" partial from using 1 primary and 1 secondary button to 2 secondary to allow for a primary in the main page content.

## Zenhub ticket

This is the [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1501) for the change.