### PR TITLE
fix: improve icon use case display

### DIFF
--- a/src/en/components/icon/use-case.md
+++ b/src/en/components/icon/use-case.md
@@ -42,7 +42,7 @@ Use an icon to:
 Choose an icon to match the information you want to emphasize.
 
 <div class="remove-empty-p">
-<gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
+<gcds-grid columns="1fr" columns-tablet="1fr 3fr" align-items="start">
   {% componentPreview "" "px-225 py-450" "mt-500" %}
     <p class="text-center">
       <gcds-icon size="h2" name="info-circle" label="A filled-in circle with the letter “i” in the centre."></gcds-icon>
@@ -53,31 +53,37 @@ Choose an icon to match the information you want to emphasize.
     <gcds-text>Non-critical but helpful information.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="warning-triangle" label="A filled-in triangle with the letter “i” in the centre."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="warning-triangle" label="A filled-in triangle with the letter “i” in the centre."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Warning-triangle</gcds-heading>
     <gcds-text>Cautionary warning with no action needed.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="exclamation-circle" label="A filled-in circle with an exclamation mark in the centre."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="exclamation-circle" label="A filled-in circle with an exclamation mark in the centre."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Exclamation-circle</gcds-heading>
     <gcds-text>Critical warning before an action.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="checkmark-circle" label="A filled-in circle with a checkmark in the centre."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="checkmark-circle" label="A filled-in circle with a checkmark in the centre."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Checkmark-circle</gcds-heading>
     <gcds-text>Confirmation of completion or successful actions.</gcds-text>
@@ -90,75 +96,87 @@ Choose an icon to match the information you want to emphasize.
 Choose an icon to match the action you want to indicate.
 
 <div class="remove-empty-p">
