### PR TITLE
fix: move new canada.ca requirments guidance into gcds-details components

### DIFF
--- a/src/en/components/breadcrumbs/design.md
+++ b/src/en/components/breadcrumbs/design.md
@@ -25,18 +25,25 @@ Here's what's required for breadcrumbs on GC sites.
 - Breadcrumbs are required in the header on Canada.ca standard and campaign pages.
 - Breadcrumbs are optional for other Canada.ca pages and GC sites.
 
-### What's required on a Canada.ca standard or campaign page
+<gcds-details details-title="What's required on a Canada.ca standard or campaign page" class="mb-300">
+  <gcds-text>Always include the breadcrumbs in the header of standard and campaign pages on Canada.ca and maintain default settings.</gcds-text>
+  <div>
+    <ul class="list-disc">
+      <li>Keep the placement aligned to the left, directly below the divider line.</li>
+      <li>Keep the Canada.ca homepage as the first link in the breadcrumbs.</li>
+      <li>Leave out the current page at the end of the breadcrumb trail.</li>
+    </ul>
+  </div>
+</gcds-details>
 
-Always include the breadcrumbs in the header of standard and campaign pages on Canada.ca and maintain default settings.
-
-- Keep the placement aligned to the left, directly below the divider line.
-- Keep the Canada.ca homepage as the first link in the breadcrumbs.
-- Leave out the current page at the end of the breadcrumb trail.
-
-### What's optional to include on a Canada.ca standard or campaign page
-
-- Shorten the link text to improve readability and reduce space.
-- On a campaign page you can link to a specific landing page as the first link. This could be the Canada.ca home page, the topic tree (Canada.ca topic categories), the institutional/organizational profile, or a campaign index page.
+<gcds-details details-title="What's optional to include on a Canada.ca standard or campaign page" class="mb-300">
+  <div>
+    <ul class="list-disc">
+      <li>Shorten the link text to improve readability and reduce space.</li>
+      <li>On a campaign page you can link to a specific landing page as the first link. This could be the Canada.ca home page, the topic tree (Canada.ca topic categories), the institutional/organizational profile, or a campaign index page.</li>
+    </ul>
+  </div>
+</gcds-details>
 
 ### Include the right links in your breadcrumbs
 

--- a/src/en/components/date-modified/design.md
+++ b/src/en/components/date-modified/design.md
@@ -21,17 +21,20 @@ date: 'git Last Modified'
 
 The date modified is required on Canada.ca pages and GC sites.
 
-#### What’s required on Canada.ca and GC sites
+<gcds-details details-title="What’s required on Canada.ca and GC sites" class="mb-300">
+  <gcds-text>Always include the date modified and maintain default settings.</gcds-text>
+  <div>
+    <ul class="list-disc">
+      <li>Place the date modified component on the left, between the main content of the page and the footer.</li>
+      <li>Use the same placement of the date modified component across all web pages to make it findable.</li>
+      <li>If your page includes the page feedback tool, place the date modified component below it.</li>
+    </ul>
+  </div>
+</gcds-details>
 
-Always include the date modified and maintain default settings.
-
-- Place the date modified component on the left, between the main content of the page and the footer.
-- Use the same placement of the date modified component across all web pages to make it findable.
-- If your page includes the page feedback tool, place the date modified component below it.
-
-#### What’s optional to include on Canada.ca pages
-
-For applications, use a version number in place of a date.
+<gcds-details details-title="What’s optional to include on Canada.ca pages" class="mb-300">
+  <gcds-text margin-bottom="0">For applications, use a version number in place of a date.</gcds-text>
+</gcds-details>
 
 ### Keep the format consistent
 

--- a/src/en/components/language-toggle/design.md
+++ b/src/en/components/language-toggle/design.md
@@ -22,14 +22,17 @@ The language toggle provides a link to the page in the other Official Language.
 
 The language toggle is required in the header on Canada.ca pages and GC sites.
 
-#### What’s required on Canada.ca and GC sites
+<gcds-details details-title="What’s required on Canada.ca and GC sites" class="mb-300">
+  <gcds-text>Always include the language toggle in the header and maintain default settings.</gcds-text>
+  <div>
+    <ul class="list-disc">
+      <li>Keep the placement in the top right corner of the header where it’s predictable and findable.</li>
+      <li>Only include English and French as options.</li>
+      <li>In the language toggle link, include the opposite Official Language of the current page.</li>
+    </ul>
+  </div>
+</gcds-details>
 
