### PR TITLE
fix: replace HTML space with non-breaking space for proper word-symbol formatting in French

### DIFF
--- a/src/_data/componenttags.js
+++ b/src/_data/componenttags.js
@@ -8,7 +8,7 @@ module.exports = {
   fr: {
     heading: 'Balises de composants',
     paragraphs: [
-      "Les composants « Requis sur Canada.ca » vous aident à respecter les normes du gouvernement fédéral canadien en matière d'identité, quel que soit votre produit.",
+      "Les composants « Requis sur Canada.ca » vous aident à respecter les normes du gouvernement fédéral canadien en matière d'identité, quel que soit votre produit.",
     ],
   },
 };

--- a/src/_data/errormessage.js
+++ b/src/_data/errormessage.js
@@ -15,7 +15,7 @@ module.exports = {
     listitems: [
       "Utilisez l'attribut `required` pour activer le valideur de champ obligatoire. La validation s'effectuera par défaut pendant l'évènement `onBlur`. Une réponse manquante ou non valide affichera un message d'erreur intercalé prédéfini.",
       "Si vous devez modifier l'évènement de validation, utilisez l'attribut `validate-on`. La validation peut se produire pendant l'évènement onBlur, lorsque l'élément perd son état ciblé, ou de façon manuelle avec la méthode `validate()`.",
-      "Utilisez l'attribut `required` pour les champs qui doivent obligatoirement être remplis. La mention « obligatoire » sera alors ajoutée à la fin de l'étiquette.",
+      "Utilisez l'attribut `required` pour les champs qui doivent obligatoirement être remplis. La mention «&nbsp;obligatoire&nbsp;» sera alors ajoutée à la fin de l'étiquette.",
       "Utilisez l'attribut `error-message` pour inclure un message d'erreur pour tous les champs de saisie obligatoires. Évitez d'utiliser des messages d'erreur pour les champs de saisie facultatifs.",
       "Pour les champs facultatifs, évitez d'ajouter l'attribut `error-message`.",
       "Pour un champ facultatif nécessitant une validation qui dépend de ce que l'utilisateur a saisi (par exemple pour valider un format d'adresse courriel), ajoutez plutôt une validation et un message d'erreur personnalisés.",

--- a/src/_data/installation.js
+++ b/src/_data/installation.js
@@ -14,7 +14,7 @@ module.exports = {
   fr: {
     heading: 'Vous n’utilisez aucun de ces cadres?',
     paragraph:
-      'Si vous n’utilisez aucun des cadres mentionnés ci-haut, choisissez l’option « Autre » ci-dessous.',
+      'Si vous n’utilisez aucun des cadres mentionnés ci-haut, choisissez l’option « Autre » ci-dessous.',
     cardLink: '/fr/installation/html/',
     cardTitle: 'Autre',
     cardDescription:

--- a/src/fr/composants/avis/cas-dutilisation.md
+++ b/src/fr/composants/avis/cas-dutilisation.md
@@ -1,6 +1,6 @@
 ---
 title: Avis
-layout: "layouts/component-documentation.njk"
+layout: 'layouts/component-documentation.njk'
 eleventyNavigation:
   key: noticeFR
   title: Avis
@@ -11,10 +11,10 @@ eleventyNavigation:
   thumbnail: /images/common/components/preview-notice.svg
   alt: Une ligne bleue verticale tronquée par un cercle bleu, représentant la ligne guide et l’icône, se situe à gauche de deux épaisses lignes grises pâle alignées sous une ligne grise foncée représentant un titres et des lignes de texte.
   state: published
-translationKey: "notice"
+translationKey: 'notice'
 tags: ['noticeFR', 'usage']
 permalink: /fr/composants/avis/
-date: "git Last Modified"
+date: 'git Last Modified'
 ---
 
 ## Problèmes résolus par les avis
@@ -41,63 +41,47 @@ Définissez le type d’avis selon le contexte du message et l’apparence visue
 
 ### Information
 
-Utilisez le type d’avis « Information » pour :
+Utilisez le type d’avis «&nbsp;Information&nbsp;» pour :
 
 - Fournir des renseignements supplémentaires pour mieux faire comprendre au lectorat le contenu environnant.
 - Offrir des conseils ou davantage de contexte pour aider le lectorat à réaliser les principales tâches de la page.
 - Communiquer des renseignements non essentiels importants pour la réalisation de la tâche qu’une personne pourrait chercher à accomplir.
 
-<gcds-notice
-  notice-title="État actuel de l’appel de candidatures : Fermé"
-  notice-title-tag="h4"
-  type="info"
->
+<gcds-notice notice-title="État actuel de l’appel de candidatures : Fermé" notice-title-tag="h4" type="info">
   <gcds-text margin-bottom="0">Nous vous remercions de votre intérêt à l’égard du programme Emplois d’été Canada. L’appel de candidatures est maintenant fermé.</gcds-text>
 </gcds-notice>
 
 ### Succès
 
-Utilisez le type d’avis « Succès » pour :
+Utilisez le type d’avis «&nbsp;Succès&nbsp;» pour :
 
 - Indiquer la réussite d’une tâche.
 - Renforcer les résultats positifs ou les confirmations au sein du contenu.
 
-<gcds-notice
-  notice-title="Votre demande de données accessibles au public à partir de la liste des organismes de bienfaisance a été acceptée."
-  notice-title-tag="h4"
-  type="success"
->
+<gcds-notice notice-title="Votre demande de données accessibles au public à partir de la liste des organismes de bienfaisance a été acceptée." notice-title-tag="h4" type="success">
   <gcds-text margin-bottom="0">Le traitement de votre demande peut prendre jusqu’à quatre (4) semaines. Nous communiquerons avec vous si nous avons besoin de plus amples renseignements.</gcds-text>
 </gcds-notice>
 
 ### Avertissement
 
-Utilisez les avis de type « Avertissement » pour :
+Utilisez les avis de type «&nbsp;Avertissement&nbsp;» pour :
 
 - Avertir les gens de problèmes ou de considérations dans des cas où il n’est pas nécessaire d’agir immédiatement.
 - Informer les gens de changements, de modifications apportées aux services ou d’autres mises à jour importantes, mais non critiques.
 - Attirer l’attention sur des renseignements concernant de futurs changements ou sur des répercussions possibles sur la santé, la sécurité et les lois.
 
-<gcds-notice
-  notice-title="Modifications aux lois sur la conduite avec facultés affaiblies et la criminalité liée au cannabis"
-  notice-title-tag="h4"
-  type="warning"
->
+<gcds-notice notice-title="Modifications aux lois sur la conduite avec facultés affaiblies et la criminalité liée au cannabis" notice-title-tag="h4" type="warning">
   <gcds-text margin-bottom="0">Les nouvelles peines pour conduite avec facultés affaiblies et infractions liées au cannabis pourraient avoir une incidence sur votre statut d’immigrant au Canada. Si vous commettez l’un de ces crimes, vous ne pourrez peut-être pas venir au Canada ou y rester.</gcds-text>
 </gcds-notice>
 
 ### Danger
 
-Utilisez le type d’avis « Danger » pour :
+Utilisez le type d’avis «&nbsp;Danger&nbsp;» pour :
 
 - Mettre en évidence du contenu dont les gens doivent prendre connaissance compte tenu de sa gravité, sous peine de s’exposer à des incidences négatives majeures.
 - Mettre l’accent sur une question ou des nouvelles ayant de graves répercussions dans les domaines de la santé, de la sécurité et de la loi. Inclure un lien vers les renseignements les plus récents.
 - Signaler à une personne qu’elle doit agir immédiatement et lui donner les moyens de le faire, par exemple en lui fournissant un lien.
 
-<gcds-notice
-  notice-title="Si vous êtes enceinte ou envisagez de concevoir un enfant – Avis concernant les deux partenaires"
-  notice-title-tag="h4"
-  type="danger"
->
+<gcds-notice notice-title="Si vous êtes enceinte ou envisagez de concevoir un enfant – Avis concernant les deux partenaires" notice-title-tag="h4" type="danger">
   <gcds-text margin-bottom="0">Évitez de voyager au Costa Rica si vous êtes enceinte ou prévoyez de concevoir un enfant au cours des trois prochains mois.</gcds-text>
 </gcds-notice>

--- a/src/fr/composants/avis/design.md
+++ b/src/fr/composants/avis/design.md
@@ -3,7 +3,7 @@ title: Avis
 layout: 'layouts/component-documentation.njk'
 translationKey: 'noticeDesign'
 tags: ['noticeFR', 'design']
-date: "git Last Modified"
+date: 'git Last Modified'
 ---
 
 ## Structure de la Avis
@@ -26,9 +26,9 @@ Référez-vous aux cas d’utilisation pour savoir quand utiliser chaque type d�
 ### Rédigez des titres et des messages concis et descriptifs
 
 - Rédigez un titre significatif, court et simple pour souligner l’objectif de l’avis.
-- Dans le titre, utilisez des titres comme « Avertissement » et « Succès » correspondant au sens transmis par l’icône et la couleur du type d’avis sélectionné.
+- Dans le titre, utilisez des titres comme «&nbsp;Avertissement&nbsp;» et «&nbsp;Succès&nbsp;» correspondant au sens transmis par l’icône et la couleur du type d’avis sélectionné.
 - Rédigez un message (en dessous du titre) bref et percutant. Idéalement, faites en sorte qu’il ne dépasse pas trois phrases.
-- Enregistrez les détails pour la zone de contenu principale d’une page. L’avis doit attirer l’attention et créer une « piste d’information » pour toute personne ayant besoin d’en savoir plus.
+- Enregistrez les détails pour la zone de contenu principale d’une page. L’avis doit attirer l’attention et créer une «&nbsp;piste d’information&nbsp;» pour toute personne ayant besoin d’en savoir plus.
 
 ### Au besoin, utilisez des liens pour guider les gens vers des renseignements supplémentaires
 

--- a/src/fr/composants/bouton/cas-dutilisation.md
+++ b/src/fr/composants/bouton/cas-dutilisation.md
@@ -17,7 +17,7 @@ permalink: /fr/composants/bouton/
 date: 'git Last Modified'
 ---
 
-Jetez un coup d'œil à ce que font les boutons pour vérifier s'ils permettent de résoudre votre problème. Sélectionnez ensuite le meilleur sous-type, appelé « rôle du bouton », pour le cas d'utilisation dont vous avez besoin.
+Jetez un coup d'œil à ce que font les boutons pour vérifier s'ils permettent de résoudre votre problème. Sélectionnez ensuite le meilleur sous-type, appelé «&nbsp;rôle du bouton&nbsp;», pour le cas d'utilisation dont vous avez besoin.
 
 Utilisez un bouton pour lancer une action, comme :
 
@@ -41,31 +41,31 @@ Utilisez un bouton pour lancer une action, comme :
 
 Le type de bouton change le HTML pour effectuer une tâche précise. Choisissez le type selon la fonction dont vous avez besoin.
 
-### Type « Bouton »
+### Type «&nbsp;Bouton&nbsp;»
 
-Utilisez le type « Bouton » lorsque vous vous attendez à ce qu'une personne :
+Utilisez le type «&nbsp;Bouton&nbsp;» lorsque vous vous attendez à ce qu'une personne :
 
 - Supprime, copie ou télécharge des renseignements;
 - Choisisse entre deux options;
 - Donne son consentement ou son accord.
 
-### Type « Soumission »
+### Type «&nbsp;Soumission&nbsp;»
 
-Utilisez le type « Soumission » lorsque vous vous attendez à ce qu'une personne :
+Utilisez le type «&nbsp;Soumission&nbsp;» lorsque vous vous attendez à ce qu'une personne :
 
 - Envoie une formulaire ou une requête.
 - Enregistre des renseignements;
 - Se connecte ou se déconnecte d'un compte.
 
-### Type « Réinitialisation »
+### Type «&nbsp;Réinitialisation&nbsp;»
 
-Utilisez le type « Réinitialisation » lorsque vous vous attendez à ce qu'une personne :
+Utilisez le type «&nbsp;Réinitialisation&nbsp;» lorsque vous vous attendez à ce qu'une personne :
 
 - Supprime les données saisies dans un formulaire.
 
-### Type « Lien »
+### Type «&nbsp;Lien&nbsp;»
 
-Utilisez le type « Lien » lorsque vous vous attendez à ce qu'une personne :
+Utilisez le type «&nbsp;Lien&nbsp;» lorsque vous vous attendez à ce qu'une personne :
 
 - Se dirige vers d'autres pages ou sites externes.
 
@@ -96,7 +96,7 @@ Le rôle du bouton change son apparence afin de signaler visuellement l'action q
   {% endcomponentPreview %}
   <div>
     <h3 class="mt-0">Bouton principal</h3>
-    <p>Anciennement le « bouton de super-tâche ».</p>
+    <p>Anciennement le «&nbsp;bouton de super-tâche&nbsp;».</p>
     <ul class="list-disc mb-300">
       <li>Le début d'une tâche ou d'un flux de travail. </li>
       <li>Plus grand que les autres boutons; donc à utiliser seul et non à côté d'autres boutons.</li>
@@ -121,11 +121,11 @@ Le rôle du bouton change son apparence afin de signaler visuellement l'action q
 </gcds-grid>
 <br/>
 <gcds-grid columns="1fr" columns-tablet="1fr 2fr" align-items="start">
-  {% componentPreview "Aperçu du bouton « Danger »" "px-225 py-300" "mt-500" %}
+  {% componentPreview "Aperçu du bouton «&nbsp;Danger&nbsp;»" "px-225 py-300" "mt-500" %}
   <gcds-button button-role="danger">Supprimer</gcds-button>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mt-0">Bbouton « Danger »</h3>
+    <h3 class="mt-0">Bouton «&nbsp;Danger&nbsp;»</h3>
     <ul class="list-disc mb-300">
       <li>Pour signaler des actions conséquentes comme la suppression ou la réinitialisation de renseignements.</li>
       <li>Les changements qui s'exécutent peuvent être difficiles à renverser.</li>

--- a/src/fr/composants/bouton/design.md
+++ b/src/fr/composants/bouton/design.md
@@ -26,7 +26,7 @@ date: 'git Last Modified'
 
 ### Écrivez un libellé de bouton court, spécifique et descriptif
 
-- Rendez l’action du bouton évidente avec un libellé court et précis qui contient un verbe, ou un verbe et un nom, comme « Soumettre » ou « Obtenir une estimation ».
+- Rendez l’action du bouton évidente avec un libellé court et précis qui contient un verbe, ou un verbe et un nom, comme «&nbsp;Soumettre&nbsp;» ou «&nbsp;Obtenir une estimation&nbsp;».
 - Utilisez la majuscule initiale.
 - Rédigez un texte d’accompagnement unique et précis afin d’éviter la répétition pour les lecteurs d’écran.
 - Utilisez des phrases littérales. Évitez d’employer des expressions verbales qui risquent d’être mal comprises par des locuteur·rice·s qui ne parlent pas couramment le français.

--- a/src/fr/composants/boutons-radio/design.md
+++ b/src/fr/composants/boutons-radio/design.md
@@ -3,7 +3,7 @@ title: Boutons radio
 layout: 'layouts/component-documentation.njk'
 translationKey: 'radiosDesign'
 tags: ['radiosFR', 'design']
-date: "git Last Modified"
+date: 'git Last Modified'
 ---
 
 ## Structure du groupe de boutons radio — avec jeu de champs
@@ -23,13 +23,13 @@ date: "git Last Modified"
 
 ### Offrir des choix clairs
 
-- Limitez le nombre d'options à 7.  
-- Limitez le texte de chaque option à quelques mots ou à une phrase courte. Incluez du texte explicatif s'il faut du contexte additionnel.  
-- Ordonnez les options de manière logique. Par exemple, par ordre alphabétique ou du plus au moins commun.  
-- Lorsque possible, incluez une option « Aucune de ces réponses » pour éviter de forcer une sélection incorrecte. Une sélection ne peut être désactivée à moins qu'une autre option ne soit sélectionnée.
+- Limitez le nombre d'options à 7.
+- Limitez le texte de chaque option à quelques mots ou à une phrase courte. Incluez du texte explicatif s'il faut du contexte additionnel.
+- Ordonnez les options de manière logique. Par exemple, par ordre alphabétique ou du plus au moins commun.
+- Lorsque possible, incluez une option «&nbsp;Aucune de ces réponses&nbsp;» pour éviter de forcer une sélection incorrecte. Une sélection ne peut être désactivée à moins qu'une autre option ne soit sélectionnée.
 
 ### Fournir des instructions claires
 
-- Expliquez aux utilisateur·rice·s que seule une réponse est acceptée.  
-- Utilisez le texte explicatif pour indiquer qu'une seule sélection est possible. Par exemple, « Sélectionnez l'option la plus pertinente ».  
+- Expliquez aux utilisateur·rice·s que seule une réponse est acceptée.
+- Utilisez le texte explicatif pour indiquer qu'une seule sélection est possible. Par exemple, «&nbsp;Sélectionnez l'option la plus pertinente&nbsp;».
 - Évitez de présélectionner une option radio. Cela augmente le risque qu'une personne saute une question ou soumette une mauvaise réponse.

--- a/src/fr/composants/cases-a-cocher/design.md
+++ b/src/fr/composants/cases-a-cocher/design.md
@@ -21,12 +21,12 @@ date: 'git Last Modified'
 
 ### Offrir des choix clairs
 
-* Limitez le nombre d'options à 7.
-* Limitez le texte de chaque option à quelques mots ou à une phrase courte. Incluez du texte explicatif s'il faut du contexte additionnel.  
-* Ordonnez les options de manière logique. Par exemple, par ordre alphabétique ou du plus au moins commun.
+- Limitez le nombre d'options à 7.
+- Limitez le texte de chaque option à quelques mots ou à une phrase courte. Incluez du texte explicatif s'il faut du contexte additionnel.
+- Ordonnez les options de manière logique. Par exemple, par ordre alphabétique ou du plus au moins commun.
 
 ### Fournir des instructions claires
 
-* Ne supposez pas qu'une personne saura comment utiliser une case à cocher.  
-* Utilisez le texte explicatif pour indiquer que plusieurs sélections sont possibles. Par exemple, « cochez toutes les cases qui s'appliquent ».  
-* Évitez de présélectionner une case à cocher. Cela augmente les risques que les utilisateur·rice·s sautent une question ou soumettent une mauvaise réponse.
+- Ne supposez pas qu'une personne saura comment utiliser une case à cocher.
+- Utilisez le texte explicatif pour indiquer que plusieurs sélections sont possibles. Par exemple, «&nbsp;cochez toutes les cases qui s'appliquent&nbsp;».
+- Évitez de présélectionner une case à cocher. Cela augmente les risques que les utilisateur·rice·s sautent une question ou soumettent une mauvaise réponse.

--- a/src/fr/composants/champ-de-date/design.md
+++ b/src/fr/composants/champ-de-date/design.md
@@ -3,13 +3,13 @@ title: Champ de date
 layout: 'layouts/component-documentation.njk'
 translationKey: 'dateinputDesign'
 tags: ['dateinputFR', 'design']
-date: "git Last Modified"
+date: 'git Last Modified'
 ---
 
 ## Structure de la champ de date
 
 <ol class="anatomy-list">
-  <li>La <strong>légende du jeu de champs</strong> indique l’information qu’une personne doit saisir dans le champ de date. Le texte est aligné à gauche et porte une majuscule initiale. Pour le champ de date, la légende sera généralement intitulée « Date » ou mentionnera le type de date précis recherché. Le texte explicatif indique le format de la date.</li>
+  <li>La <strong>légende du jeu de champs</strong> indique l’information qu’une personne doit saisir dans le champ de date. Le texte est aligné à gauche et porte une majuscule initiale. Pour le champ de date, la légende sera généralement intitulée «&nbsp;Date&nbsp;» ou mentionnera le type de date précis recherché. Le texte explicatif indique le format de la date.</li>
   <li>L’<strong>étiquette Jour</strong> identifie le champ de saisie du jour.</li>
   <li>Le <strong>champ de saisie du jour</strong> peut comporter 1 ou 2 chiffres.</li>
   <li>L’<strong>étiquette Mois</strong> identifie le champ de sélection du mois.</li>
@@ -24,7 +24,7 @@ date: "git Last Modified"
 
 ### Favorisez la réussite de la tâche à l’aide d’un texte explicatif
 
-Utilisez un texte explicatif dans la légende du jeu de champs pour aider une personne à comprendre le format de date qu’elle peut utiliser. Par exemple, le texte explicatif « 7 septembre » plutôt que « 07 septembre » indique qu’un chiffre unique, non précédé d’un zéro, suffit.
+Utilisez un texte explicatif dans la légende du jeu de champs pour aider une personne à comprendre le format de date qu’elle peut utiliser. Par exemple, le texte explicatif «&nbsp;7 septembre&nbsp;» plutôt que «&nbsp;07 septembre&nbsp;» indique qu’un chiffre unique, non précédé d’un zéro, suffit.
 
 ### Rédigez des messages d’erreur précis
 

--- a/src/fr/composants/champ-de-saisie/design.md
+++ b/src/fr/composants/champ-de-saisie/design.md
@@ -21,10 +21,10 @@ date: 'git Last Modified'
 ### Rédigez une étiquette court, précis et unique
 
 - Demandez les renseignements requis avec le plus de concision possible. La forme interrogative peut rendre une étiquette inutilement longue et l'utilisateur·rice pourrait ne pas la lire en entier.
-- Choisissez des étiquettes uniques pour chaque champ de saisie et zone de texte dans une page, comme « Votre nom complet » et « Nom du ou de la gestionnaire ».
-- Évitez d'employer un jargon technique, comme « adresse électronique du sujet » ou « ID du compte ». Soyez plutôt précis·e et employez un ton personnel, comme « nom complet » et « âge de l'enfant ».
+- Choisissez des étiquettes uniques pour chaque champ de saisie et zone de texte dans une page, comme «&nbsp;Votre nom complet&nbsp;» et «&nbsp;Nom du ou de la gestionnaire&nbsp;».
+- Évitez d'employer un jargon technique, comme «&nbsp;adresse électronique du sujet&nbsp;» ou «&nbsp;ID du compte&nbsp;». Soyez plutôt précis·e et employez un ton personnel, comme «&nbsp;nom complet&nbsp;» et «&nbsp;âge de l'enfant&nbsp;».
 - Évitez d'utiliser des expressions familières et des verbes courants qui ne sont pas connus des personnes ne parlant pas couramment l'anglais ou le français.
-- Expliquez tout terme qui pourrait porter à confusion. Par exemple, « Pseudonyme (nom que vous souhaitez utiliser) ».
+- Expliquez tout terme qui pourrait porter à confusion. Par exemple, «&nbsp;Pseudonyme (nom que vous souhaitez utiliser)&nbsp;».
 
 ### Adaptez la taille du champ de saisie au type de réponse
 

--- a/src/fr/composants/chemin-de-navigation/design.md
+++ b/src/fr/composants/chemin-de-navigation/design.md
@@ -69,4 +69,4 @@ Conseil : Si vous utilisez également d'autres composants de navigation, comme 
 
 ### Placez le chemin de navigation avant le contenu principal
 
-Placez le chemin de navigation en haut d'une page, avant le contenu principal. De cette façon, un lien « Passer au contenu principal » permettra à l'utilisateur·rice d'ignorer tous les liens de navigation, y compris les chemins de navigation.
+Placez le chemin de navigation en haut d'une page, avant le contenu principal. De cette façon, un lien «&nbsp;Passer au contenu principal&nbsp;» permettra à l'utilisateur·rice d'ignorer tous les liens de navigation, y compris les chemins de navigation.

--- a/src/fr/composants/date-de-modification/cas-dutilisation.md
+++ b/src/fr/composants/date-de-modification/cas-dutilisation.md
@@ -43,8 +43,8 @@ Utilisez la date de modification pour :
   <gcds-date-modified>2023-08-22</gcds-date-modified>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mt-0">Type « Date »</h3>
-    <p>Utilisez le type « date » pour :</p>
+    <h3 class="mt-0">Type «&nbsp;Date&nbsp;»</h3>
+    <p>Utilisez le type «&nbsp;date&nbsp;» pour :</p>
     <ul class="list-disc mb-300">
       <li>Indiquer la date de la dernière modification apportée à une page ou à un site Web.</li>
     </ul>
@@ -56,8 +56,8 @@ Utilisez la date de modification pour :
   <gcds-date-modified type="version">1.0.0</gcds-date-modified>
   {% endcomponentPreview %}
   <div>
-    <h3 class="mt-0">Type « Version »</h3>
-    <p>Utilisez le type « version » pour :</p>
+    <h3 class="mt-0">Type «&nbsp;Version&nbsp;»</h3>
+    <p>Utilisez le type «&nbsp;version&nbsp;» pour :</p>
     <ul class="list-disc mb-300">
       <li>Identifier la version actuelle d'une application.</li>
     </ul>

--- a/src/fr/composants/date-de-modification/design.md
+++ b/src/fr/composants/date-de-modification/design.md
@@ -9,7 +9,7 @@ date: 'git Last Modified'
 ## Structure de la date de modification
 
 <ol class="anatomy-list">
-  <li>Le <strong>libellé</strong> décrit le type précisé dans la valeur et affiche soit « Date de modification » ou « Version » selon le type de composant.</li>
+  <li>Le <strong>libellé</strong> décrit le type précisé dans la valeur et affiche soit «&nbsp;Date de modification&nbsp;» ou «&nbsp;Version&nbsp;» selon le type de composant.</li>
   <li>La <strong>valeur</strong> correspond soit à une date numérique au format AAAA-MM-JJ, soit à un numéro de version.</li>
 </ol>
 

--- a/src/fr/composants/details/code.md
+++ b/src/fr/composants/details/code.md
@@ -25,7 +25,7 @@ Le composant Détails peut ajouter à la charge cognitive d'une personne si :
 Pour aider une personne à accéder au contenu du composant Détails :
 
 - Utilisez l'attribut `open` pour définir si le contenu du composant Détails est affiché par défaut ou non;
-- Faites en sorte que les titres utilisés dans le composant Détails indiquent clairement la nature du contenu. Évitez les titres non descriptifs tels que « En savoir plus ». Au lieu de cela, optez pour un résumé spécifique et descriptif, comme « Montant de couverture maximal pour vos prestations de physiothérapie ».
+- Faites en sorte que les titres utilisés dans le composant Détails indiquent clairement la nature du contenu. Évitez les titres non descriptifs tels que «&nbsp;En savoir plus&nbsp;». Au lieu de cela, optez pour un résumé spécifique et descriptif, comme «&nbsp;Montant de couverture maximal pour vos prestations de physiothérapie&nbsp;».
 - Choisissez des titres distinctifs pour que les gens comprennent la différence. Les titres identiques ou similaires peuvent prêter à confusion.
 - Évitez de placer un composant Détails dans un autre, là où personne ne penserait à chercher ce contenu.
   0 Faites en sorte que le contenu du composant Détails puisse faire l'objet d'une recherche.

--- a/src/fr/composants/details/design.md
+++ b/src/fr/composants/details/design.md
@@ -44,7 +44,7 @@ Commencez par retirer tout contenu qui ne serait pas utile ou important au regar
 ### Utilisez le résumé pour rendre le contenu facile à trouver
 
 - Gardez le titre clair et bref. Les titres courts sont plus faciles à comprendre d'un simple coup d'œil et peuvent aider une personne utilisant une technologie d'assistance à naviguer au sein d'un ensemble de composants Détails.
-- Écrivez un titre qui indique la nature du contenu. Évitez les titres non descriptifs tels que « En savoir plus ». Au lieu de cela, optez pour un résumé spécifique et descriptif, comme « Montant de couverture maximal pour vos prestations de physiothérapie ».
+- Écrivez un titre qui indique la nature du contenu. Évitez les titres non descriptifs tels que «&nbsp;En savoir plus&nbsp;». Au lieu de cela, optez pour un résumé spécifique et descriptif, comme «&nbsp;Montant de couverture maximal pour vos prestations de physiothérapie&nbsp;».
 - Évitez d'utiliser des titres similaires ou identiques à d'autres. Des titres distincts aident les gens à faire la différence et à choisir le contenu qu'ils et elles veulent lire.
 - Évitez d'accroître la charge cognitive des personnes qui vous liront en publiant des renseignements difficiles à trouver.
 

--- a/src/fr/composants/en-tete/code.md
+++ b/src/fr/composants/en-tete/code.md
@@ -16,34 +16,34 @@ Les composants de Système de design du GC sont conçus pour s'adapter à la tai
 
 ### Préserver l'élément signature dans l'en-tête pour les sites Web du GC
 
-- Conservez la [signature]({{ links.signature }}) pour tous les sites du GC.  
+- Conservez la [signature]({{ links.signature }}) pour tous les sites du GC.
 - Utilisez l'attribut `signature-variant` pour paramétrer la signature du gouvernement du Canada à `colour` ou `white`. Pour les arrière-plans blancs, conservez le paramètre `colour` par défaut pour la signature.
 - Assurez toujours l'intégrité de la signature du gouvernement du Canada. Évitez de la modifier de quelque manière que ce soit, de l'étirer ou d'en modifier les couleurs ou le texte.
 - Sur les pages Canada.ca, paramétrez l'attribut `signature-has-link` à `true` pour définir le lien de la signature à Canada.ca.
 
 ### Inclure la bascule de langue sur tous les sites du GC
 
-- Ajoutez la [bascule de langue]({{ links.langToggle }}) en définissant l'attribut `lang-href`. L'attribut `lang-href` définit également l'élément « href » de la bascule de langue.
-- Utilisez l'attribut `lang` pour définir la langue du site; le bouton à bascule proposera l'autre langue officielle.  
+- Ajoutez la [bascule de langue]({{ links.langToggle }}) en définissant l'attribut `lang-href`. L'attribut `lang-href` définit également l'élément «&nbsp;href&nbsp;» de la bascule de langue.
+- Utilisez l'attribut `lang` pour définir la langue du site; le bouton à bascule proposera l'autre langue officielle.
 
-### Configurer un lien « passer au contenu » (`skip-to-content`) pour améliorer l'accessibilité 
+### Configurer un lien «&nbsp;passer au contenu&nbsp;» (`skip-to-content`) pour améliorer l'accessibilité
 
-- Configurez un [lien]({{ links.link }}) `skip-to-content` comme raccourci pour les personnes utilisant une technologie d'assistance et améliorer la navigation au clavier. 
-- Définissez l'élément « href » du lien `skip-to-content` dans la navigation supérieure de l'en-tête à l'aide de l'attribut `skip-to-href`.
+- Configurez un [lien]({{ links.link }}) `skip-to-content` comme raccourci pour les personnes utilisant une technologie d'assistance et améliorer la navigation au clavier.
+- Définissez l'élément «&nbsp;href&nbsp;» du lien `skip-to-content` dans la navigation supérieure de l'en-tête à l'aide de l'attribut `skip-to-href`.
 - Utilisez l'emplacement `skip-to-nav` pour remplacer la navigation supérieure par défaut par le lien `skip-to-content`.
 - Passez un élément enfant avec l'attribut `slot="skip-to-nav"` pour placer l'élément en première position dans l'en-tête.
 
 ### Inclure le chemin d'accès et la recherche sur les sites Canada.ca
 
 - Sur les pages de Canada.ca, conservez le paramètre par défaut de `hide-canada-link` à `false`.
-- Ajoutez le composant [chemin de navigation]({{ links.breadcrumbs }}) en passant un élément enfant avec l'attribut `slot="breadcrumb"`. Cela placera le chemin de navigation dans l'en-tête sous les emplacements de la bascule de langue, la signature et la recherche. 
+- Ajoutez le composant [chemin de navigation]({{ links.breadcrumbs }}) en passant un élément enfant avec l'attribut `slot="breadcrumb"`. Cela placera le chemin de navigation dans l'en-tête sous les emplacements de la bascule de langue, la signature et la recherche.
 - Ajoutez un nouveau lien au chemin de navigation en utilisant le composant `gcds-breadcrumbs-item`. Le lien peut être ajouté à l'aide de la propriété `href`.
-- Ajoutez l'élément [recherche]({{ links.search }}) en ajoutant `<gcds-search slot="search"></gcds-search>` ou en passant un élément enfant avec l'attribut `slot="search"`. Cela placera l'élément sous la bascule de langue et à côté de la signature dans l'en-tête. 
+- Ajoutez l'élément [recherche]({{ links.search }}) en ajoutant `<gcds-search slot="search"></gcds-search>` ou en passant un élément enfant avec l'attribut `slot="search"`. Cela placera l'élément sous la bascule de langue et à côté de la signature dans l'en-tête.
 - Paramétrez la recherche de sorte à effectuer une recherche locale ou globale. Par défaut, le composant est configuré pour la recherche dans Canada.ca.
 
 ### Configurer une barre de navigation supérieure
 
-- Ajoutez une [barre de navigation supérieure]({{ links.topNav }}) en passant un élément enfant à l'aide de l'attribut `slot="menu"`. Cela placera l'élément dans l'en-tête, sous les emplacements du bouton de bascule de langue, de la signature et de la barre de recherche. 
+- Ajoutez une [barre de navigation supérieure]({{ links.topNav }}) en passant un élément enfant à l'aide de l'attribut `slot="menu"`. Cela placera l'élément dans l'en-tête, sous les emplacements du bouton de bascule de langue, de la signature et de la barre de recherche.
 - Vous avez le choix d'ajouter une bannière en faisant passer un élément enfant avec l'attribut `slot="banner"`. Cela placera l'élément en haut de l'en-tête sous l'élément `skip-to-nav`.
 
 {% include "partials/getcode.njk" %}

--- a/src/fr/composants/en-tete/design.md
+++ b/src/fr/composants/en-tete/design.md
@@ -12,7 +12,7 @@ Les éléments d'en-tête sont requis pour les sites du GC, sauf indication cont
 
 <ol class="anatomy-list">
   <li>La <strong>signature</strong> est un élément de marque qui identifie une page comme un espace du gouvernement du Canada. La signature du gouvernement du Canada renvoie à la page d'accueil Canada.ca.</li>
-  <li>Le <strong>lien « passer au contenu »</strong> permet à une personne de passer la navigation pour accéder directement au contenu principal. Le lien est caché jusqu'à ce qu'une personne y navigue avec un clavier (état ciblé visible).</li>
+  <li>Le <strong>lien «&nbsp;passer au contenu&nbsp;»</strong> permet à une personne de passer la navigation pour accéder directement au contenu principal. Le lien est caché jusqu'à ce qu'une personne y navigue avec un clavier (état ciblé visible).</li>
   <li>La <strong>bascule de langue</strong> est un lien qui permet à une personne de passer d'un contenu en français à un contenu en anglais en établissant un lien vers la page dans l'autre langue officielle.</li>
   <li>La <strong>recherche</strong> permet à une personne de saisir des mots-clés ou des phrases pour trouver du contenu. Elle peut être configurée pour effectuer une recherche locale ou globale. Facultatif, sauf sur les pages de campagne et les pages standard de Canada.ca.</li>
   <li>La <strong>ligne séparatrice</strong> divise visuellement les éléments principaux de l'en-tête et le contenu de la page.</li>
@@ -24,7 +24,7 @@ Les éléments d'en-tête sont requis pour les sites du GC, sauf indication cont
 
 ## Design et accessibilité de l'en-tête
 
-Les composants de Système de design du GC sont conçus pour s'adapter à la taille de l'écran ou du cadre où ils sont visualisés. À titre d'exception, la taille du texte dans l'en-tête et le pied de page est fixe.  
+Les composants de Système de design du GC sont conçus pour s'adapter à la taille de l'écran ou du cadre où ils sont visualisés. À titre d'exception, la taille du texte dans l'en-tête et le pied de page est fixe.
 
 ### Vérifier les exigences de l'en-tête
 
@@ -65,10 +65,10 @@ Voici les éléments requis pour l'en-tête sur les sites du GC.
 
 ### Améliorer l'accessibilité de l'en-tête
 
-- Configurez un [lien]({{ links.link }}) `skip-to-content` comme raccourci pour les personnes utilisant une technologie d'assistance et améliorer la navigation au clavier. Le lien passe les éléments de navigation pour mener directement au contenu principal de la page.  
-- Évitez de placer d'autres éléments avant le lien « passer au contenu ». Il est plus facile à découvrir s'il s'agit du premier ou deuxième élément.
+- Configurez un [lien]({{ links.link }}) `skip-to-content` comme raccourci pour les personnes utilisant une technologie d'assistance et améliorer la navigation au clavier. Le lien passe les éléments de navigation pour mener directement au contenu principal de la page.
+- Évitez de placer d'autres éléments avant le lien «&nbsp;passer au contenu&nbsp;». Il est plus facile à découvrir s'il s'agit du premier ou deuxième élément.
 
 ### Ajouter des éléments facultatifs à l'en-tête
 
-- Considérez utiliser la [barre de navigation supérieure]({{ links.topNav }}) pour les services et les sites Web qui ont besoin d'une navigation principale dédiée.  
+- Considérez utiliser la [barre de navigation supérieure]({{ links.topNav }}) pour les services et les sites Web qui ont besoin d'une navigation principale dédiée.
 - Utilisez la barre de navigation supérieure sur les pages Canada.ca lorsque le service ou le produit est autonome et cible un public interne, comme Système de design GC.

--- a/src/fr/composants/lien/code.md
+++ b/src/fr/composants/lien/code.md
@@ -19,10 +19,10 @@ Le lien est un élément de navigation qui amène une personne à une nouvelle p
 
 Remarque : Seuls les fichiers dont l'URL est de la même origine que le site Web seront téléchargés sur l'appareil de l'utilisateur·rice.
 
-### Ajoutez un lien « Passer au contenu »
+### Ajoutez un lien «&nbsp;Passer au contenu&nbsp;»
 
-- Un lien « Passer au contenu » permet à une personne de sauter un ensemble de liens de navigation pour passer au contenu principal.
-- Pour éviter de dissimuler le contenu, configurez le lien de manière à ce qu'il pousse le contenu vers le bas et ne flotte pas. Pour la version bureau, placez le lien « Passer au contenu » en haut à gauche de la page afin qu'il n'interrompe pas le flux.
+- Un lien «&nbsp;Passer au contenu&nbsp;» permet à une personne de sauter un ensemble de liens de navigation pour passer au contenu principal.
+- Pour éviter de dissimuler le contenu, configurez le lien de manière à ce qu'il pousse le contenu vers le bas et ne flotte pas. Pour la version bureau, placez le lien «&nbsp;Passer au contenu&nbsp;» en haut à gauche de la page afin qu'il n'interrompe pas le flux.
 
 ### Évitez les liens externes dans la mesure du possible
 

--- a/src/fr/composants/lien/design.md
+++ b/src/fr/composants/lien/design.md
@@ -27,7 +27,7 @@ date: 'git Last Modified'
 ### Rédigez du texte de lien descriptif et précis
 
 - Faites en sorte que le texte du lien soit clair, descriptif et précis pour aider une personne à prévoir où le lien la mènera et ce qu'elle y trouvera.
-- Évitez d'utiliser du texte générique ou vague pour les liens, comme « Cliquez ici », « En savoir plus » ou encore « Accueil ».
+- Évitez d'utiliser du texte générique ou vague pour les liens, comme «&nbsp;Cliquez ici&nbsp;», «&nbsp;En savoir plus&nbsp;» ou encore «&nbsp;Accueil&nbsp;».
 - Placez l'information la plus importante au début du texte du lien afin de faciliter la lecture pour les personnes utilisant des technologies d'assistance.
 - Fournissez dans le texte du lien suffisamment d'information sur son but, plutôt que de vous fier au contexte. Certaines technologies d'assistance présentent les liens de façon distincte.
 - Gardez le texte des liens court et précis afin qu'une personne puisse parcourir les liens et trouver ce qu'elle cherche. En règle générale, limitez le texte à 60 caractères et évitez de dépasser 80 caractères.
@@ -45,10 +45,10 @@ Conseil : Utilisez des éléments de navigation comme le [chemin de navigation]
 - Fournissez dans le texte du lien des renseignements sur le type et la taille des fichiers à télécharger.
 - Évitez de placer le lien de téléchargement dans le texte du paragraphe.
 
-### Ajoutez un lien « Passer au contenu »
+### Ajoutez un lien «&nbsp;Passer au contenu&nbsp;»
 
-- Un lien « Passer au contenu » permet à une personne de sauter un ensemble de liens de navigation pour passer au contenu principal.
-- Pour éviter de dissimuler le contenu, configurez le lien de manière à ce qu'il pousse le contenu vers le bas et ne flotte pas. Pour la version bureau, placez le lien « Passer au contenu » en haut à gauche de la page afin qu'il n'interrompe pas le flux.
+- Un lien «&nbsp;Passer au contenu&nbsp;» permet à une personne de sauter un ensemble de liens de navigation pour passer au contenu principal.
+- Pour éviter de dissimuler le contenu, configurez le lien de manière à ce qu'il pousse le contenu vers le bas et ne flotte pas. Pour la version bureau, placez le lien «&nbsp;Passer au contenu&nbsp;» en haut à gauche de la page afin qu'il n'interrompe pas le flux.
 
 ### Évitez les liens externes dans la mesure du possible
 

--- a/src/fr/composants/menu-thematique/design.md
+++ b/src/fr/composants/menu-thematique/design.md
@@ -10,7 +10,7 @@ date: 'git Last Modified'
 
 <ol class="anatomy-list">
   <li>Le <strong>bouton du menu</strong> permet d’ouvrir et de fermer le menu thématique.</li>
-  <li>La <strong>section « Thèmes et sujets »</strong> est une liste contenant les thèmes principaux prédéfinis sur Canada.ca.</li>
+  <li>La <strong>section «&nbsp;Thèmes et sujets&nbsp;»</strong> est une liste contenant les thèmes principaux prédéfinis sur Canada.ca.</li>
   <li>Le <strong>menu volant</strong> est une liste de liens pertinents pour chaque sujet. Tous les liens seront chargés et mis à jour automatiquement.</li>
   <li>Les <strong>liens les plus en demande</strong> est une liste des actions les plus fréquemment effectuées pour chaque thème. Tous les liens seront chargés et mis à jour automatiquement.</li>
 </ol>

--- a/src/fr/composants/message-derreur/design.md
+++ b/src/fr/composants/message-derreur/design.md
@@ -37,7 +37,7 @@ Lorsque vous interrompez le déroulement d'une action, vous aidez l'utilisateur�
 
 - Rédigez des messages d'erreur pour chaque contrainte de réponse d'un composant. Énumérez la liste des risques, puis rédigez un bref énoncé précis décrivant chaque besoin.
 - N'indiquez qu'une seule raison par erreur, notamment le critère que la réponse ne rempli pas.
-- Ne mentionnez pas l'action menée par l'utilisateur·rice qui a donné lieu au problème. Par exemple, si l'on écrit « Vous n'avez pas répondu à une question », on attribue la responsabilité à l'utilisateur·rice. En revanche, une formulation du genre « Question obligatoire » se limite à signaler le problème sans blâmer personne.
+- Ne mentionnez pas l'action menée par l'utilisateur·rice qui a donné lieu au problème. Par exemple, si l'on écrit «&nbsp;Vous n'avez pas répondu à une question&nbsp;», on attribue la responsabilité à l'utilisateur·rice. En revanche, une formulation du genre «&nbsp;Question obligatoire&nbsp;» se limite à signaler le problème sans blâmer personne.
 
 ### Remettez la personne sur la bonne voie avec un appel à l'action
 

--- a/src/fr/composants/pagination/design.md
+++ b/src/fr/composants/pagination/design.md
@@ -91,4 +91,4 @@ La pagination simple est plus adaptée à un contenu réparti sur 2 à 5 pages.
 
 ### Utilisez la pagination sous forme de liste pour un grand nombre de pages
 
-Utilisez la pagination sous forme de liste lorsque le nombre de pages est important et que les seuls liens « Précédent » et « Suivant » rendraient la navigation fastidieuse.
+Utilisez la pagination sous forme de liste lorsque le nombre de pages est important et que les seuls liens «&nbsp;Précédent&nbsp;» et «&nbsp;Suivant&nbsp;» rendraient la navigation fastidieuse.

--- a/src/fr/composants/pied-de-page/design.md
+++ b/src/fr/composants/pied-de-page/design.md
@@ -83,6 +83,6 @@ Les composants de Système de design du GC sont conçus pour s’adapter à la t
 
 ### Modifier les liens
 
-- Dans la bande contextuelle, modifiez les trois liens pour votre site. Choisissez des liens que les gens s’attendent à trouver dans un pied de page, comme « Contactez-nous », « Carrières » ou « Actualités ».
-- Dans la bande de liens du pied de page du GC, modifiez les liens « Avis » et « Confidentialité » pour votre site.
+- Dans la bande contextuelle, modifiez les trois liens pour votre site. Choisissez des liens que les gens s’attendent à trouver dans un pied de page, comme «&nbsp;Contactez-nous&nbsp;», «&nbsp;Carrières&nbsp;» ou «&nbsp;Actualités&nbsp;».
+- Dans la bande de liens du pied de page du GC, modifiez les liens «&nbsp;Avis&nbsp;» et «&nbsp;Confidentialité&nbsp;» pour votre site.
 - Faites en sorte que le texte du lien soit clair et précis pour aider les gens à décider s’ils doivent quitter la page actuelle. Indiquez la page cible où une personne sera redirigée ou ce qu’elle trouvera en cliquant sur le lien.

--- a/src/fr/composants/selection/design.md
+++ b/src/fr/composants/selection/design.md
@@ -23,14 +23,14 @@ date: 'git Last Modified'
 
 - Limitez le texte de chaque option à quelques mots ou à une phrase courte.
 - En règle générale, les options sont classées par ordre alphabétique. Dans certains cas, il peut être utile de classer les options de la plus commune à la moins commune.
-- Lorsque possible, ajoutez une option telle que « Aucun » ou « Aucun des éléments ci-dessus ».
+- Lorsque possible, ajoutez une option telle que «&nbsp;Aucun&nbsp;» ou «&nbsp;Aucun des éléments ci-dessus&nbsp;».
 
 ### Aidez l'utilisateur·rice à comprendre comment utiliser les sélections
 
 - Ne partez pas du principe qu'une personne saura utiliser une sélection.
-- Utilisez le texte explicatif pour expliquer aux utilisateur·rice·s qui ne sont pas à l'aide avec la sélection qu'ils et elles ne peuvent choisir qu'une seule option. Par exemple, « Sélectionnez l'option la plus pertinente ».
+- Utilisez le texte explicatif pour expliquer aux utilisateur·rice·s qui ne sont pas à l'aide avec la sélection qu'ils et elles ne peuvent choisir qu'une seule option. Par exemple, «&nbsp;Sélectionnez l'option la plus pertinente&nbsp;».
 - Évitez de présélectionner une option de sélection. Cela augmente les risques que les utilisateur·rice·s sautent une question ou soumettent une mauvaise réponse.
-- Lorsque possible, ajoutez une option telle que « Aucun » ou « Aucun des éléments ci-dessus ». Une fois sélectionnée, une option ne peut être désélectionnée, ou inversée, à moins de choisir une autre option dans le groupe. Le cas échéant, le ou la répondant·e est obligé·e de sélectionner une mauvaise option ou d'abandonner la tâche.
+- Lorsque possible, ajoutez une option telle que «&nbsp;Aucun&nbsp;» ou «&nbsp;Aucun des éléments ci-dessus&nbsp;». Une fois sélectionnée, une option ne peut être désélectionnée, ou inversée, à moins de choisir une autre option dans le groupe. Le cas échéant, le ou la répondant·e est obligé·e de sélectionner une mauvaise option ou d'abandonner la tâche.
 
 ### Utilisez d'autres questions pour réduire le nombre d'options de sélection
 

--- a/src/fr/composants/signature/design.md
+++ b/src/fr/composants/signature/design.md
@@ -10,7 +10,7 @@ date: 'git Last Modified'
 
 <ol class="anatomy-list">
   <li>La <strong>signature du gouvernement du Canada</strong> est l'identificateur de l'image de marque placée dans l'<gcds-link href="{{ links.header }}">en-tête</gcds-link> du site. La signature sert de lien général vers la page d'accueil du site.</li>
-  <li>Le <strong>mot-symbole « Canada »</strong> est l'identificateur de l'image de marque placé dans le <gcds-link href="{{ links.footer }}">pied de page</gcds-link> du site. Il renforce l'image de marque en informant les visiteur·rice·s du site que le contenu qui leur est présenté provient du gouvernement du Canada.</li>
+  <li>Le <strong>mot-symbole «&nbsp;Canada&nbsp;»</strong> est l'identificateur de l'image de marque placé dans le <gcds-link href="{{ links.footer }}">pied de page</gcds-link> du site. Il renforce l'image de marque en informant les visiteur·rice·s du site que le contenu qui leur est présenté provient du gouvernement du Canada.</li>
 </ol>
 
 <img class="b-sm b-default p-300" src="/images/fr/components/anatomy/gcds-signature-anatomy-fr.svg" alt="Signature avec les étiquettes « Signature du gouvernement du Canada » et « Mot-symbole Canada ». Chaque élément du composant est identifié à l’aide d’un chiffre.]" />
@@ -43,7 +43,7 @@ La signature est requise dans l’en-tête et le mot-symbole est requis dans le 
 ### Établir l'ordre des langues dans la signature
 
 - Affichez d'abord la signature en français sur les pages en français. De même, insérez d'abord la signature en anglais sur les pages en anglais.
-- Conservez « Government of Canada » pour le texte de remplacement (alt-text) en anglais et « Gouvernement du Canada » pour le français.
+- Conservez «&nbsp;Government of Canada&nbsp;» pour le texte de remplacement (alt-text) en anglais et «&nbsp;Gouvernement du Canada&nbsp;» pour le français.
 
 **Remarque :** L’image contient un lien qui mène à la page d’accueil Canada.ca dans la même langue officielle que la page actuelle.
 

--- a/src/fr/composants/texte/design.md
+++ b/src/fr/composants/texte/design.md
@@ -20,7 +20,7 @@ tags: ['textFR', 'design']
 ### Rédigez du contenu facile à lire en un coup d'oeil
 
 - Structurez le contenu de manière à placer les informations les plus importantes pour la tâche en premier.
-- Gardez le contenu bref et axé sur les tâches. Notre « besoin de dire » n'est pas égal au « besoin de savoir » d'un lecteur.
+- Gardez le contenu bref et axé sur les tâches. Notre «&nbsp;besoin de dire&nbsp;» n'est pas égal au «&nbsp;besoin de savoir&nbsp;» d'un lecteur.
 - Supprimez les détails et les explications inutiles. Incluez uniquement les renseignements dont une personne a besoin.
 - Utilisez des phrases courtes qui communiquent une seule idée. Indiquez clairement le sujet de l'action dans chaque phrase.
 - Évitez le chargement frontal de contenu qui pourrait plutôt être placé là où une personne en a besoin. Plutôt que d'expliquer un processus, faites que le processus est plus facile à suivre et à comprendre.

--- a/src/fr/composants/zone-de-texte/code.md
+++ b/src/fr/composants/zone-de-texte/code.md
@@ -15,6 +15,7 @@ La zone de texte donne aux utilisateur·rice·s la possibilité de fournir les r
 ## Codage et accessibilité des zones de texte
 
 ### Appliquez les attributs requis
+
 Pour que la zone de texte fonctionne correctement, utilisez toujours les attributs suivants avec `<gcds-textarea>`:
 
 - `name`
@@ -24,7 +25,7 @@ Pour que la zone de texte fonctionne correctement, utilisez toujours les attribu
 ### Adaptez la zone de texte au type de réponse
 
 - Utilisez des zones de texte pour les réponses qui peuvent nécessiter plus de 75 caractères.
-- Faites en sorte que la hauteur d'une zone de texte soit proportionnelle à la quantité de texte que vous attendez de l'utilisateur·rice. Vous pouvez définir la hauteur d'une zone de texte en spécifiant l'attribut « rows ».
+- Faites en sorte que la hauteur d'une zone de texte soit proportionnelle à la quantité de texte que vous attendez de l'utilisateur·rice. Vous pouvez définir la hauteur d'une zone de texte en spécifiant l'attribut «&nbsp;rows&nbsp;».
 - Évitez de définir une largeur inférieure à 50 % (1/2 largeur).
 - Utilisez le maximum pour les réponses sans longueur fixe.
 

--- a/src/fr/composants/zone-de-texte/design.md
+++ b/src/fr/composants/zone-de-texte/design.md
@@ -22,9 +22,9 @@ date: 'git Last Modified'
 
 - Demandez les renseignements requis avec le plus de concision possible. La forme interrogative peut rendre une étiquette inutilement longue et l'utilisateur·rice pourrait ne pas la lire en entier.
 - Choisissez des étiquettes uniques pour chaque champ de saisie et zone de texte dans une page. Une personne parcourant les champs entendra le texte de l'étiquette en succession rapide et n'aura pas d'indication pour associer l'etiquette avec chaque contexte.
-- Évitez d'employer un jargon technique, comme « adresse électronique du sujet » ou « ID du compte ». Soyez plutôt précis·e et employez un ton personnel, comme « nom complet » et « âge de l'enfant ».
+- Évitez d'employer un jargon technique, comme «&nbsp;adresse électronique du sujet&nbsp;» ou «&nbsp;ID du compte&nbsp;». Soyez plutôt précis·e et employez un ton personnel, comme «&nbsp;nom complet&nbsp;» et «&nbsp;âge de l'enfant&nbsp;».
 - Évitez d'utiliser des expressions familières et des verbes courants qui ne sont pas connus des personnes ne parlant pas couramment l'anglais ou le français.
-- Expliquez tout terme qui pourrait porter à confusion. Par exemple, « Biographie (Dites nous quelques mots à propos de vous-même) ».
+- Expliquez tout terme qui pourrait porter à confusion. Par exemple, «&nbsp;Biographie (Dites nous quelques mots à propos de vous-même)&nbsp;».
 
 ### Favorisez la réussite de la tâche en ajoutant du texte explicatif
 

--- a/src/fr/modeles-de-page/basic/basic.md
+++ b/src/fr/modeles-de-page/basic/basic.md
@@ -9,11 +9,11 @@ eleventyNavigation:
   description: Point de départ de toute page Web. Offre une structure et une hiérarchie basiques et accessibles, et comprend les éléments obligatoires pour la plupart des pages du GC.
   descriptionSecondaryText:
   state: published
-#  tag: Canada.ca required
+  #  tag: Canada.ca required
   order: 1
 translationKey: 'basicPageTemplate'
-tags: ["templates"]
-date: "git Last Modified"
+tags: ['templates']
+date: 'git Last Modified'
 github: https://github.com/cds-snc/gcds-examples/blob/feat/add-basic-page-templates/templates/english/basic-page-template.html
 figma: https://figma.com
 ---
@@ -48,10 +48,10 @@ Pour réaliser un prototype dans Figma, trouvez le <gcds-link external href="{{ 
 
 ### Améliorer la navigation dans les longues pages
 
-- Pour toute page ayant 4 sections ou plus, ajoutez une section « Sur cette page » comprenant une liste de liens (ancres) renvoyant aux autres sections. 
+- Pour toute page ayant 4 sections ou plus, ajoutez une section «&nbsp;Sur cette page&nbsp;» comprenant une liste de liens (ancres) renvoyant aux autres sections.
 - Ajouter des ancres afin d'améliorer la navigation et aident les gens à trouver le contenu dont ils ont besoin.
 
-### Aperçu « Sur cette page »
+### Aperçu «&nbsp;Sur cette page&nbsp;»
 
 <gcds-button class="mb-300" button-role="secondary" type="link" href="{{ links.pageTemplatesBasicExtOTPPreview }}" target="_blank">Ouvrir demo dans un nouvel onglet</gcds-button>
 <gcds-button  button-role="secondary" type="link" href="{{ links.pageTemplatesBasicExtOTPCode }}" target="_blank">Obtenez code dans un nouvel onglet</gcds-button>

--- a/src/fr/styles/couleur/couleur.md
+++ b/src/fr/styles/couleur/couleur.md
@@ -114,6 +114,6 @@ Utilisez les unités de style de base pour :
 {% include "partials/token_table.njk", token: 'color.grayscale color.blue color.red color.green color.yellow', type: 'color' %}
 </div>
 
-Remarque : Les éléments de code utilisent l'orthographe américaine pour « colour » et « grey ».
+Remarque : Les éléments de code utilisent l'orthographe américaine pour «&nbsp;colour&nbsp;» et «&nbsp;grey&nbsp;».
 
 {% include "partials/helpus.njk" %}

--- a/src/fr/styles/typographie/typographie.md
+++ b/src/fr/styles/typographie/typographie.md
@@ -81,7 +81,7 @@ Remarque : La propriété de la police représente à la fois l'épaisseur, la t
 
 ### Familles de police
 
-Les en-têtes font appel à la police « Lato ». Les paragraphes et autres éléments textuels se servent de la police « Noto Sans ».
+Les en-têtes font appel à la police «&nbsp;Lato&nbsp;». Les paragraphes et autres éléments textuels se servent de la police «&nbsp;Noto Sans&nbsp;».
 
 La famille de police comprend des valeurs de rechange. Les valeurs de rechange sont seulement utilisées pour une famille de police lorsqu'une police n'est pas disponible.
 


### PR DESCRIPTION
# Summary | Résumé

Replaced regular HTML space with the non-breaking space character `&nbsp;` in  md files and the (` `) in localized string values to prevent word-symbol separation in rendered text. The previous approach treated the text as plain text, leading to unwanted line breaks at times.

### Impact:

This ensures that the « symbols remain attached to the following word, even when the text is wrapped or broken across lines.
