### PR TITLE
fix: Add copy button to basic on this page template

### DIFF
--- a/src/en/page-templates/basic/code-on-this-page.md
+++ b/src/en/page-templates/basic/code-on-this-page.md
@@ -14,4 +14,8 @@ date: "git Last Modified"
 
 Copy this code to use the basic page template with on this page section.
 
+<div class="page-template-highlight">
+
 {% include 'partials/templates/en/code-basic-page-template-on-this-page.njk' %}
+
+</div>

--- a/src/fr/modeles-de-page/basic/code-sur-cette-page.md
+++ b/src/fr/modeles-de-page/basic/code-sur-cette-page.md
@@ -14,4 +14,8 @@ date: "git Last Modified"
 
 Copiez ce code pour utiliser le modèle de page de base avec la section sur cette page.
 
+<div class="page-template-highlight">
+
 {% include 'partials/templates/fr/code-basic-page-template-on-this-page.njk' %}
+
+</div>


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/design-gc-conception/issues/1788, the copy template button was missing from basic page template with table of contents. The additional markup was added to the page to render the copy button.
