### PR TITLE
feat: remove experimental tag from components page

### DIFF
--- a/src/_data/componenttags.js
+++ b/src/_data/componenttags.js
@@ -1,16 +1,14 @@
 module.exports = {
-    en: {
-        heading: 'Component tags',
-        paragraphs: [
-            "Canada.ca required components help you meet federal identity standards for the Government of Canada in any product.",
-            "Experimental components point out new features we're trying out and think you might like to use.",
-            ]
-    },
-    fr: {
-        heading: 'Balises de composants',
-        paragraphs: [
-            "Les composants « Requis sur Canada.ca » vous aident à respecter les normes du gouvernement fédéral canadien en matière d'identité, quel que soit votre produit.",
-            "Les composants « À l'essai » indiquent de nouvelles fonctionnalités que nous testons ou qui devraient vous plaire.",
-        ]
-    },
+  en: {
+    heading: 'Component tags',
+    paragraphs: [
+      'Canada.ca required components help you meet federal identity standards for the Government of Canada in any product.',
+    ],
+  },
+  fr: {
+    heading: 'Balises de composants',
+    paragraphs: [
+      "Les composants « Requis sur Canada.ca » vous aident à respecter les normes du gouvernement fédéral canadien en matière d'identité, quel que soit votre produit.",
+    ],
+  },
 };

--- a/src/en/components/grid/use-case.md
+++ b/src/en/components/grid/use-case.md
@@ -10,7 +10,6 @@ eleventyNavigation:
   description: A grid is a responsive, flexible column layout to position elements on a page.
   thumbnail: /images/common/components/preview-grid.svg
   alt: Three columns, separated by two dotted lines, hold thick grey lines representing text.
-  tag: Experimental
   state: published
 translationKey: 'grid'
 tags: ['gridEN', 'usage']

--- a/src/en/components/screenreader-only/use-case.md
+++ b/src/en/components/screenreader-only/use-case.md
@@ -10,7 +10,6 @@ eleventyNavigation:
   description: The screenreader-only component is text information only accessible with assistive technologies.
   thumbnail: /images/common/components/preview-screenreader-only.svg
   alt: One blue-grey line with a dotted line border stacked above two grey lines. The colour of all of the lines fades from the left to the right ends. A blue-grey sound icon is superimposed on the two bottom lines.
-  tag: Experimental
   state: published
 translationKey: 'screenreaderonly'
 tags: ['screenreaderonlyEN', 'usage']

--- a/src/fr/composants/grille/cas-dutilisation.md
+++ b/src/fr/composants/grille/cas-dutilisation.md
@@ -10,7 +10,6 @@ eleventyNavigation:
   description: Une grille est une mise en page réactive et flexible.
   thumbnail: /images/common/components/preview-grid.svg
   alt: Trois colonnes séparées par des lignes verticales pointillées renferment d’épaisses lignes grises représentant du texte.
-  tag: À l'essai
   state: published
 translationKey: 'grid'
 tags: ['gridFR', 'usage']


### PR DESCRIPTION
# Summary | Résumé

We decided to remove the `experimental` flag from the components page as it no longer serves the purpose we initially intended for it.

The `experimental` flag was removed from the `grid` and `screenreader only` components.

## Preview

- Preview for [EN components page](https://pr-594.djtlis5vpn8jd.amplifyapp.com/en/components/)
- Preview for [FR components page](https://pr-594.d35vdwuoev573o.amplifyapp.com/fr/composants/)

## Zenhub ticket

This is the [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1690) for the change.