### PR TITLE
fix: remove extra div in gcds-details component on mandatory pages

### DIFF
--- a/src/en/accessibility/accessibility.md
+++ b/src/en/accessibility/accessibility.md
@@ -25,79 +25,77 @@ The entire GC Design System builds in accessibility from the start to meet acces
 ### Navigation
 
 <gcds-details details-title="Focus states">
-  <p>Interactive elements, like buttons, links, and form fields, have clear and visible focus states to guide people who use keyboard navigation.</p>
+  <gcds-text margin-bottom="0">Interactive elements, like buttons, links, and form fields, have clear and visible focus states to guide people who use keyboard navigation.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Keyboard navigation">
-  <p>Keyboards can be used to navigate the system by people who cannot use a mouse.</p>
+  <gcds-text margin-bottom="0">Keyboards can be used to navigate the system by people who cannot use a mouse.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Screen reader compatibility">
-  <p>Screen readers can be used to navigate the system by people using assistive technologies.</p>
+  <gcds-text margin-bottom="0">Screen readers can be used to navigate the system by people using assistive technologies.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Responsive design">
-  <p>The components are responsive so people have consistent experiences regardless of the device they use.</p>
+  <gcds-text margin-bottom="0">>The components are responsive so people have consistent experiences regardless of the device they use.</gcds-text>
 </gcds-details>
 
 ### Visuals
 
 <gcds-details details-title="Colour contrast">
-  <p>Text and interface elements meet or exceed the required colour contrast ratios to maintain readability for people with low vision or colour blindness.</p>
+  <gcds-text margin-bottom="0">Text and interface elements meet or exceed the required colour contrast ratios to maintain readability for people with low vision or colour blindness.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Non-colour indicators">
-  <p>In addition to colour, visual cues like shapes, icons, or bold text, are used to indicate important information for people with colour blindness.</p> 
+  <gcds-text margin-bottom="0">In addition to colour, visual cues like shapes, icons, or bold text, are used to indicate important information for people with colour blindness.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Screen magnifier compatibility">
-  <p>Screen magnifiers can be used by people with low vision to zoom in on content without losing functionality.</p>
+  <gcds-text margin-bottom="0">Screen magnifiers can be used by people with low vision to zoom in on content without losing functionality.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Browsers and assistive plugins compatibility.">
-  <p>Accessibility formatting like Accessible Rich Internet Applications (ARIA) roles and landmarks is preserved and works in different environments.</p>
+  <gcds-text margin-bottom="0">Accessibility formatting like Accessible Rich Internet Applications (ARIA) roles and landmarks is preserved and works in different environments.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Alt text">
-  <p>Images and non-text content include appropriate alt text to provide a description for people relying on screen readers.</p>
+  <gcds-text margin-bottom="0">Images and non-text content include appropriate alt text to provide a description for people relying on screen readers.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="ARIA roles and attributes">
-  <p>Accessible Rich Internet Applications (ARIA) roles and attributes are used so interactive elements, like menus, buttons, and forms, can be identified and operated by assistive technologies.</p> 
+  <gcds-text margin-bottom="0">Accessible Rich Internet Applications (ARIA) roles and attributes are used so interactive elements, like menus, buttons, and forms, can be identified and operated by assistive technologies.</gcds-text>
 </gcds-details>
 
 ### Clarity
 
 <gcds-details details-title="Clear form fields">
-  <p>Form fields follow guidance to have accessible labels, clear instructions, and are compatible with assistive technologies.</p>
+  <gcds-text margin-bottom="0">Form fields follow guidance to have accessible labels, clear instructions, and are compatible with assistive technologies.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Clear and specific error messages">
-  <p>Clear and actionable guidance appears when there are errors in forms or interactions so people know how to fix the error.</p>
+  <gcds-text margin-bottom="0">Clear and actionable guidance appears when there are errors in forms or interactions so people know how to fix the error.</gcds-text>
 </gcds-details>
 
 ## How we test for accessibility
 
 <gcds-details details-title="Automated accessibility testing">
- <p>Before components are released, we leverage automated tools that scan tokens, components, and website for accessibility issues. This early-stage testing allows us to resolve common issues before deeper testing begins.</p>
+ <gcds-text margin-bottom="0">Before components are released, we leverage automated tools that scan tokens, components, and website for accessibility issues. This early-stage testing allows us to resolve common issues before deeper testing begins.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Manual testing for accessibility needs">
-  <p>We conduct testing with people who have accessibility needs, including individuals with various disabilities. This ensures our system is functional and usable in a range of scenarios that automated testing cannot fully capture.</p>
+  <gcds-text margin-bottom="0">We conduct testing with people who have accessibility needs, including individuals with various disabilities. This ensures our system is functional and usable in a range of scenarios that automated testing cannot fully capture.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Research and best practices">
-  <p>We’re always looking at new accessibility rules and best practices from different industries. We add new findings and suggestions to our design system guidance.</p>
+  <gcds-text margin-bottom="0">We’re always looking at new accessibility rules and best practices from different industries. We add new findings and suggestions to our design system guidance.</gcds-text>
 </gcds-details>
 
 <gcds-card