-<gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
+<gcds-grid columns="1fr" columns-tablet="1fr 3fr" align-items="start">
   {% componentPreview "" "px-50 py-400" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="chevron-left" label="An arrow pointing left." margin-right="150"></gcds-icon>
-      <gcds-icon size="h2" name="chevron-right" label="An arrow pointing right." margin-right="150"></gcds-icon>
-      <gcds-icon size="h2" name="chevron-up" label="An arrow pointing up." margin-right="150"></gcds-icon>
-      <gcds-icon size="h2" name="chevron-down" label="An arrow pointing down."></gcds-icon>
-    </p>
+  <gcds-grid columns="repeat(4, 50px)" columns-tablet="repeat(4, 50px)" gap="150" justify-content="center">
+    <gcds-icon size="h2" name="chevron-left" label="An arrow pointing left."></gcds-icon>
+    <gcds-icon size="h2" name="chevron-right" label="An arrow pointing right."></gcds-icon>
+    <gcds-icon size="h2" name="chevron-up" label="An arrow pointing up."></gcds-icon>
+    <gcds-icon size="h2" name="chevron-down" label="An arrow pointing down."></gcds-icon>
+  </gcds-grid>
   {% endcomponentPreview %}
   <div>
     <gcds-heading tag="h3">Chevron-[left/right/up/down]</gcds-heading>
     <gcds-text>Expand / collapse content or indicate direction.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="close" label="An “x”."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="close" label="An “x”."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Close</gcds-heading>
     <gcds-text>Cancel an action or close a flow.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="download" label="An arrow pointing down towards a horizontal line."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="download" label="An arrow pointing down towards a horizontal line."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Download</gcds-heading>
     <gcds-text>Download a file.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="email" label="An envelope."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="email" label="An envelope."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Email</gcds-heading>
     <gcds-text>Send an email.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="external" label="An arrow pointing outside of the top right corner of a square."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="external" label="An arrow pointing outside of the top right corner of a square."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">External-link</gcds-heading>
     <gcds-text>Open a link in a new tab or window.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="phone" label="A telephone."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="phone" label="A telephone."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Phone</gcds-heading>
     <gcds-text>Call a phone number.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="search" label="A magnifying glass."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="search" label="A magnifying glass."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Search</gcds-heading>
     <gcds-text>Search for specific information.</gcds-text>

--- a/src/fr/composants/icone/cas-dutilisation.md
+++ b/src/fr/composants/icone/cas-dutilisation.md
@@ -42,7 +42,7 @@ Utilisez une icône pour :
 Choisissez une icône correspondant à l’information que vous souhaitez mettre en évidence.
 
 <div class="remove-empty-p">
-<gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
+<gcds-grid columns="1fr" columns-tablet="1fr 3fr" align-items="start">
   {% componentPreview "" "px-225 py-450" "mt-500" %}
     <p class="text-center">
       <gcds-icon size="h2" name="info-circle" label="Un cercle rempli avec la lettre « i » au centre."></gcds-icon>
@@ -53,31 +53,37 @@ Choisissez une icône correspondant à l’information que vous souhaitez mettre
     <gcds-text>Information non critique, mais utile.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="warning-triangle" label="Un triangle rempli avec la lettre « i » au centre."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="warning-triangle" label="Un triangle rempli avec la lettre « i » au centre."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Triangle avertissement <code>gcds-icon-warning-triangle</code></gcds-heading>
     <gcds-text> Mise en garde sans action nécessaire.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="exclamation-circle" label="Un cercle rempli avec un point d’exclamation au centre."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="exclamation-circle" label="Un cercle rempli avec un point d’exclamation au centre."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Cercle exclamation <code>gcds-icon-exclamation-circle</code></gcds-heading>
     <gcds-text>Avertissement critique avant une action.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="checkmark-circle" label="Un cercle rempli avec un point d’exclamation au centre."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="checkmark-circle" label="Un cercle rempli avec un point d’exclamation au centre."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Cercle coche <code>gcds-icon-checkmark-circle</code></gcds-heading>
     <gcds-text>Confirmation de l’achèvement ou du succès d’une action.</gcds-text>
@@ -90,14 +96,14 @@ Choisissez une icône correspondant à l’information que vous souhaitez mettre
 Choisissez une icône correspondant à l’action que vous souhaitez mettre en évidence.
 
 <div class="remove-empty-p">
-<gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
+<gcds-grid columns="1fr" columns-tablet="1fr 3fr" align-items="start">
   {% componentPreview "" "px-50 py-400" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="chevron-left" label="Une flèche pointant vers la gauche." margin-right="150"></gcds-icon>
-      <gcds-icon size="h2" name="chevron-right" label="Une flèche pointant vers la droite." margin-right="150"></gcds-icon>
-      <gcds-icon size="h2" name="chevron-up" label="Une flèche pointant vers le haut." margin-right="150"></gcds-icon>
-      <gcds-icon size="h2" name="chevron-down" label="Une flèche pointant vers le bas."></gcds-icon>
-    </p>
+  <gcds-grid columns="repeat(4, 50px)" columns-tablet="repeat(4, 50px)" gap="150" justify-content="center">
+    <gcds-icon size="h2" name="chevron-left" label="Une flèche pointant vers la gauche."></gcds-icon>
+    <gcds-icon size="h2" name="chevron-right" label="Une flèche pointant vers la droite."></gcds-icon>
+    <gcds-icon size="h2" name="chevron-up" label="Une flèche pointant vers le haut."></gcds-icon>
+    <gcds-icon size="h2" name="chevron-down" label="Une flèche pointant vers le bas."></gcds-icon>
+  </gcds-grid>
   {% endcomponentPreview %}
   <div>
     <gcds-heading tag="h3">Chevron gauche/droite/haut/bas<br/>
@@ -109,61 +115,73 @@ Choisissez une icône correspondant à l’action que vous souhaitez mettre en �
     <gcds-text>Développer / réduire le contenu ou indiquer une direction.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="close" label="Un « x »."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="close" label="Un « x »."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Fermer <code>gcds-icon-close</code></gcds-heading>
     <gcds-text>Annuler une action ou fermer un flux.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="download" label="Une flèche pointant vers le bas en direction d’une ligne horizontale."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="download" label="Une flèche pointant vers le bas en direction d’une ligne horizontale."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Téléchargement <code>gcds-icon-download</code></gcds-heading>
     <gcds-text>Télécharger un fichier.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="email" label="Une enveloppe."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="email" label="Une enveloppe."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Courriel <code>gcds-icon-email</code></gcds-heading>
     <gcds-text>Envoyer un courriel.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="external" label="Une flèche pointant vers l’extérieur du coin supérieur droit d’un carré."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="external" label="Une flèche pointant vers l’extérieur du coin supérieur droit d’un carré."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Lien externe <code>gcds-icon-external-link</code></gcds-heading>
     <gcds-text>Ouvrir un lien dans un nouvel onglet ou une nouvelle fenêtre.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="phone" label="Un téléphone."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="phone" label="Un téléphone."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Téléphone <code>gcds-icon-phone</code></gcds-heading>
     <gcds-text>Composer un numéro de téléphone.</gcds-text>
   </div>
 
-  {% componentPreview "" "px-225 py-450" "mt-500" %}
-    <p class="text-center">
-      <gcds-icon size="h2" name="search" label="Une loupe."></gcds-icon>
-    </p>
-  {% endcomponentPreview %}
+{% componentPreview "" "px-225 py-450" "mt-500" %}
+
+<p class="text-center">
+<gcds-icon size="h2" name="search" label="Une loupe."></gcds-icon>
+</p>
+{% endcomponentPreview %}
+
   <div>
     <gcds-heading tag="h3">Recherche <code>gcds-icon-search</code></gcds-heading>
     <gcds-text>Rechercher des renseignements précis.</gcds-text>


### PR DESCRIPTION
# Summary | Résumé

Fix icon use case display by reducing the icon preview box and displaying the chevron icons in a grid.