### PR TITLE
feat: Change placement of copy button for template code examples

### DIFF
--- a/src/en/page-templates/basic/code.md
+++ b/src/en/page-templates/basic/code.md
@@ -14,4 +14,8 @@ date: "git Last Modified"
 
 Copy this code to use the basic page template.
 
+<div class="page-template-highlight">
+
 {% include 'partials/templates/en/code-basic-page-template.njk' %}
+
+</div>

--- a/src/fr/modeles-de-page/basic/code.md
+++ b/src/fr/modeles-de-page/basic/code.md
@@ -14,4 +14,8 @@ date: "git Last Modified"
 
 Copiez ce code pour utiliser le modèle de page de base.
 
+<div class="page-template-highlight">
+
 {% include 'partials/templates/fr/code-basic-page-template.njk' %}
+
+</div>

--- a/src/scripts/code-copy.js
+++ b/src/scripts/code-copy.js
@@ -8,37 +8,43 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   const buttonText = {
-    'en' : {
+    en: {
       copy: 'Copy',
-      copied: 'Copied'
+      copyTemplate: 'Copy template',
+      copied: 'Copied',
     },
-    'fr' : {
+    fr: {
       copy: 'Copier',
-      copied: 'Copié'
-    }
-  }
+      copyTemplate: 'Copier le modèle',
+      copied: 'Copié',
+    },
+  };
 
-  const buttonClasses = [
-    'd-block',
-    'mt-150',
-    'code-copy-button'
-  ]
+  const buttonClasses = ['d-block', 'mt-150', 'code-copy-button'];
 
-  code.forEach((pre) => {
+  code.forEach(pre => {
+    const templateHighlight = pre.closest('.page-template-highlight');
     const button = document.createElement('gcds-button');
-    button.classList.add(...buttonClasses);
     button.setAttribute('button-role', 'secondary');
-    button.setAttribute('size', 'small');
 
-    button.innerHTML = buttonText[lang].copy;
+    if (templateHighlight) {
+      button.innerHTML = buttonText[lang].copyTemplate;
+    } else {
+      button.classList.add(...buttonClasses);
+      button.setAttribute('size', 'small');
+      button.innerHTML = buttonText[lang].copy;
+    }
 
     button.addEventListener('click', () => {
       navigator.clipboard.writeText(pre.querySelector('code').textContent);
       button.innerHTML = buttonText[lang].copied;
     });
     button.addEventListener('blur', () => {
-      button.innerHTML = buttonText[lang].copy;
+      button.innerHTML = templateHighlight
+        ? buttonText[lang].copyTemplate
+        : buttonText[lang].copy;
     });
-    pre.append(button);
+
+    templateHighlight ? templateHighlight.prepend(button) : pre.append(button);
   });
 });

--- a/src/scripts/code-copy.js
+++ b/src/scripts/code-copy.js
@@ -24,6 +24,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   code.forEach(pre => {
     const templateHighlight = pre.closest('.page-template-highlight');
+    pre.setAttribute('tabindex', 0);
     const button = document.createElement('gcds-button');
     button.setAttribute('button-role', 'secondary');
 


### PR DESCRIPTION
# Summary | Résumé

Based on feedback, place the copy button for template code examples at the top of the template page.

Closes https://github.com/cds-snc/design-gc-conception/issues/1471