### PR TITLE
docs: fix small typos on installation pages

### DIFF
--- a/src/en/get-started/html.md
+++ b/src/en/get-started/html.md
@@ -125,7 +125,7 @@ The code will remain unchanged until you manually update the version in the CDN 
 
 Check for <gcds-link href="{{ links.releaseNotes }}" external>new GC Design System versions</gcds-link> regularly to update the latest pinned version.
 
-#### b. Use <@latest> version
+#### b. Use `@latest` version
 
 Use the `@latest` tag to pull the most recent version of GC Design System into your project. Put this tag in place of the version number.
 

--- a/src/en/get-started/react.md
+++ b/src/en/get-started/react.md
@@ -27,6 +27,8 @@ The web components inherit native properties and interoperability.
 
 ## React installation instructions
 
+Follow these steps to install and use GC Design System components in your React project.
+
 ### 1. Install the package
 
 Navigate to your project’s root folder and run the following command:

--- a/src/fr/demarrer/html.md
+++ b/src/fr/demarrer/html.md
@@ -125,7 +125,7 @@ Le code restera inchangé jusqu’à ce que vous mettiez à jour manuellement la
 
 Vérifiez régulièrement s’il y a des <gcds-link href="{{ links.releaseNotes }}" external>nouvelles versions de Système de design GC</gcds-link> afin de mettre à jour la dernière version épinglée.
 
-#### b. Utiliser la version <@latest> (la dernière version)
+#### b. Utiliser la version `@latest` (la dernière version)
 
 Utilisez la balise `@latest` pour insérer la plus récente version de Système de design GC dans votre projet. Remplacez le numéro de version par cette balise.
 

--- a/src/fr/demarrer/react.md
+++ b/src/fr/demarrer/react.md
@@ -27,6 +27,8 @@ Les composants Web héritent les propriétés et l’interopérabilité natives.
 
 ## Instructions d’installation dans React
 
+Suivez ces étapes pour installer et utiliser les composants de Système de design GC dans votre projet React.
+
 ### 1. Installer le paquet
 
 Naviguez vers le dossier racine de votre projet et exécutez la commande suivante :


### PR DESCRIPTION
# Summary | Résumé

Fixing a small display error and adding a missing sentence that I noticed while working on the new CSS Shortcuts pages.