### PR TITLE
feat: remove PII from user submitted messages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -35,6 +35,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy(
     './src/scripts/component-preview-iframe.js',
   );
+  eleventyConfig.addPassthroughCopy('./src/scripts/sanitize-contact-form.js');
   eleventyConfig.addPassthroughCopy('./src/favicon.ico');
   eleventyConfig.addPassthroughCopy({ './src/variables/': 'variables' });
   eleventyConfig.addPassthroughCopy({
@@ -43,6 +44,9 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({
     './node_modules/@cdssnc/gcds-utility/dist/gcds-utility.min.css':
       'gcds-utility.min.css',
+  });
+  eleventyConfig.addPassthroughCopy({
+    './node_modules/@cdssnc/sanitize-pii/dist/umd/sanitize-pii.min.js': './scripts/sanitize-pii.min.js',
   });
   // Add copy fo a11y testing
   eleventyConfig.addPassthroughCopy('./.pa11yci.json');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@11ty/eleventy": "^2.0.1",
         "@11ty/eleventy-navigation": "^0.3.2",
+        "@cdssnc/sanitize-pii": "^1.0.1",
         "axios": "^1.8.3",
         "eleventy-plugin-code-clipboard": "^0.2.0",
         "html-entities": "^2.5.2",
@@ -824,6 +825,12 @@
       "resolved": "https://registry.npmjs.org/@cdssnc/gcds-utility/-/gcds-utility-1.9.1.tgz",
       "integrity": "sha512-oTMDjy0D6ysYKnLDBhDrNqTvJ5MIEQbFS65PRaoZ4EVkt+qKIjB1YZ+4ZGLCLWyqS506MvVRwY9yPy/h9C4ooQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cdssnc/sanitize-pii": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@cdssnc/sanitize-pii/-/sanitize-pii-1.0.2.tgz",
+      "integrity": "sha512-/knv1OChnJgBOInLYLaGu+3zJitsloBNClCGvStzVZhs2zTnSgnEwkzUDSfGbwfGQQRd3bcivhHjpQcqmdfLrw==",
       "license": "MIT"
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@11ty/eleventy": "^2.0.1",
     "@11ty/eleventy-navigation": "^0.3.2",
+    "@cdssnc/sanitize-pii": "^1.0.2",
     "axios": "^1.8.3",
     "eleventy-plugin-code-clipboard": "^0.2.0",
     "html-entities": "^2.5.2",

--- a/src/en/contact/contact.md
+++ b/src/en/contact/contact.md
@@ -61,3 +61,6 @@ This form is for people building government websites and digital products. You c
     Submit
   </gcds-button>
 </form>
+
+<script async src="/scripts/sanitize-pii.min.js"></script>
+<script async src="/scripts/sanitize-contact-form.js"></script>

--- a/src/fr/contactez/contactez.md
+++ b/src/fr/contactez/contactez.md
@@ -62,3 +62,6 @@ Pour obtenir de l’aide avec un service gouvernemental, aller à la page <gcds-
     Envoyer
   </gcds-button>
 </form>
+
+<script async src="/scripts/sanitize-pii.min.js"></script>
+<script async src="/scripts/sanitize-contact-form.js"></script>

--- a/src/scripts/sanitize-contact-form.js
+++ b/src/scripts/sanitize-contact-form.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const contactForm = document.querySelector('form.contact-us-form');
+
+  // If the contact form exists, remove PII from textareas before submission
+  if (contactForm) {
+    contactForm.addEventListener('submit', function (event) {
+      event.preventDefault();
+      const textareas = contactForm.querySelectorAll('gcds-textarea');
+
+      textareas.forEach(textarea => {
+        textarea.value = sanitizePii(textarea.value);
+        console.log('Sanitized textarea value:', textarea.value);
+      });
+      contactForm.submit();
+    });
+  }
+});


### PR DESCRIPTION
# Summary
Add the @cdssnc/sanitize-pii module and a contact form submit handler that removes personally identifiable information from the `gcds-textarea` elements of the contact form.

The module will remove the following types of PII: https://github.com/cds-snc/sanitize-pii/blob/main/src/patterns.ts

# Related
- https://github.com/cds-snc/platform-core-services/issues/781
- Closes https://github.com/cds-snc/gcds-docs/pull/614