### PR TITLE
feat: update "subscribe to mailing list" link anchor on get-involved page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -30,6 +30,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy('./src/scripts/code-showcase.js');
   eleventyConfig.addPassthroughCopy('./src/scripts/search.js');
   eleventyConfig.addPassthroughCopy('./src/scripts/code-copy.js');
+  eleventyConfig.addPassthroughCopy('./src/scripts/general.js');
   eleventyConfig.addPassthroughCopy('./src/scripts/component-preview.js');
   eleventyConfig.addPassthroughCopy(
     './src/scripts/component-preview-iframe.js',
@@ -340,7 +341,7 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addPairedShortcode(
     'baseComponentPreview',
-    (children, title, url, queryString = "") => {
+    (children, title, url, queryString = '') => {
       return `
       <div class="my-600 b-sm b-default component-preview">
         <h2 class="container-full font-text font-semibold m-0 px-225 py-150 bb-sm b-default bg-light">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -23,6 +23,7 @@
     <script src="{{ '/scripts/code-showcase.js' | url }}"></script>
     <script src="{{ '/scripts/code-copy.js' | url }}"></script>
     <script src="{{ '/scripts/component-preview.js' | url }}"></script>
+    <script src="{{ '/scripts/general.js' | url }}"></script>
     <link rel="icon" type="image/x-icon" sizes="96x96" href="{{ '/favicon.ico' | url }}">
 
     <!-- GC Design System  Components-->
@@ -32,7 +33,6 @@
     <!-- Pagefind -->
     <script src="/pagefind/pagefind.js" type="module"></script>
     <script src="{{ '/scripts/search.js' | url }}" type="module"></script>
-
   </head>
   <body>
     {% include "partials/header.njk" %}
@@ -49,7 +49,6 @@
     {% include "partials/footer.njk" %}
 
     </div>
-
     {% initClipboardJS %}
   </body>
 </html>

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -21,6 +21,7 @@
     <link rel="stylesheet" href="{{ '/styles/prism.css' | url }}">
     <link rel="stylesheet" href="{{ '/styles/style.css' | url }}">
     <script src="{{ '/scripts/code-showcase.js' | url }}"></script>
+    <script src="{{ '/scripts/general.js' | url }}"></script>
     <link rel="icon" type="image/x-icon" sizes="96x96" href="{{ '/favicon.ico' | url }}">
 
     <!-- GC Design System  Components-->

--- a/src/en/en.json
+++ b/src/en/en.json
@@ -57,6 +57,7 @@
     "accessibilityTesting": "/en/accessibility/accessibility-testing",
     "contact": "/en/contact",
     "contactMail": "mailto:cds-snc@servicecanada.gc.ca",
+    "contactMailingList": "/en/contact#get-in-contact-with-the-design-system-team",
     "getInvolved": "/en/get-involved",
     "roadmap": "/en/roadmap",
     "registerDemo": "/en/register-for-a-demo",

--- a/src/en/get-involved.md
+++ b/src/en/get-involved.md
@@ -22,7 +22,7 @@ Right now, we're testing GC Design System in alpha, the first usable phase of a 
 <gcds-grid columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
   <gcds-card
     card-title="Subscribe to mailing list"
-    href="{{ links.contact }}"
+    href="{{ links.contactMailingList }}"
     description="Subscribe to our mailing list to get GC Design System updates, release communications, and special events."
   ></gcds-card>
   <gcds-card

--- a/src/fr/fr.json
+++ b/src/fr/fr.json
@@ -55,6 +55,7 @@
     "about": "/fr/a-propos",
     "contact": "/fr/contactez",
     "contactMail": "mailto:cds-snc@servicecanada.gc.ca",
+    "contactMailingList": "/fr/contactez#contactez-lequipe-du-systeme-de-design",
     "getInvolved": "/fr/simpliquer",
     "roadmap": "/fr/feuille-de-route",
     "registerDemo": "/fr/inscrivez-vous-a-une-demonstration",

--- a/src/fr/simpliquer.md
+++ b/src/fr/simpliquer.md
@@ -22,7 +22,7 @@ Nous testons actuellement la version alpha de Système de design GC, ce qui corr
 <gcds-grid columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr">
   <gcds-card
     card-title="Recevez nos communications"
-    href="{{ links.contact }}"
+    href="{{ links.contactMailingList }}"
     description="Abonnez-vous à notre liste d'envoi pour manquer aucune communication de Système de design GC concernant les mises à jour, les lancements ou encore les évènements spéciaux."
   ></gcds-card>
   <gcds-card

--- a/src/scripts/general.js
+++ b/src/scripts/general.js
@@ -1,0 +1,19 @@
+// Scrolls smoothly to the element specified in a URL hash after the page has fully loaded.
+// The delay allows time for the layout and content to finish loading before scrolling.
+window.addEventListener('load', function () {
+  const hash = window.location.hash; // Get the hash from the URL
+
+  if (hash) {
+    // Ensure the element exists for the given hash
+    const target = document.querySelector(hash);
+
+    if (target) {
+      // Wait a bit for layout shifts or content loading before scrolling
+      setTimeout(() => {
+        target.scrollIntoView({ behavior: 'smooth' });
+      }, 150);
+    } else {
+      console.warn('Element not found for hash:', hash);
+    }
+  }
+});


### PR DESCRIPTION
# Summary | Résumé

This PR updates the anchor on the "Subscribe to Mailing List" link (within the card) on the Get Involved page.

Previously, the link navigated to the top of the Contact Us page. It now correctly navigates the user to the "Get in contact with the design system team" section (H2) within that page.

## Issue

This is the [issue ticket](https://github.com/cds-snc/gcds-docs/issues/560) for this change.
