### PR TITLE
fix: ignore npm links in scan dead links check

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -19,7 +19,12 @@ Cypress.Commands.add('scanDeadLinks', () => {
       .each(link => {
         const href = link.prop('href');
 
-        if (href.startsWith('mailto') || href.includes('.pdf')) return;
+        if (
+          href.startsWith('mailto') ||
+          href.includes('.pdf') ||
+          href.includes('https://www.npmjs')
+        )
+          return;
 
         // Skip GitHub UI links to avoid 429 errors
         if (href.startsWith('https://github.com/')) {


### PR DESCRIPTION
# Summary | Résumé

NPM seems to be blocking the scan dead link check, ignore npm links until an appropriate fix can be found.