-  card-title="Testing tools"
-  href="{{ links.accessibilityTesting }}"
-  card-title-tag="h3"
-  description="Tools and tips for teams who may choose to do their own testing before release."
-  class="mt-600"
->
-</gcds-card>
+card-title="Testing tools"
+href="{{ links.accessibilityTesting }}"
+card-title-tag="h3"
+description="Tools and tips for teams who may choose to do their own testing before release."
+class="mt-600"> </gcds-card>
 
 ## Contact us
 

--- a/src/en/components/breadcrumbs/design.md
+++ b/src/en/components/breadcrumbs/design.md
@@ -27,22 +27,18 @@ Here's what's required for breadcrumbs on GC sites.
 
 <gcds-details details-title="What's required on a Canada.ca standard or campaign page" class="mb-300">
   <gcds-text>Always include the breadcrumbs in the header of standard and campaign pages on Canada.ca and maintain default settings.</gcds-text>
-  <div>
-    <ul class="list-disc">
-      <li>Keep the placement aligned to the left, directly below the divider line.</li>
-      <li>Keep the Canada.ca homepage as the first link in the breadcrumbs.</li>
-      <li>Leave out the current page at the end of the breadcrumb trail.</li>
-    </ul>
-  </div>
+  <ul class="list-disc">
+    <li>Keep the placement aligned to the left, directly below the divider line.</li>
+    <li>Keep the Canada.ca homepage as the first link in the breadcrumbs.</li>
+    <li>Leave out the current page at the end of the breadcrumb trail.</li>
+  </ul>
 </gcds-details>
 
 <gcds-details details-title="What's optional to include on a Canada.ca standard or campaign page" class="mb-300">
-  <div>
-    <ul class="list-disc">
-      <li>Shorten the link text to improve readability and reduce space.</li>
-      <li>On a campaign page you can link to a specific landing page as the first link. This could be the Canada.ca home page, the topic tree (Canada.ca topic categories), the institutional/organizational profile, or a campaign index page.</li>
-    </ul>
-  </div>
+  <ul class="list-disc">
+    <li>Shorten the link text to improve readability and reduce space.</li>
+    <li>On a campaign page you can link to a specific landing page as the first link. This could be the Canada.ca home page, the topic tree (Canada.ca topic categories), the institutional/organizational profile, or a campaign index page.</li>
+  </ul>
 </gcds-details>
 
 ### Include the right links in your breadcrumbs

--- a/src/en/components/date-modified/design.md
+++ b/src/en/components/date-modified/design.md
@@ -23,13 +23,11 @@ The date modified is required on Canada.ca pages and GC sites.
 
 <gcds-details details-title="What’s required on Canada.ca and GC sites" class="mb-300">
   <gcds-text>Always include the date modified and maintain default settings.</gcds-text>
-  <div>
-    <ul class="list-disc">
-      <li>Place the date modified component on the left, between the main content of the page and the footer.</li>
-      <li>Use the same placement of the date modified component across all web pages to make it findable.</li>
-      <li>If your page includes the page feedback tool, place the date modified component below it.</li>
-    </ul>
-  </div>
+  <ul class="list-disc">
+    <li>Place the date modified component on the left, between the main content of the page and the footer.</li>
+    <li>Use the same placement of the date modified component across all web pages to make it findable.</li>
+    <li>If your page includes the page feedback tool, place the date modified component below it.</li>
+  </ul>
 </gcds-details>
 
 <gcds-details details-title="What’s optional to include on Canada.ca pages" class="mb-300">

--- a/src/en/components/details/preview.md
+++ b/src/en/components/details/preview.md
@@ -7,5 +7,5 @@ templateEngineOverride: njk
 ---
 
 <gcds-details details-title="Learn more about this topic">
-  <p>Additional information.</p>
+  <gcds-text margin-bottom="0">Additional information.</gcds-text>
 </gcds-details>

--- a/src/en/components/footer/design.md
+++ b/src/en/components/footer/design.md
@@ -40,25 +40,23 @@ GC Design System components are designed to adapt to the size of the screen or f
 
 <gcds-details details-title="What’s required on a Canada.ca standard page" class="mb-300">
   <gcds-text>Always include the following components on a standard page:</gcds-text>
-  <div>
-    <ul class="list-disc mb-300">
-      <li>Main band.</li>
-      <li>
-        GC footer links band.
-        <ul class="ms-300">
-          <li>Social media link.</li>
-          <li>Mobile app link.</li>
-          <li>About Canada.ca link.</li>
-          <li>Terms and conditions link.</li>
-          <li>Privacy statement link.</li>
-          <li>Canada wordmark.</li>
-        </ul>
-      </li>
-    </ul>
-  </div>
+  <ul class="list-disc mb-300">
+    <li>Main band.</li>
+    <li>
+      GC footer links band.
+      <ul class="ms-300">
+        <li>Social media link.</li>
+        <li>Mobile app link.</li>
+        <li>About Canada.ca link.</li>
+        <li>Terms and conditions link.</li>
+        <li>Privacy statement link.</li>
+        <li>Canada wordmark.</li>
+      </ul>
+    </li>
+  </ul>
   <gcds-text>Always preserve the integrity of the Government of Canada signature. Never modify it in any way, stretch it, or change the colours or text.</gcds-text>
   <gcds-text>It’s optional to include the following components on a standard page:</gcds-text>
