### PR TITLE
fix: missing french css shortcuts

### DIFF
--- a/src/_data/responsivelayout.js
+++ b/src/_data/responsivelayout.js
@@ -11,7 +11,7 @@ module.exports = {
     heading: 'Style conditionnel ',
     subheading: 'Appliquer ces styles à des tailles d’écran précises',
     textIntro:
-      'Utilisez un préfixe de mise en page réactive pour appliquer cette classe uniquement à une taille d’écran précise.',
+      'Utilisez un préfixe de mise en page réactive pour appliquer cette classe uniquement à une taille d’écran précise. Voici les points d’arrêt possibles :',
     textLink:
       'En savoir plus sur le <gcds-link href="/fr/raccourcis-css/mise-en-page-reactive">préfixe de mise en page réactive</gcds-link>.',
   },

--- a/src/_data/state.js
+++ b/src/_data/state.js
@@ -9,7 +9,7 @@ module.exports = {
   fr: {
     heading: 'Appliquer ces styles à des états spécifiques',
     textIntro:
-      'Utilisez un préfixe d’état pour appliquer cette classe uniquement à un état d’interaction spécifié',
+      'Utilisez un préfixe d’état pour appliquer cette classe uniquement à un état d’interaction spécifié. Voici les états possibles :',
     textLink:
       'En savoir plus sur le <gcds-link href="/fr/raccourcis-css/etat">préfixe d’état</gcds-link>.',
   },


### PR DESCRIPTION
# Summary | Résumé

Add missing French text to css shortcut partials.
