### PR TITLE
fix: update two broken links + optimize shortcuts setup instructions

### DIFF
--- a/src/en/css-shortcuts/css-shortcuts.md
+++ b/src/en/css-shortcuts/css-shortcuts.md
@@ -19,7 +19,7 @@ CSS Shortcuts is a CSS utility framework built to match GC Design System (GCDS) 
 
 ## How to use CSS Shortcuts
 
-1. [Add the CSS stylesheet into your project]({{ links.getStartedDevelop }}). Different frameworks add it in different places.
+1. [Select the framework of your choice]({{ links.startToUseDevelop }}) and follow the instructions to add the CSS Shortcuts stylesheet into your project.
 2. Explore the different styling options in the menu.
 3. Add the classes to their corresponding HTML to adjust the styling to meet your needs.
 

--- a/src/fr/demarrer/html.md
+++ b/src/fr/demarrer/html.md
@@ -33,7 +33,7 @@ Utilisez cette option pour les situations suivantes :
   <li>.NET</li>
 </ul>
 
-Si vous utilisez les cadres React, Angular ou Vue, consultez la <gcds-link href="{{ links.getStartedDevelop }}">page d’installation</gcds-link> pour connaître les options propres à chaque cadre.
+Si vous utilisez les cadres React, Angular ou Vue, consultez la <gcds-link href="{{ links.startToUseDevelop }}">page d’installation</gcds-link> pour connaître les options propres à chaque cadre.
 
 ## Sélectionner le paquet utilisé
 

--- a/src/fr/raccourcis-css/raccourcis-css.md
+++ b/src/fr/raccourcis-css/raccourcis-css.md
@@ -19,7 +19,7 @@ Les Raccourcis CSS sont un cadre utilitaire CSS conçu en conformité avec les s
 
 ## Comment utiliser les Raccourcis CSS
 
-1. [Ajoutez la feuille de style CSS à votre projet]({{ links.getStartedDevelop }}). Celle-ci s’ajoute à différents endroits selon le cadre.
+1. [Sélectionnez le cadre de votre choix]({{ links.startToUseDevelop }}) et suivez les instructions pour ajouter la feuille de style Raccourcis CSS à votre projet.
 2. Explorez les différentes options de style dans le menu.
 3. Ajoutez les classes au code HTML correspondant pour ajuster le style selon vos besoins.
 


### PR DESCRIPTION
# Summary | Résumé

Updating two broken links to use the new link locations and optimizing the content that directs users to the installation page from the CSS Shortcuts landing page.

## Previews

- [EN preview](https://pr-670.djtlis5vpn8jd.amplifyapp.com/en/css-shortcuts/)
- [FR preview](https://pr-670.d35vdwuoev573o.amplifyapp.com/fr/raccourcis-css/)