### PR TITLE
fix: update installation instructions to remove outdated file

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -28,7 +28,6 @@
     <!-- GC Design System  Components-->
     <link rel="stylesheet" href="{{ '/components/dist/gcds/gcds.css' | url }}">
     <script type="module" src="/components/dist/gcds/gcds.esm.js"></script>
-    <script nomodule src="/components/dist/gcds/gcds.js"></script>
 
     <!-- Pagefind -->
     <script src="/pagefind/pagefind.js" type="module"></script>

--- a/src/_includes/layouts/component-preview.njk
+++ b/src/_includes/layouts/component-preview.njk
@@ -16,7 +16,6 @@
     <!-- GC Design System  Components-->
     <link rel="stylesheet" href="{{ '/components/dist/gcds/gcds.css' | url }}">
     <script type="module" src="/components/dist/gcds/gcds.esm.js"></script>
-    <script nomodule src="/components/dist/gcds/gcds.js"></script>
 
     <script src="{{ '/scripts/component-preview-iframe.js' | url }}"></script>
   </head>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -26,7 +26,6 @@
     <!-- GC Design System  Components-->
     <link rel="stylesheet" href="{{ '/components/dist/gcds/gcds.css' | url }}">
     <script type="module" src="/components/dist/gcds/gcds.esm.js"></script>
-    <script nomodule src="/components/dist/gcds/gcds.js"></script>
 
     <!-- Pagefind -->
     <script src="/pagefind/pagefind.js" type="module"></script>

--- a/src/_includes/partials/installation/step-2-cdn.njk
+++ b/src/_includes/partials/installation/step-2-cdn.njk
@@ -10,7 +10,6 @@
 <!-- GC Design System -->
 <link rel="stylesheet" href="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@||version||/dist/gcds/gcds.css">
 <script type="module" src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@||version||/dist/gcds/gcds.esm.js"></script>
-<script nomodule src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@||version||/dist/gcds/gcds.js"></script>
 {% endhighlight %}
 
   <small>{{ installation[locale].step2.cdn.note | safe }}</small>

--- a/src/_includes/partials/installation/step-2-node.njk
+++ b/src/_includes/partials/installation/step-2-node.njk
@@ -15,6 +15,5 @@
 <!-- GC Design System -->
 <link rel="stylesheet" href="/node_modules/@cdssnc/gcds-components/dist/gcds/gcds.css">
 <script type="module" src="/node_modules/@cdssnc/gcds-components/dist/gcds/gcds.esm.js"></script>
-<script nomodule src="/node_modules/@cdssnc/gcds-components/dist/gcds/gcds.js"></script>
 {% endhighlight %}
 </div>


### PR DESCRIPTION
# Summary | Résumé

The `dist/` folder on our `gcds-components` hasn't contained the `gcds/gcds.js` file since this commit [cds-snc/gcds-components@16732e5](https://github.com/cds-snc/gcds-components/commit/16732e5dc068cdb65d17f5485bb3189b2871836c). Removing the file from our layouts and installation instructions to avoid any confusion.