### PR TITLE
feat: add new unsubscribe pages

### DIFF
--- a/src/en/unsubscribe/error.md
+++ b/src/en/unsubscribe/error.md
@@ -1,0 +1,12 @@
+---
+title: Something went wrong
+layout: 'layouts/base.njk'
+eleventyExcludeFromCollections: true
+date: 'git Last Modified'
+---
+
+# Something went wrong
+
+We weren’t able to receive your request to unsubscribe from the mailing list. Please try again in 30 minutes.
+
+If it still doesn’t work, <gcds-link href="/en/contact">contact us</gcds-button>.

--- a/src/en/unsubscribe/success.md
+++ b/src/en/unsubscribe/success.md
@@ -1,0 +1,12 @@
+---
+title: You’re unsubscribed
+layout: 'layouts/base.njk'
+eleventyExcludeFromCollections: true
+date: 'git Last Modified'
+---
+
+# You’re unsubscribed
+
+It may take up to 48 hours to take effect.
+
+If you want to re-subscribe to the mailing list, use the <gcds-link href="/en/contact">Contact us page</gcds-link>. 

--- a/src/en/unsubscribe/unsubscribe.md
+++ b/src/en/unsubscribe/unsubscribe.md
@@ -1,0 +1,24 @@
+---
+title: Unsubscribe
+layout: 'layouts/base.njk'
+eleventyExcludeFromCollections: true
+date: 'git Last Modified'
+---
+
+# Unsubscribe
+
+Unsubscribe from the GC Design System mailing list to stop receiving all English and French emails. 
+
+It may take up to 48 hours to take effect.
+
+<form class="my-600 unsubscribe-form" name="unsubscribeEN" method="post" action="/api/submission">
+  <input type="hidden" name="form-name" value="unsubscribeEN" />
+  <input name="honeypot" type="text" aria-label="bot" hidden/>
+  <input type="hidden" name="unsubscribe" value="true" />
+
+  <gcds-input type="email" name="email" input-id="email" label="Email address" hint="Enter the email address you want to remove from the mailing list." autocomplete="email" required></gcds-input>
+
+  <gcds-button button-role="primary" type="submit">
+    Unsubscribe
+  </gcds-button>
+</form>

--- a/src/fr/se-desabonner/erreur.md
+++ b/src/fr/se-desabonner/erreur.md
@@ -1,0 +1,13 @@
+---
+title: Erreur - Se désabonner
+layout: 'layouts/base.njk'
+eleventyExcludeFromCollections: true
+date: 'git Last Modified'
+---
+
+
+# Something went wrong
+
+We weren’t able to receive your request to unsubscribe from the mailing list. Please try again in 30 minutes.
+
+If it still doesn’t work, <gcds-link href="/fr/contactez">contact us</gcds-button>.

--- a/src/fr/se-desabonner/se-desabonner.md
+++ b/src/fr/se-desabonner/se-desabonner.md
@@ -1,0 +1,24 @@
+---
+title: Se désabonner
+layout: 'layouts/base.njk'
+eleventyExcludeFromCollections: true
+date: 'git Last Modified'
+---
+
+# Se désabonner
+
+Unsubscribe from the GC Design System mailing list to stop receiving all English and French emails. 
+
+It may take up to 48 hours to take effect.
+
+<form class="my-600 unsubscribe-form" name="unsubscribeFR" method="post" action="/api/submission">
+  <input type="hidden" name="form-name" value="unsubscribeFR" />
+  <input name="honeypot" type="text" aria-label="bot" hidden/>
+  <input type="hidden" name="unsubscribe" value="true" />
+
+  <gcds-input type="email" name="email" input-id="email" label="Adresse courriel" hint="Enter the adresse courriel you want to remove from the mailing list." autocomplete="email" required></gcds-input>
+
+  <gcds-button button-role="primary" type="submit">
+    Se désabonner
+  </gcds-button>
+</form>

--- a/src/fr/se-desabonner/succes.md
+++ b/src/fr/se-desabonner/succes.md
@@ -1,0 +1,12 @@
+---
+title: You’re unsubscribed
+layout: 'layouts/base.njk'
+eleventyExcludeFromCollections: true
+date: 'git Last Modified'
+---
+
+# You’re unsubscribed
+
+It may take up to 48 hours to take effect.
+
+If you want to re-subscribe to the mailing list, use the <gcds-link href="/en/contact">Contact us page</gcds-link>. 


### PR DESCRIPTION
# Summary | Résumé
Fixes https://github.com/cds-snc/design-gc-conception/issues/1650

Adds new unsubscribe pages in English and in French (coming soon, waiting for localization)

# Test instructions | Instructions pour tester la modification
⚠️ API won't work on the preview environment, but you should be able to test it locally