-Always include the language toggle in the header and maintain default settings.
-
-- Keep the placement in the top right corner of the header where it’s predictable and findable.
-- Only include English and French as options.
-- In the language toggle link, include the opposite Official Language of the current page.
-
-#### What’s optional to include on a Canada.ca page
-
-If needed, include links to content in other languages in the content area of the page
+<gcds-details details-title="What’s optional to include on a Canada.ca page" class="mb-300">
+  <gcds-text margin-bottom="0">If needed, include links to content in other languages in the content area of the page.</gcds-text>
+</gcds-details>

--- a/src/en/components/search/design.md
+++ b/src/en/components/search/design.md
@@ -25,22 +25,27 @@ Here’s what’s required for search on GC sites.
 - Search is required in the <gcds-link href="{{ links.header }}">header</gcds-link> on Canada.ca standard and campaign pages.
 - It's optional for other Canada.ca pages and GC sites.
 
-#### What’s required on a Canada.ca standard or campaign page
+<gcds-details details-title="What’s required on a Canada.ca standard or campaign page" class="mb-300">
+  <gcds-text>Always include the search in the header of a standard or campaign page and maintain the default settings.</gcds-text>
+  <div>
+    <ul class="list-disc">
+      <li>Use default GC Search indexing.</li>
+      <li>Set indexing across Canada.ca content or at an institution or program level.</li>
+      <li>For a Canada.ca site-wide search, maintain the default search prompt text “Search Canada.ca” in English and <span lang="fr">“Rechercher dans Canada.ca”</lang> in French.</li>
+      <li>For an institution, program, or product specific search, use the following search prompt text:
+        <ul class="ms-300">
+          <li>“Search [institution/program/product]” in English</li>
+          <li>“<span lang="fr">Rechercher dans [institution/programme/produit]</span>” in French</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <gcds-text margin-bottom="0"><strong>Note:</strong> As an exception, pages solely intended for a public service audience may apply a customized search indexation in particular contexts.</gcds-text>
+</gcds-details>
 
-Always include the search in the header of a standard or campaign page and maintain the default settings.
-
-- Use default GC Search indexing.
-- Set indexing across Canada.ca content or at an institution or program level.
-- For a Canada.ca site-wide search, maintain the default search prompt text “Search Canada.ca” in English and <span lang="fr">“Rechercher dans Canada.ca”</lang> in French
-- For an institution, program, or product specific search, use the following search prompt text:
-  - “Search [institution/program/product]” in English
-  - “<span lang="fr">Rechercher dans [institution/programme/produit]</span>” in French
-
-**Note:** As an exception, pages solely intended for a public service audience may apply a customized search indexation in particular contexts.
-
-#### What’s optional to include on a Canada.ca standard or campaign page
-
-Opt to add a search for other datasets within the content area of the page.
+<gcds-details details-title="What’s optional to include on a Canada.ca standard or campaign page" class="mb-300">
+  <gcds-text margin-bottom="0">Opt to add a search for other datasets within the content area of the page.</gcds-text>
+</gcds-details>
 
 ### Opt to set up an additional search
 

--- a/src/en/components/signature/design.md
+++ b/src/en/components/signature/design.md
@@ -21,20 +21,24 @@ date: 'git Last Modified'
 
 The signature is required in the header and the wordmark is required in the footer on Canada.ca pages and GC sites.
 
-### What’s required on Canada.ca
-
-Always include the signature in the header and maintain default settings.
-
-- Use black text, do not select white text.
-- Keep placement in the top-left corner of the header on both desktop and mobile.
-- Link to the Canada.ca homepage.
-
-Always include the wordmark in the sub-footer band and maintain default settings.
-
-- Use black text, do not select white text.
-- Keep placement in the bottom-right corner of the footer.
-
-**Note:** Default settings for the Signature and Wordmark follow the <gcds-link href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/design-standard.html" external>Design Standard for the Federal Identity Program</gcds-link>.
+<gcds-details details-title="What's required on Canada.ca" class="mb-300">
+  <gcds-text>Always include the signature in the header and maintain default settings.</gcds-text>
+  <div>
+    <ul class="list-disc mb-300">
+      <li>Use black text, do not select white text.</li>
+      <li>Keep placement in the top-left corner of the header on both desktop and mobile.</li>
+      <li>Link to the Canada.ca homepage.</li>
+    </ul>
+  </div>
+  <gcds-text>Always include the wordmark in the sub-footer band and maintain default settings.</gcds-text>
+  <div>
+    <ul class="list-disc mb-300">
+      <li>Use black text, do not select white text.</li>
+      <li>Keep placement in the bottom-right corner of the footer.</li>
+    </ul>
+  </div>
+  <gcds-text margin-bottom="0"><strong>Note:</strong> Default settings for the Signature and Wordmark follow the <gcds-link href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/design-standard.html" external>Design Standard for the Federal Identity Program</gcds-link>.</gcds-text>
+</gcds-details>
 
 ### Set the language order in the signature
 