-  <ul class="list-disc mb-300">
+  <ul class="list-disc">
     <li>Contextual band.</li>
   </ul>
 </gcds-details>

--- a/src/en/components/header/design.md
+++ b/src/en/components/header/design.md
@@ -49,14 +49,14 @@ Here's what's required for the header on GC sites.
     <li>Divider line.</li>
   </ul>
 
-  <gcds-text>
+  <gcds-text margin-bottom="0">
     <strong>Note</strong>: As an exception on legacy applications, the language toggle can be omitted if it results in a destructive action (a person loses their data when language is switched).
   </gcds-text>
 </gcds-details>
 
 <gcds-details details-title="What's optional to include on a Canada.ca standard or campaign page" class="mb-300">
   <gcds-text>Opt to include:</gcds-text>
-  <ul class="list-disc mb-300">
+  <ul class="list-disc">
     <li>An approved program or institution specific search form instead of the global search form.</li>
     <li>Sign in button.</li>
     <li>Top navigation.</li>
@@ -65,10 +65,10 @@ Here's what's required for the header on GC sites.
 
 ### Improve the accessibility of the header
 
-- Set up a skip-to-content [link]({{ links.link }}) as a shortcut for people using an assistive technology and improve keyboard navigation. The link skips navigation elements to lead directly to the main page content.  
+- Set up a skip-to-content [link]({{ links.link }}) as a shortcut for people using an assistive technology and improve keyboard navigation. The link skips navigation elements to lead directly to the main page content.
 - Avoid putting other elements ahead of the skip-to-content link. It’s more discoverable if it’s the first or second item.
 
 ### Include optional elements in your header
 
-- Consider using the [top navigation]({{ links.topNav }}) for services and websites that need a dedicated primary navigation.  
+- Consider using the [top navigation]({{ links.topNav }}) for services and websites that need a dedicated primary navigation.
 - Use the top navigation on Canada.ca pages when the service or product is self-contained and targets an internal audience, **like GC Design System**.

--- a/src/en/components/language-toggle/design.md
+++ b/src/en/components/language-toggle/design.md
@@ -24,13 +24,11 @@ The language toggle is required in the header on Canada.ca pages and GC sites.
 
 <gcds-details details-title="What’s required on Canada.ca and GC sites" class="mb-300">
   <gcds-text>Always include the language toggle in the header and maintain default settings.</gcds-text>
-  <div>
-    <ul class="list-disc">
-      <li>Keep the placement in the top right corner of the header where it’s predictable and findable.</li>
-      <li>Only include English and French as options.</li>
-      <li>In the language toggle link, include the opposite Official Language of the current page.</li>
-    </ul>
-  </div>
+  <ul class="list-disc">
+    <li>Keep the placement in the top right corner of the header where it’s predictable and findable.</li>
+    <li>Only include English and French as options.</li>
+    <li>In the language toggle link, include the opposite Official Language of the current page.</li>
+  </ul>
 </gcds-details>
 
 <gcds-details details-title="What’s optional to include on a Canada.ca page" class="mb-300">

--- a/src/en/components/search/design.md
+++ b/src/en/components/search/design.md
@@ -27,19 +27,17 @@ Here’s what’s required for search on GC sites.
 
 <gcds-details details-title="What’s required on a Canada.ca standard or campaign page" class="mb-300">
   <gcds-text>Always include the search in the header of a standard or campaign page and maintain the default settings.</gcds-text>
-  <div>
-    <ul class="list-disc">
-      <li>Use default GC Search indexing.</li>
-      <li>Set indexing across Canada.ca content or at an institution or program level.</li>
-      <li>For a Canada.ca site-wide search, maintain the default search prompt text “Search Canada.ca” in English and <span lang="fr">“Rechercher dans Canada.ca”</lang> in French.</li>
-      <li>For an institution, program, or product specific search, use the following search prompt text:
-        <ul class="ms-300">
-          <li>“Search [institution/program/product]” in English</li>
-          <li>“<span lang="fr">Rechercher dans [institution/programme/produit]</span>” in French</li>
-        </ul>
-      </li>
-    </ul>
-  </div>
+  <ul class="list-disc">
+    <li>Use default GC Search indexing.</li>
+    <li>Set indexing across Canada.ca content or at an institution or program level.</li>
+    <li>For a Canada.ca site-wide search, maintain the default search prompt text “Search Canada.ca” in English and <span lang="fr">“Rechercher dans Canada.ca”</lang> in French.</li>
+    <li>For an institution, program, or product specific search, use the following search prompt text:
+      <ul class="ms-300">
+        <li>“Search [institution/program/product]” in English</li>
+        <li>“<span lang="fr">Rechercher dans [institution/programme/produit]</span>” in French</li>
+      </ul>
+    </li>
+  </ul>
   <gcds-text margin-bottom="0"><strong>Note:</strong> As an exception, pages solely intended for a public service audience may apply a customized search indexation in particular contexts.</gcds-text>
 </gcds-details>
 

