### PR TITLE
fix: update position examples

### DIFF
--- a/src/en/css-shortcuts/position.md
+++ b/src/en/css-shortcuts/position.md
@@ -35,47 +35,42 @@ The position class sets the `position` property. It determines how the element i
 
 ### Static<br/>`position-static`
 
-{% shortcutPreview %}
-
+```html
 <p class="position-static">
   This element displays a static position where it exists in the normal document flow.
 </p>
-{% endshortcutPreview %}
+```
 
 ### Absolute<br/>`position-absolute`
 
-{% shortcutPreview %}
-
+```html
 <p class="position-absolute">
   This element is removed from the normal document flow and displays relative to its nearest positioned ancestor or the page itself.
 </p>
-{% endshortcutPreview %}
+```
 
 ### Fixed<br/>`position-fixed`
 
-{% shortcutPreview %}
-
+```html
 <p class="position-fixed">
   This element displays relative to the viewport and stays fixed in place when the page is scrolled.
 </p>
-{% endshortcutPreview %}
+```
 
 ### Relative<br/>`position-relative`
 
-{% shortcutPreview %}
-
+```html
 <p class="position-relative">
   This element is offset relative to its normal position using top, right, bottom, or left.
 </p>
-{% endshortcutPreview %}
+```
 
 ### Sticky<br/>`position-sticky`
 
-{% shortcutPreview %}
-
+```html
 <p class="position-sticky">
   This element scrolls with the page until a specified offset is reached, then sticks in place within its containing block.
 </p>
-{% endshortcutPreview %}
+```
 
 {% include "partials/responsive-layout.njk" %}

--- a/src/fr/raccourcis-css/position.md
+++ b/src/fr/raccourcis-css/position.md
@@ -35,47 +35,42 @@ La classe position définit la propriété `position`. Elle détermine comment l
 
 ### Statique <br/>`position-static`
 
-{% shortcutPreview %}
-
+```html
 <p class="position-static">
   Cet élément affiche une position statique où il se trouve dans le flux normal du document.
 </p>
-{% endshortcutPreview %}
+```
 
 ### Absolue<br/>`position-absolute`
 
-{% shortcutPreview %}
-
+```html
 <p class="position-absolute">
   Cet élément est retiré du flux normal du document et s’affiche par rapport à son élément ancêtre le plus proche ou à la page elle-même.
 </p>
-{% endshortcutPreview %}
+```
 
 ### Fixe<br/>`position-fixed`
 
-{% shortcutPreview %}
-
+```html
 <p class="position-fixed">
   Cet élément s’affiche par rapport à la fenêtre d’affichage et reste fixe lorsqu’on fait défiler la page.
 </p>
-{% endshortcutPreview %}
+```
 
 ### Relative<br/>`position-relative`
 
-{% shortcutPreview %}
-
+```html
 <p class="position-relative">
   Cet élément est décalé par rapport à sa position normale en utilisant le haut, la droite, le bas ou la gauche.
 </p>
-{% endshortcutPreview %}
+```
 
 ### Élément collant<br/>`position-sticky`
 
-{% shortcutPreview %}
-
+```html
 <p class="position-sticky">
   Cet élément défile avec la page jusqu’à ce qu’un décalage spécifié soit atteint, puis reste en place dans sa boîte.
 </p>
-{% endshortcutPreview %}
+```
 
 {% include "partials/responsive-layout.njk" %}


### PR DESCRIPTION
# Summary | Résumé

Simplifying the CSS Shortcut position examples for now, to not have them block the launch. We can update them after we had time to work on the extra content needed for it.