--- a/src/fr/composants/bascule-de-langue/design.md
+++ b/src/fr/composants/bascule-de-langue/design.md
@@ -22,14 +22,17 @@ La bascule de langue est un lien menant vers la même page dans l’autre langue
 
 La bascule de langue est requise dans l'en-tête des pages Canada.ca et des sites du GC.
 
-#### Éléments requis sur Canada.ca et les sites du GC
+<gcds-details details-title="Éléments requis sur Canada.ca et les sites du GC" class="mb-300">
+  <gcds-text>Insérez toujours le commutateur de langue dans l’en-tête et conservez les paramètres par défaut.</gcds-text>
+  <div>
+    <ul class="list-disc">
+      <li>Gardez la bascule de langue en haut à droite de l’en-tête. Cet emplacement prévisible la rendra plus facile à trouver.</li>
+      <li>L’anglais et le français sont les seules options approuvées.</li>
+      <li>Précisez l’autre langue officielle dans le lien de la bascule de langue afin d’indiquer qu’il mène vers la page actuelle dans l’autre langue.</li>
+    </ul>
+  </div>
+</gcds-details>
 
-Insérez toujours le commutateur de langue dans l’en-tête et conservez les paramètres par défaut.
-
-- Gardez la bascule de langue en haut à droite de l’en-tête. Cet emplacement prévisible la rendra plus facile à trouver.
-- L’anglais et le français sont les seules options approuvées.
-- Précisez l’autre langue officielle dans le lien de la bascule de langue afin d’indiquer qu’il mène vers la page actuelle dans l’autre langue.
-
-#### Éléments facultatifs sur une page Canada.ca
-
-Au besoin, ajoutez des liens vers du contenu dans d'autres langues dans la zone de contenu de la page.
+<gcds-details details-title="Éléments facultatifs sur une page Canada.ca" class="mb-300">
+  <gcds-text margin-bottom="0">Au besoin, ajoutez des liens vers du contenu dans d'autres langues dans la zone de contenu de la page.</gcds-text>
+</gcds-details>

--- a/src/fr/composants/chemin-de-navigation/design.md
+++ b/src/fr/composants/chemin-de-navigation/design.md
@@ -25,18 +25,25 @@ Voici les éléments requis pour le chemin de navigation sur les sites du GC.
 - Le chemin de navigation est requis dans l’en-tête des pages standard et de campagne de Canada.ca.
 - Le chemin de navigation est facultatif pour les autres pages de Canada.ca et les sites du GC.
 
-### Éléments requis sur une page standard ou de campagne de Canada.ca
+<gcds-details details-title="Éléments requis sur une page standard ou de campagne de Canada.ca" class="mb-300">
+  <gcds-text>Toujours inclure le chemin de navigation dans l’en-tête des pages standard et de campagne sur Canada.ca et maintenir les paramètres par défaut.</gcds-text>
+  <div>
+    <ul class="list-disc">
+      <li>Gardez le placement avec alignement sur la gauche, directement en dessous de la ligne séparatrice.</li>
+      <li>Gardez la page d’accueil de Canada.ca comme premier lien dans le chemin de navigation.</li>
+      <li>N’incluez pas la page actuelle à la fin du chemin de navigation.</li>
+    </ul>
+  </div>
+</gcds-details>
 
-Toujours inclure le chemin de navigation dans l’en-tête des pages standard et de campagne sur Canada.ca et maintenir les paramètres par défaut.
-
-- Gardez le placement avec alignement sur la gauche, directement en dessous de la ligne séparatrice.
-- Gardez la page d’accueil de Canada.ca comme premier lien dans le chemin de navigation.
-- N’incluez pas la page actuelle à la fin du chemin de navigation.
-
-### Éléments facultatifs sur une page standard ou de campagne de Canada.ca
-
-- Raccourcissez le texte du lien pour améliorer la lisibilité et réduire l’espace.
-- Sur une page de campagne, vous pouvez définir une page d’accueil précise comme premier lien. Il peut s’agir de la page d’accueil de Canada.ca, l’arborescence thématique (catégories de sujets de Canada.ca), le profil institutionnel/organisationnel, ou une page d’index de campagne.
+<gcds-details details-title="Éléments facultatifs sur une page standard ou de campagne de Canada.ca" class="mb-300">
+  <div>
+    <ul class="list-disc">
+      <li>Raccourcissez le texte du lien pour améliorer la lisibilité et réduire l’espace.</li>
+      <li>Sur une page de campagne, vous pouvez définir une page d’accueil précise comme premier lien. Il peut s’agir de la page d’accueil de Canada.ca, l’arborescence thématique (catégories de sujets de Canada.ca), le profil institutionnel/organisationnel, ou une page d’index de campagne.</li>
+    </ul>
+  </div>
+</gcds-details>
 
 ### Incluez les bons liens dans votre chemin de navigation
 