--- a/src/en/components/signature/design.md
+++ b/src/en/components/signature/design.md
@@ -23,20 +23,16 @@ The signature is required in the header and the wordmark is required in the foot
 
 <gcds-details details-title="What's required on Canada.ca" class="mb-300">
   <gcds-text>Always include the signature in the header and maintain default settings.</gcds-text>
-  <div>
-    <ul class="list-disc mb-300">
-      <li>Use black text, do not select white text.</li>
-      <li>Keep placement in the top-left corner of the header on both desktop and mobile.</li>
-      <li>Link to the Canada.ca homepage.</li>
-    </ul>
-  </div>
+  <ul class="list-disc mb-300">
+    <li>Use black text, do not select white text.</li>
+    <li>Keep placement in the top-left corner of the header on both desktop and mobile.</li>
+    <li>Link to the Canada.ca homepage.</li>
+  </ul>
   <gcds-text>Always include the wordmark in the sub-footer band and maintain default settings.</gcds-text>
-  <div>
-    <ul class="list-disc mb-300">
-      <li>Use black text, do not select white text.</li>
-      <li>Keep placement in the bottom-right corner of the footer.</li>
-    </ul>
-  </div>
+  <ul class="list-disc mb-300">
+    <li>Use black text, do not select white text.</li>
+    <li>Keep placement in the bottom-right corner of the footer.</li>
+  </ul>
   <gcds-text margin-bottom="0"><strong>Note:</strong> Default settings for the Signature and Wordmark follow the <gcds-link href="https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/design-standard.html" external>Design Standard for the Federal Identity Program</gcds-link>.</gcds-text>
 </gcds-details>
 

--- a/src/fr/accessibilite/accessibilite.md
+++ b/src/fr/accessibilite/accessibilite.md
@@ -25,82 +25,80 @@ Système de design GC intègre l’accessibilité dès le départ pour répondre
 ### Navigation
 
 <gcds-details details-title="États ciblés">
-  <p>Les éléments interactifs, comme les boutons, les liens et les champs de formulaires, ont des états ciblés clairs et visibles pour guider les personnes qui utilisent la navigation au clavier.</p>
+  <gcds-text margin-bottom="0">Les éléments interactifs, comme les boutons, les liens et les champs de formulaires, ont des états ciblés clairs et visibles pour guider les personnes qui utilisent la navigation au clavier.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Navigation au clavier">
-  <p>Les personnes ne pouvant pas utiliser de souris peuvent se servir d’un clavier pour la navigation au sein du système.</p>
+  <gcds-text margin-bottom="0">Les personnes ne pouvant pas utiliser de souris peuvent se servir d’un clavier pour la navigation au sein du système.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Compatibilité avec les lecteurs d’écran">
-  <p>Les personnes utilisant des technologies d’assistance peuvent se servir des lecteurs d’écran pour la navigation au sein du système.</p>
+  <gcds-text margin-bottom="0">Les personnes utilisant des technologies d’assistance peuvent se servir des lecteurs d’écran pour la navigation au sein du système.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Conception réactive">
-  <p>Les composants sont réactifs de manière à offrir des expériences uniformes, quel que soit l’appareil que les gens utilisent.</p>
+  <gcds-text margin-bottom="0">Les composants sont réactifs de manière à offrir des expériences uniformes, quel que soit l’appareil que les gens utilisent.</gcds-text>
 </gcds-details>
 
 ### Visuels
 
 <gcds-details details-title="Contraste de couleurs">
