### PR TITLE
feat: Add version numbers in page templates code page

### DIFF
--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -14,22 +14,22 @@ async function downloadFile(url, outputDir, outputFileName) {
     }
     // Get initial file contents
     const fileContent = await response.text();
-
-    // Add code formatting for code files
-    const codeContent = `{% highlight html %}\n${fileContent}\n{% endhighlight %}`;
-
+    
     // Replace version numbers in preview files
     let previewContent = fileContent.replace(
       /gcds-utility\@<version-number>/g,
       'gcds-utility@' +
-        pjson.devDependencies['@cdssnc/gcds-utility'].replace(/^\^/, ''),
+      pjson.devDependencies['@cdssnc/gcds-utility'].replace(/^\^/, ''),
     );
     previewContent = previewContent.replace(
       /gcds-components\@<version-number>/g,
       'gcds-components@' +
-        pjson.devDependencies['@cdssnc/gcds-components'].replace(/^\^/, ''),
+      pjson.devDependencies['@cdssnc/gcds-components'].replace(/^\^/, ''),
     );
 
+    // Add code formatting for code files
+    const codeContent = `{% highlight html %}\n${previewContent}\n{% endhighlight %}`;
+    
     fs.mkdirSync(outputDir, { recursive: true });
     const previewOutputPath = path.join(outputDir, outputFileName);
     const codeOutputPath = path.join(outputDir, 'code-' + outputFileName);

--- a/scripts/templates.js
+++ b/scripts/templates.js
@@ -14,22 +14,22 @@ async function downloadFile(url, outputDir, outputFileName) {
     }
     // Get initial file contents
     const fileContent = await response.text();
-    
+
     // Replace version numbers in preview files
     let previewContent = fileContent.replace(
       /gcds-utility\@<version-number>/g,
       'gcds-utility@' +
-      pjson.devDependencies['@cdssnc/gcds-utility'].replace(/^\^/, ''),
+        pjson.devDependencies['@cdssnc/gcds-utility'].replace(/^\^/, ''),
     );
     previewContent = previewContent.replace(
       /gcds-components\@<version-number>/g,
       'gcds-components@' +
-      pjson.devDependencies['@cdssnc/gcds-components'].replace(/^\^/, ''),
+        pjson.devDependencies['@cdssnc/gcds-components'].replace(/^\^/, ''),
     );
 
     // Add code formatting for code files
     const codeContent = `{% highlight html %}\n${previewContent}\n{% endhighlight %}`;
-    
+
     fs.mkdirSync(outputDir, { recursive: true });
     const previewOutputPath = path.join(outputDir, outputFileName);
     const codeOutputPath = path.join(outputDir, 'code-' + outputFileName);


### PR DESCRIPTION
# Summary | Résumé

To add the current version being used in `gcds-components` and `gcds-utility` to the basic page template code, move the `codeContent` logic below the version replacement logic in the `templates.js` script.

https://github.com/cds-snc/design-gc-conception/issues/1387

## How to test

1. On `main` branch, run `npm run build` & `npm run start`.
2. Visit http://localhost:8080/en/page-templates/basic/code/.
3. Notice the version numbers for the components and UF imports are formatted as `<version-number>`.
4. On this branch, run `npm run build` & `npm run start`.
5. Visit http://localhost:8080/en/page-templates/basic/code/.
6. Notice the version numbers the components and UF imports now match the version numbers in use by the 11ty docs site.