--- a/src/fr/composants/date-de-modification/design.md
+++ b/src/fr/composants/date-de-modification/design.md
@@ -21,17 +21,20 @@ date: 'git Last Modified'
 
 La date de modification est requise sur les pages Canada.ca et les sites du GC.
 
-#### Éléments requis sur Canada.ca et les sites du GC
+<gcds-details details-title="Éléments requis sur Canada.ca et les sites du GC" class="mb-300">
+  <gcds-text>Toujours inclure la date de modification et maintenir les paramètres par défaut.</gcds-text>
+  <div>
+    <ul class="list-disc">
+      <li>Placez le composant date de modification du côté gauche, entre le contenu principal de la page et le pied de page.</li>
+      <li>Placez le composant date de modification au même endroit d’une page Web à l’autre afin qu’il soit repérable.</li>
+      <li>Si votre page inclut l’outil de rétroaction sur la page, placez le composant date de modification en dessous de celui-ci.</li>
+    </ul>
+  </div>
+</gcds-details>
 
-Toujours inclure la date de modification et maintenir les paramètres par défaut.
-
-- Placez le composant date de modification du côté gauche, entre le contenu principal de la page et le pied de page.
-- Placez le composant date de modification au même endroit d’une page Web à l’autre afin qu’il soit repérable.
-- Si votre page inclut l’outil de rétroaction sur la page, placez le composant date de modification en dessous de celui-ci.
-
-#### Éléments facultatifs sur une page Canada.ca
-
-Pour les applications, utilisez un numéro de version plutôt qu’une date.
+<gcds-details details-title="Éléments facultatifs sur une page Canada.ca" class="mb-300">
+  <gcds-text margin-bottom="0">Pour les applications, utilisez un numéro de version plutôt qu’une date.</gcds-text>
+</gcds-details>
 
 ### Veiller à l’uniformité du formatage
 

--- a/src/fr/composants/recherche/design.md
+++ b/src/fr/composants/recherche/design.md
@@ -25,22 +25,27 @@ Voici les éléments requis pour la recherche sur les sites du GC.
 - La recherche est requise dans l’<gcds-link href="{{ links.header }}">en-tête</gcds-link> des pages standard et de campagne de Canada.ca.
 - Elle est facultative pour les autres pages de Canada.ca et les sites du GC.
 
-#### Éléments requis sur une page standard ou de campagne de Canada.ca
+<gcds-details details-title="Éléments requis sur une page standard ou de campagne de Canada.ca" class="mb-300">
+  <gcds-text>Toujours inclure la recherche dans l’en-tête d’une page standard ou de campagne et maintenir les paramètres par défaut.</gcds-text>
+  <div>
+    <ul class="list-disc">
+      <li>Utilisez l’indexation par défaut de la recherche du GC.</li>
+      <li>Définissez l’indexation pour tout le contenu de Canada.ca ou à l’échelle d’un organisme ou d’un programme.</li>
+      <li>Pour la recherche à l’échelle du site Canada.ca, maintenez le texte de l’espace réservé par défaut « <span lang="en">Search Canada.ca</span> » en anglais et « Rechercher dans Canada.ca » en français.</li>
+      <li>Pour la recherche à l’échelle d’un organisme, d’un programme ou d’un produit, utilisez le texte de l’espace réservé suivant :
+        <ul class="ms-300">
+          <li>« <span lang="en">Search [institution/program/product] </span>» en anglais</li>
+          <li>« Rechercher dans [institution/programme/produit] » en français</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <gcds-text margin-bottom="0"><strong>Remarque :</strong> Par exception, les pages destinées uniquement à un public de la fonction publique peuvent appliquer une indexation de recherche personnalisée dans certains contextes précis.</gcds-text>
+</gcds-details>
 