-  <p>Les éléments de texte et d’interface respectent ou dépassent les ratios exigés en matière de contraste de couleurs pour garantir leur lisibilité par les personnes ayant une visuelle partielle ou le daltonisme.</p>
+  <gcds-text margin-bottom="0">Les éléments de texte et d’interface respectent ou dépassent les ratios exigés en matière de contraste de couleurs pour garantir leur lisibilité par les personnes ayant une visuelle partielle ou le daltonisme.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Indicateurs autres que les couleurs">
-  <p>Des repères visuels autres que les couleurs, comme des formes, des icônes ou du texte en gras, sont utilisés pour indiquer les renseignements importants aux personnes ayant une déficience dans la perception des couleurs.</p> 
+  <gcds-text margin-bottom="0">Des repères visuels autres que les couleurs, comme des formes, des icônes ou du texte en gras, sont utilisés pour indiquer les renseignements importants aux personnes ayant une déficience dans la perception des couleurs.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Compatibilité avec les loupes d’écran">
-  <p>Les personnes ayant une incapacité visuelle peuvent utiliser des loupes d’écran pour agrandir le contenu sans perdre en fonctionnalité.</p>
+  <gcds-text margin-bottom="0">Les personnes ayant une incapacité visuelle peuvent utiliser des loupes d’écran pour agrandir le contenu sans perdre en fonctionnalité.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Compatibilité avec les navigateurs et avec les modules d’extension d’assistance">
-  <p>La mise en forme pour l’accessibilité (comme les rôles et points caractéristiques ARIA [Accessible Rich Internet Applications ou « applications Internet enrichies accessibles »]) est préservée et fonctionne dans différents environnements.</p>
+  <gcds-text margin-bottom="0">La mise en forme pour l’accessibilité (comme les rôles et points caractéristiques ARIA [Accessible Rich Internet Applications ou « applications Internet enrichies accessibles »]) est préservée et fonctionne dans différents environnements.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Texte de remplacement">
-  <p>Les images et le contenu non textuel comprennent du texte de remplacement approprié afin d’offrir une description aux personnes ayant besoin de lecteurs d’écran.</p>
+  <gcds-text margin-bottom="0">Les images et le contenu non textuel comprennent du texte de remplacement approprié afin d’offrir une description aux personnes ayant besoin de lecteurs d’écran.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Rôles et attributs ARIA">
-  <p>Les rôles et attributs ARIA (Accessible Rich Internet Applications ou « applications Internet enrichies accessibles ») sont utilisés afin que les éléments interactifs, comme les menus, les boutons et les formulaires, puissent être reconnus et utilisés par les technologies d’assistance.</p>
+  <gcds-text margin-bottom="0">Les rôles et attributs ARIA (Accessible Rich Internet Applications ou « applications Internet enrichies accessibles ») sont utilisés afin que les éléments interactifs, comme les menus, les boutons et les formulaires, puissent être reconnus et utilisés par les technologies d’assistance.</gcds-text>
 </gcds-details>
 
 ### Clarté
 
 <gcds-details details-title="Champs de formulaires clairs">
-  <p>Conformément aux lignes directrices, les champs de formulaires comprennent des étiquettes accessibles et des instructions claires et sont compatibles avec les technologies d’assistance.</p>
+  <gcds-text margin-bottom="0">Conformément aux lignes directrices, les champs de formulaires comprennent des étiquettes accessibles et des instructions claires et sont compatibles avec les technologies d’assistance.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Messages d’erreur clairs et précis">
-  <p>En cas d’erreur dans les formulaires ou les interactions, des lignes directrices claires et exploitables s’affichent pour expliquer comment corriger l’erreur en question.</p>
+  <gcds-text margin-bottom="0">En cas d’erreur dans les formulaires ou les interactions, des lignes directrices claires et exploitables s’affichent pour expliquer comment corriger l’erreur en question.</gcds-text>
 </gcds-details>
 
 ## Nos tests en matière d’accessibilité
 
 <gcds-details details-title="Tests d’accessibilité automatisés">
- <p>Avant le lancement de nouveaux composants, nous utilisons des outils automatisés permettant d’examiner les unités de style, les composants et le site Web pour déceler les éventuels problèmes d’accessibilité. Ces tests précoces nous permettent de résoudre les problèmes courants avant le début des tests approfondis.</p>
+ <gcds-text margin-bottom="0">Avant le lancement de nouveaux composants, nous utilisons des outils automatisés permettant d’examiner les unités de style, les composants et le site Web pour déceler les éventuels problèmes d’accessibilité. Ces tests précoces nous permettent de résoudre les problèmes courants avant le début des tests approfondis.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Tests manuels à des fins d’accessibilité">
-  <p>Nous effectuons des tests auprès de personnes présentant des besoins en matière d’accessibilité, y compris des personnes ayant des handicaps divers. De cette manière, nous veillons à ce que notre système soit fonctionnel et utilisable dans une variété de scénarios que les tests automatisés ne permettent pas de totalement prendre en compte.</p>
+  <gcds-text margin-bottom="0">Nous effectuons des tests auprès de personnes présentant des besoins en matière d’accessibilité, y compris des personnes ayant des handicaps divers. De cette manière, nous veillons à ce que notre système soit fonctionnel et utilisable dans une variété de scénarios que les tests automatisés ne permettent pas de totalement prendre en compte.</gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Recherche et meilleures pratiques">
-  <p>Nous guettons toujours les nouvelles règles d’accessibilité et meilleures pratiques issues de différentes industries. Nous intégrons les nouvelles observations et suggestions aux lignes directrices de notre système de design.</p>
+  <gcds-text margin-bottom="0">Nous guettons toujours les nouvelles règles d’accessibilité et meilleures pratiques issues de différentes industries. Nous intégrons les nouvelles observations et suggestions aux lignes directrices de notre système de design.</gcds-text>
 </gcds-details>
 
 <gcds-card
