### PR TITLE
feat: update get involved content

### DIFF
--- a/src/en/get-involved.md
+++ b/src/en/get-involved.md
@@ -41,7 +41,6 @@ You can contribute to upcoming GC Design System work.
 We’re actively seeking contributions for the following items:
 
 - **Data tables** to organize and display large amounts of data in rows and columns.
-- **Tags** to label, categorize, or organize items using descriptive key words.
 
 We’re also interested in user interactions that have a common application across GC services.
 
@@ -63,29 +62,5 @@ Provide any of the following for each component or pattern:
 ### Upcoming components and templates
 
 Here’s what we’ll soon be releasing. More on our <gcds-link href="{{ links.roadmap }}">roadmap</gcds-link>.
-
-<div>
-  <gcds-heading tag="h4" margin-bottom="0">Header update</gcds-heading>
-  <ul class="mb-300">
-    <li>We’re making updates to the header to match the Canada.ca global header pattern.</li>
-    <li><strong>Expected release:</strong> Spring 2025</li>
-  </ul>
-</div>
-
-<div>
-  <gcds-heading tag="h4" margin-bottom="0">Footer update</gcds-heading>
-  <ul class="mb-300">
-    <li>We’re making updates to the footer to match the Canada.ca global footer pattern.</li>
-    <li><strong>Expected release:</strong> Spring 2025</li>
-  </ul>
-</div>
-
-<div>
-  <gcds-heading tag="h4" margin-bottom="0">Button update</gcds-heading>
-  <ul class="mb-300">
-    <li>We’re making changes to the button to add a new button role and size.</li>
-    <li><strong>Expected release:</strong> Spring 2025</li>
-  </ul>
-</div>
 
 {% include "partials/helpus.njk" %}

--- a/src/en/get-involved.md
+++ b/src/en/get-involved.md
@@ -61,6 +61,6 @@ Provide any of the following for each component or pattern:
 
 ### Upcoming components and templates
 
-Here’s what we’ll soon be releasing. More on our <gcds-link href="{{ links.roadmap }}">roadmap</gcds-link>.
+More on our <gcds-link href="{{ links.roadmap }}">roadmap</gcds-link>.
 
 {% include "partials/helpus.njk" %}

--- a/src/fr/simpliquer.md
+++ b/src/fr/simpliquer.md
@@ -59,6 +59,6 @@ Fournissez l'un des éléments suivants pour chaque composant ou modèle de page
 
 ## Autres nouveautés à venir
 
-Voici ce que nous allons bientôt publier. Plus de renseignements sur notre <gcds-link href="{{ links.roadmap }}" >feuille de route</gcds-link>.
+Plus de renseignements sur notre <gcds-link href="{{ links.roadmap }}" >feuille de route</gcds-link>.
 
 {% include "partials/helpus.njk" %}

--- a/src/fr/simpliquer.md
+++ b/src/fr/simpliquer.md
@@ -41,7 +41,6 @@ Vous pouvez contribuer à l’avenir de Système de design GC.
 Nous recherchons activement des contributions pour les éléments suivants :
 
 - **Des tableaux de données** pour organiser et afficher une grande quantité de données dans des rangées et des colonnes.
-- **Des balises** pour étiqueter, catégoriser et organiser des éléments à l’aide de mots-clés descriptifs.
 
 Nous nous intéressons également aux problèmes concernant les interactions avec les utilisateurs et utilisatrice ou aux solutions qui peuvent s’appliquer aux différents services du GC.
 
@@ -61,29 +60,5 @@ Fournissez l'un des éléments suivants pour chaque composant ou modèle de page
 ## Autres nouveautés à venir
 
 Voici ce que nous allons bientôt publier. Plus de renseignements sur notre <gcds-link href="{{ links.roadmap }}" >feuille de route</gcds-link>.
-
-<div>
-  <gcds-heading tag="h3" margin-bottom="0">Mise à jour à l'en-tête</gcds-heading>
-  <ul class="mb-300">
-    <li>Nous apportons des mises à jour au composant « En-tête » pour l’harmoniser avec l’en-tête général de Canada.ca.</li>
-    <li><strong>Sortie prévue :</strong> automne 2024</li>
-  </ul>
-</div>
-
-<div>
-  <gcds-heading tag="h3" margin-bottom="0">Mise à jour au pied de page</gcds-heading>
-  <ul class="mb-300">
-    <li>Nous apportons des mises à jour au composant « Pied de page » pour l’harmoniser avec le pied de page général de Canada.ca.</li>
-    <li><strong>Sortie prévue :</strong> automne 2024</li>
-  </ul>
-</div>
-
-<div>
-  <gcds-heading tag="h4" margin-bottom="0">Mise à jour au bouton</gcds-heading>
-  <ul class="mb-300">
-    <li>Nous apportons des modifications au composant « Bouton » afin d’ajouter un nouveau rôle et une nouvelle taille de bouton. </li>
-    <li><strong>Sortie prévue :</strong> automne 2024</li>
-  </ul>
-</div>
 
 {% include "partials/helpus.njk" %}


### PR DESCRIPTION
# Summary | Résumé

Update Get Involved page content with the following changes:

- Remove `Tags` from `next priorities`.
- Remove `header`, `footer,` and `button` under `What else is coming soon` section as the work has been completed.

## Page previews

- [EN Get Involved page](https://pr-584.djtlis5vpn8jd.amplifyapp.com/en/get-involved/)
- [FR Get Involved page](https://pr-584.d35vdwuoev573o.amplifyapp.com/fr/simpliquer/)

## Issue

This is the [issue ticket](https://github.com/cds-snc/gcds-docs/issues/578) for the change.