-Toujours inclure la recherche dans l’en-tête d’une page standard ou de campagne et maintenir les paramètres par défaut.
-
-- Utilisez l’indexation par défaut de la recherche du GC.
-- Définissez l’indexation pour tout le contenu de Canada.ca ou à l’échelle d’un organisme ou d’un programme.
-- Pour la recherche à l’échelle du site Canada.ca, maintenez le texte de l’espace réservé par défaut « <span lang="en">Search Canada.ca</span> » en anglais et « Rechercher dans Canada.ca » en français.
-- Pour la recherche à l’échelle d’un organisme, d’un programme ou d’un produit, utilisez le texte de l’espace réservé suivant :
-  - « <span lang="en">Search [institution/program/product] </span>» en anglais
-  - « Rechercher dans [institution/programme/produit] » en français
-
-**Remarque :** Par exception, les pages destinées uniquement à un public de la fonction publique peuvent appliquer une indexation de recherche personnalisée dans certains contextes précis.
-
-#### Éléments facultatifs sur une page standard ou de campagne de Canada.ca
-
-Envisagez d’ajouter une recherche pour d’autres ensembles de données dans la zone de contenu de la page.
+<gcds-details details-title="Éléments facultatifs sur une page standard ou de campagne de Canada.ca" class="mb-300">
+  <gcds-text margin-bottom="0">Envisagez d’ajouter une recherche pour d’autres ensembles de données dans la zone de contenu de la page.</gcds-text>
+</gcds-details>
 
 ### Envisager de configurer une recherche supplémentaire
 

--- a/src/fr/composants/signature/design.md
+++ b/src/fr/composants/signature/design.md
@@ -21,20 +21,24 @@ date: 'git Last Modified'
 
 La signature est requise dans l’en-tête et le mot-symbole est requis dans le pied de page sur les pages Canada.ca et les sites du GC.
 
-### Éléments requis sur Canada.ca
-
-Toujours inclure la signature dans l’en-tête et conserver les paramètres par défaut.
-
-- Utilisez du texte noir, ne sélectionnez pas de texte blanc.
-- Gardez la position de la signature dans le coin supérieur gauche de l’en-tête tant pour la version bureau que mobile.
-- Lien vers la page d’accueil de Canada.ca.
-
-Toujours inclure le mot-symbole dans la bande de sous-pied de page et maintenir les paramètres par défaut.
-
-- Utilisez du texte noir, ne sélectionnez pas de texte blanc.
-- Gardez la position dans le coin inférieur droit du pied de page.
-
-**Remarque :** les paramètres par défaut pour la signature et le mot-symbole suivent <gcds-link href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/communications-gouvernementales/norme-graphique.html" external>norme graphique du Programme fédéral de l’image de marque</gcds-link>.
+<gcds-details details-title="Éléments requis sur Canada.ca" class="mb-300">
+  <gcds-text>Toujours inclure la signature dans l’en-tête et conserver les paramètres par défaut.</gcds-text>
+  <div>
+    <ul class="list-disc mb-300">
+      <li>Utilisez du texte noir, ne sélectionnez pas de texte blanc.</li>
+      <li>Gardez la position de la signature dans le coin supérieur gauche de l’en-tête tant pour la version bureau que mobile.</li>
+      <li>Lien vers la page d’accueil de Canada.ca.</li>
+    </ul>
+  </div>
+  <gcds-text>Toujours inclure le mot-symbole dans la bande de sous-pied de page et maintenir les paramètres par défaut.</gcds-text>
+  <div>
+    <ul class="list-disc mb-300">
+      <li>Utilisez du texte noir, ne sélectionnez pas de texte blanc.</li>
+      <li>Gardez la position dans le coin inférieur droit du pied de page.</li>
+    </ul>
+  </div>
+  <gcds-text margin-bottom="0"><strong>Remarque :</strong> les paramètres par défaut pour la signature et le mot-symbole suivent <gcds-link href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/communications-gouvernementales/norme-graphique.html" external>norme graphique du Programme fédéral de l’image de marque</gcds-link>.</gcds-text>
+</gcds-details>
 
 ### Établir l'ordre des langues dans la signature
 


### PR DESCRIPTION
# Summary | Résumé

There was a minor miscommunication during the content updates for the new Canada.ca requirements guidance on the mandatory elements design pages. The subsections beginning with `What's required on [Canada.ca](http://canada.ca/)...` and `What's optional to include o [Canada.ca](http://canada.ca/)...` were intended to be added within `gcds-details` components. While this was noted in the ticket, it wasn't reflected in the content document, which led to the oversight.

This PR moves the new guidance sections, starting with `What's required on [Canada.ca](http://canada.ca/)...` and `What's optional to include o [Canada.ca](http://canada.ca/)...` into the appropriate `gcds-details` components.

## Previews

- [EN preview](https://pr-569.djtlis5vpn8jd.amplifyapp.com/)
- [FR preview](https://pr-569.d35vdwuoev573o.amplifyapp.com/)