### PR TITLE
Update registerdemos.js to include CSS Shortcuts demo

### DIFF
--- a/src/_data/registerdemos.js
+++ b/src/_data/registerdemos.js
@@ -84,6 +84,13 @@ module.exports = [
     link: 'https://events.teams.microsoft.com/event/e5e410a6-0868-4697-b923-41207e2562b1@9ed55846-8a81-4246-acd8-b1a01abfc0d1'
   },
   {
+    date: "2025-10-09",
+    starttime: "15:00",
+    endtime: "16:00",
+    lang: 'en',
+    link: 'https://events.teams.microsoft.com/event/d8455bea-30b3-42bd-9e96-ceb4fcec355f@9ed55846-8a81-4246-acd8-b1a01abfc0d1'
+  },
+  {
     date: "2025-10-21",
     starttime: "14:00",
     endtime: "15:00",


### PR DESCRIPTION
I've added a demo date for October 9th.  Is it possible to title it "English CSS Shortcuts demo" rather than just demo?

On the french website it will be "Démo de Raccourcis CSS - anglais"

Also, I understand if this is not possible with the current script.  Is there a better way to publish a one-off demo?

# Summary | Résumé

> 1-3 sentence description of the changed you're proposing, including a link to
> a GitHub Issue # or Trello card if applicable.

---

> Description en 1 à 3 phrases de la modification proposée, avec un lien vers le
> problème (« issue ») GitHub ou la fiche Trello, le cas échéant.

# Test instructions | Instructions pour tester la modification

> Sequential steps (1., 2., 3., ...) that describe how to test this change. This
> will help a developer test things out without too much detective work. Also,
> include any environmental setup steps that aren't in the normal README steps
> and/or any time-based elements that this requires.

---

> Étapes consécutives (1., 2., 3., …) qui décrivent la façon de tester la
> modification. Elles aideront les développeurs à faire des tests sans avoir à
> jouer au détective. Veuillez aussi inclure toutes les étapes de configuration
> de l’environnement qui ne font pas partie des étapes normales dans le fichier
> README et tout élément temporel requis.