-  card-title="Outils de test"
-  href="{{ links.accessibilityTesting }}"
-  card-title-tag="h3"
-  description="Outils et conseils pour les équipes qui choisissent de faire leurs propres tests avant la publication."
-  class="mt-600"
->
-</gcds-card>
+card-title="Outils de test"
+href="{{ links.accessibilityTesting }}"
+card-title-tag="h3"
+description="Outils et conseils pour les équipes qui choisissent de faire leurs propres tests avant la publication."
+class="mt-600"> </gcds-card>
 
 ## Contactez-nous
 
 Si vous avec des questions ou si vous rencontrez des obstacles en matière d’accessibilité lors de l’utilisation de Système de design GC, ‌[contactez-nous]({{ links.contact }}).
 
-Nous nous engageons à résoudre rapidement tout problème afin de garantir une expérience inclusive pour tous et toutes. 
+Nous nous engageons à résoudre rapidement tout problème afin de garantir une expérience inclusive pour tous et toutes.

--- a/src/fr/composants/bascule-de-langue/design.md
+++ b/src/fr/composants/bascule-de-langue/design.md
@@ -24,13 +24,11 @@ La bascule de langue est requise dans l'en-tête des pages Canada.ca et des site
 
 <gcds-details details-title="Éléments requis sur Canada.ca et les sites du GC" class="mb-300">
   <gcds-text>Insérez toujours le commutateur de langue dans l’en-tête et conservez les paramètres par défaut.</gcds-text>
-  <div>
-    <ul class="list-disc">
-      <li>Gardez la bascule de langue en haut à droite de l’en-tête. Cet emplacement prévisible la rendra plus facile à trouver.</li>
-      <li>L’anglais et le français sont les seules options approuvées.</li>
-      <li>Précisez l’autre langue officielle dans le lien de la bascule de langue afin d’indiquer qu’il mène vers la page actuelle dans l’autre langue.</li>
-    </ul>
-  </div>
+  <ul class="list-disc">
+    <li>Gardez la bascule de langue en haut à droite de l’en-tête. Cet emplacement prévisible la rendra plus facile à trouver.</li>
+    <li>L’anglais et le français sont les seules options approuvées.</li>
+    <li>Précisez l’autre langue officielle dans le lien de la bascule de langue afin d’indiquer qu’il mène vers la page actuelle dans l’autre langue.</li>
+  </ul>
 </gcds-details>
 
 <gcds-details details-title="Éléments facultatifs sur une page Canada.ca" class="mb-300">

--- a/src/fr/composants/chemin-de-navigation/design.md
+++ b/src/fr/composants/chemin-de-navigation/design.md
@@ -27,22 +27,18 @@ Voici les éléments requis pour le chemin de navigation sur les sites du GC.
 
 <gcds-details details-title="Éléments requis sur une page standard ou de campagne de Canada.ca" class="mb-300">
   <gcds-text>Toujours inclure le chemin de navigation dans l’en-tête des pages standard et de campagne sur Canada.ca et maintenir les paramètres par défaut.</gcds-text>
-  <div>
-    <ul class="list-disc">
-      <li>Gardez le placement avec alignement sur la gauche, directement en dessous de la ligne séparatrice.</li>
-      <li>Gardez la page d’accueil de Canada.ca comme premier lien dans le chemin de navigation.</li>
-      <li>N’incluez pas la page actuelle à la fin du chemin de navigation.</li>
-    </ul>
-  </div>
+  <ul class="list-disc">
+    <li>Gardez le placement avec alignement sur la gauche, directement en dessous de la ligne séparatrice.</li>
+    <li>Gardez la page d’accueil de Canada.ca comme premier lien dans le chemin de navigation.</li>
+    <li>N’incluez pas la page actuelle à la fin du chemin de navigation.</li>
+  </ul>
 </gcds-details>
 
 <gcds-details details-title="Éléments facultatifs sur une page standard ou de campagne de Canada.ca" class="mb-300">
-  <div>
-    <ul class="list-disc">
-      <li>Raccourcissez le texte du lien pour améliorer la lisibilité et réduire l’espace.</li>
-      <li>Sur une page de campagne, vous pouvez définir une page d’accueil précise comme premier lien. Il peut s’agir de la page d’accueil de Canada.ca, l’arborescence thématique (catégories de sujets de Canada.ca), le profil institutionnel/organisationnel, ou une page d’index de campagne.</li>
-    </ul>
-  </div>
+  <ul class="list-disc">
+    <li>Raccourcissez le texte du lien pour améliorer la lisibilité et réduire l’espace.</li>
+    <li>Sur une page de campagne, vous pouvez définir une page d’accueil précise comme premier lien. Il peut s’agir de la page d’accueil de Canada.ca, l’arborescence thématique (catégories de sujets de Canada.ca), le profil institutionnel/organisationnel, ou une page d’index de campagne.</li>
+  </ul>
 </gcds-details>
 
 ### Incluez les bons liens dans votre chemin de navigation

