### PR TITLE
fix: requiredOn shortcode list formatting

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -316,11 +316,7 @@ module.exports = function (eleventyConfig) {
         </li>`;
       }
 
-      return `
-      <ul class="d-flex flex-wrap gap-300">
-        ${canChip}
-        ${gcChip}
-      </ul>`;
+      return `<ul class="d-flex flex-wrap gap-300">${canChip}${gcChip}</ul>`;
     },
   );
 


### PR DESCRIPTION
# Summary | Résumé

Fix rendering of `requiredOn` shortcode to prevent failure when running accessibility tests. The returned list would leave some whitespace that 11ty would convert to `p` tags which would cause a list formatting error in the a11y test.

## How to test

Using the code below

```
{% requiredOn locale true %}
{% endrequiredOn %}
```

1. On main branch, place the code example on a page.
2. Run the a11y tests.
3. Notice a list structure error after the page has been tested.
4. Switch to this branch and run the test again.
5. Notice no errors for the page.
