### PR TITLE
fix: checkboxes preview

### DIFF
--- a/src/en/components/checkboxes/preview.md
+++ b/src/en/components/checkboxes/preview.md
@@ -14,12 +14,14 @@ templateEngineOverride: njk
     {
       "id": "form-check-1",
       "label": "Label",
-      "hint": "Description or example to make the option clearer."
+      "hint": "Description or example to make the option clearer.",
+      "value": "check1"
     },
     {
-      "id": "form-check-1",
+      "id": "form-check-2",
       "label": "Label",
-      "hint": "Description or example to make the option clearer."
+      "hint": "Description or example to make the option clearer.",
+      "value": "check2"
     }
   ]'
 >

--- a/src/fr/composants/cases-a-cocher/preview.md
+++ b/src/fr/composants/cases-a-cocher/preview.md
@@ -14,12 +14,14 @@ templateEngineOverride: njk
     {
       "id": "form-check-1",
       "label": "Libellé",
-      "hint": "Ceci est une description ou un exemple à titre de clarification."
+      "hint": "Ceci est une description ou un exemple à titre de clarification.",
+      "value": "check1"
     },
     {
-      "id": "form-check-1",
+      "id": "form-check-2",
       "label": "Libellé",
-      "hint": "Ceci est une description ou un exemple à titre de clarification."
+      "hint": "Ceci est une description ou un exemple à titre de clarification.",
+      "value": "check2"
     }
   ]'
 >


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/gcds-docs/issues/601, the checkboxes preview was not working correctly when clicking the checkboxes. This should fix the issue by correctly configuring the `gcds-checkboxes` in the preview files.

Closes https://github.com/cds-snc/gcds-docs/issues/601