--- a/src/fr/composants/date-de-modification/design.md
+++ b/src/fr/composants/date-de-modification/design.md
@@ -23,13 +23,11 @@ La date de modification est requise sur les pages Canada.ca et les sites du GC.
 
 <gcds-details details-title="Éléments requis sur Canada.ca et les sites du GC" class="mb-300">
   <gcds-text>Toujours inclure la date de modification et maintenir les paramètres par défaut.</gcds-text>
-  <div>
-    <ul class="list-disc">
-      <li>Placez le composant date de modification du côté gauche, entre le contenu principal de la page et le pied de page.</li>
-      <li>Placez le composant date de modification au même endroit d’une page Web à l’autre afin qu’il soit repérable.</li>
-      <li>Si votre page inclut l’outil de rétroaction sur la page, placez le composant date de modification en dessous de celui-ci.</li>
-    </ul>
-  </div>
+  <ul class="list-disc">
+    <li>Placez le composant date de modification du côté gauche, entre le contenu principal de la page et le pied de page.</li>
+    <li>Placez le composant date de modification au même endroit d’une page Web à l’autre afin qu’il soit repérable.</li>
+    <li>Si votre page inclut l’outil de rétroaction sur la page, placez le composant date de modification en dessous de celui-ci.</li>
+  </ul>
 </gcds-details>
 
 <gcds-details details-title="Éléments facultatifs sur une page Canada.ca" class="mb-300">

--- a/src/fr/composants/details/preview.md
+++ b/src/fr/composants/details/preview.md
@@ -7,5 +7,5 @@ templateEngineOverride: njk
 ---
 
 <gcds-details details-title="Apprenez-en plus sur ce sujet">
-  <p>Renseignements supplémentaires.</p>
+  <gcds-text margin-bottom="0">Renseignements supplémentaires.</gcds-text>
 </gcds-details>

--- a/src/fr/composants/en-tete/design.md
+++ b/src/fr/composants/en-tete/design.md
@@ -49,14 +49,14 @@ Voici les éléments requis pour l'en-tête sur les sites du GC.
     <li>Ligne séparatrice.</li>
   </ul>
 
-  <gcds-text>
+  <gcds-text margin-bottom="0">
     <strong>Remarque</strong> : Par exception pour les anciennes applications, la bascule de langue peut être omise si elle entraîne une action destructive (perte de données lorsque la langue est changée).
   </gcds-text>
 </gcds-details>
 
 <gcds-details details-title="Éléments facultatifs sur une page standard ou de campagne de Canada.ca" class="mb-300">
   <gcds-text>Vous pouvez choisir d'inclure :</gcds-text>
-  <ul class="list-disc mb-300">
+  <ul class="list-disc">
     <li>Un formulaire de recherche approuvé propre à un programme ou à un organisme plutôt que le formulaire de recherche global.</li>
     <li>Bouton « Se connecter ».</li>
     <li>Barre de navigation supérieure.</li>

--- a/src/fr/composants/pied-de-page/design.md
+++ b/src/fr/composants/pied-de-page/design.md
@@ -42,25 +42,23 @@ Les composants de Système de design du GC sont conçus pour s’adapter à la t
 
 <gcds-details details-title="Éléments requis sur une page standard de Canada.ca " class="mb-300">
   <gcds-text>Intégrez toujours les composants suivants sur une page standard :</gcds-text>
-  <div>
-    <ul class="list-disc mb-300">
-      <li>Bande principale.</li>
-      <li>
-        Bande de liens de pied de page du GC.
-        <ul class="ms-300">
-          <li>Lien Médias sociaux.</li>
-          <li>Lien Applications mobiles.</li>
-          <li>Lien À propos de Canada.ca.</li>
-          <li>Lien Avis.</li>
-          <li>Lien Confidentialité.</li>
-          <li>Mot-symbol Canada.</li>
-        </ul>
-      </li>
-    </ul>
-  </div>
+  <ul class="list-disc mb-300">
+    <li>Bande principale.</li>
+    <li>
+      Bande de liens de pied de page du GC.
+      <ul class="ms-300">
+        <li>Lien Médias sociaux.</li>
+        <li>Lien Applications mobiles.</li>
+        <li>Lien À propos de Canada.ca.</li>
+        <li>Lien Avis.</li>
+        <li>Lien Confidentialité.</li>
+        <li>Mot-symbol Canada.</li>
+      </ul>
+    </li>
+  </ul>
   <gcds-text>Assurez toujours l’intégrité de la signature du gouvernement du Canada. Ne la modifiez jamais de quelque façon que ce soit — ne l’étirez pas et n’en changez pas les couleurs ni le texte.</gcds-text>
   <gcds-text>Les composants suivants sont facultatifs sur une page standard :</gcds-text>
-  <ul class="list-disc mb-300">
+  <ul class="list-disc">
     <li>Bande contextuelle.</li>
   </ul>
 </gcds-details>

