### PR TITLE
chore: add translation toggle

### DIFF
--- a/src/en/unsubscribe/unsubscribe.md
+++ b/src/en/unsubscribe/unsubscribe.md
@@ -2,7 +2,12 @@
 title: Unsubscribe
 layout: 'layouts/base.njk'
 translationKey: 'unsubscribe'
-eleventyExcludeFromCollections: true
+eleventyNavigation:
+  key: unsubscribeEN
+  title: Unsubscribe
+  locale: en
+  hideMain: true
+nocrawl: true
 date: 'git Last Modified'
 ---
 

--- a/src/fr/se-desabonner/se-desabonner.md
+++ b/src/fr/se-desabonner/se-desabonner.md
@@ -2,7 +2,12 @@
 title: Se désabonner
 layout: 'layouts/base.njk'
 translationKey: 'unsubscribe'
-eleventyExcludeFromCollections: true
+eleventyNavigation:
+  key: unsubscribeFR
+  title: Se désabonner
+  locale: fr
+  hideMain: true
+nocrawl: true
 date: 'git Last Modified'
 ---
 


### PR DESCRIPTION
# Summary | Résumé
On the new unsubscribe page, even though the `translationKey` is set, it doesn't show the language toggle at the top. This PR fixes that.

# How to test
Go to the unsubscribe page: https://design-system.alpha.canada.ca/en/unsubscribe/ to see the current/old version
Go to the preview page of this PR: https://pr-608.djtlis5vpn8jd.amplifyapp.com/en/unsubscribe
Go to the french version: https://pr-608.d35vdwuoev573o.amplifyapp.com/fr/se-desabonner
The language toggle should appear at the top