--- a/src/fr/composants/recherche/design.md
+++ b/src/fr/composants/recherche/design.md
@@ -27,19 +27,17 @@ Voici les éléments requis pour la recherche sur les sites du GC.
 
 <gcds-details details-title="Éléments requis sur une page standard ou de campagne de Canada.ca" class="mb-300">
   <gcds-text>Toujours inclure la recherche dans l’en-tête d’une page standard ou de campagne et maintenir les paramètres par défaut.</gcds-text>
-  <div>
-    <ul class="list-disc">
-      <li>Utilisez l’indexation par défaut de la recherche du GC.</li>
-      <li>Définissez l’indexation pour tout le contenu de Canada.ca ou à l’échelle d’un organisme ou d’un programme.</li>
-      <li>Pour la recherche à l’échelle du site Canada.ca, maintenez le texte de l’espace réservé par défaut « <span lang="en">Search Canada.ca</span> » en anglais et « Rechercher dans Canada.ca » en français.</li>
-      <li>Pour la recherche à l’échelle d’un organisme, d’un programme ou d’un produit, utilisez le texte de l’espace réservé suivant :
-        <ul class="ms-300">
-          <li>« <span lang="en">Search [institution/program/product] </span>» en anglais</li>
-          <li>« Rechercher dans [institution/programme/produit] » en français</li>
-        </ul>
-      </li>
-    </ul>
-  </div>
+  <ul class="list-disc">
+    <li>Utilisez l’indexation par défaut de la recherche du GC.</li>
+    <li>Définissez l’indexation pour tout le contenu de Canada.ca ou à l’échelle d’un organisme ou d’un programme.</li>
+    <li>Pour la recherche à l’échelle du site Canada.ca, maintenez le texte de l’espace réservé par défaut « <span lang="en">Search Canada.ca</span> » en anglais et « Rechercher dans Canada.ca » en français.</li>
+    <li>Pour la recherche à l’échelle d’un organisme, d’un programme ou d’un produit, utilisez le texte de l’espace réservé suivant :
+      <ul class="ms-300">
+        <li>« <span lang="en">Search [institution/program/product] </span>» en anglais</li>
+        <li>« Rechercher dans [institution/programme/produit] » en français</li>
+      </ul>
+    </li>
+  </ul>
   <gcds-text margin-bottom="0"><strong>Remarque :</strong> Par exception, les pages destinées uniquement à un public de la fonction publique peuvent appliquer une indexation de recherche personnalisée dans certains contextes précis.</gcds-text>
 </gcds-details>
 

--- a/src/fr/composants/signature/design.md
+++ b/src/fr/composants/signature/design.md
@@ -23,20 +23,16 @@ La signature est requise dans l’en-tête et le mot-symbole est requis dans le 
 
 <gcds-details details-title="Éléments requis sur Canada.ca" class="mb-300">
   <gcds-text>Toujours inclure la signature dans l’en-tête et conserver les paramètres par défaut.</gcds-text>
-  <div>
-    <ul class="list-disc mb-300">
-      <li>Utilisez du texte noir, ne sélectionnez pas de texte blanc.</li>
-      <li>Gardez la position de la signature dans le coin supérieur gauche de l’en-tête tant pour la version bureau que mobile.</li>
-      <li>Lien vers la page d’accueil de Canada.ca.</li>
-    </ul>
-  </div>
+  <ul class="list-disc mb-300">
+    <li>Utilisez du texte noir, ne sélectionnez pas de texte blanc.</li>
+    <li>Gardez la position de la signature dans le coin supérieur gauche de l’en-tête tant pour la version bureau que mobile.</li>
+    <li>Lien vers la page d’accueil de Canada.ca.</li>
+  </ul>
   <gcds-text>Toujours inclure le mot-symbole dans la bande de sous-pied de page et maintenir les paramètres par défaut.</gcds-text>
-  <div>
-    <ul class="list-disc mb-300">
-      <li>Utilisez du texte noir, ne sélectionnez pas de texte blanc.</li>
-      <li>Gardez la position dans le coin inférieur droit du pied de page.</li>
-    </ul>
-  </div>
+  <ul class="list-disc mb-300">
+    <li>Utilisez du texte noir, ne sélectionnez pas de texte blanc.</li>
+    <li>Gardez la position dans le coin inférieur droit du pied de page.</li>
+  </ul>
   <gcds-text margin-bottom="0"><strong>Remarque :</strong> les paramètres par défaut pour la signature et le mot-symbole suivent <gcds-link href="https://www.canada.ca/fr/secretariat-conseil-tresor/services/communications-gouvernementales/norme-graphique.html" external>norme graphique du Programme fédéral de l’image de marque</gcds-link>.</gcds-text>
 </gcds-details>
 


### PR DESCRIPTION
# Summary | Résumé

Small cleanup PR: When we added the new details section to all mandatory components, a minor bug in the details component required us to wrap content in extra `div` elements for proper rendering. That bug has since been resolved, so this PR removes the now-unnecessary `div` wrappers.