### PR TITLE
fix: About us link on homepage

### DIFF
--- a/src/en/pages/index.md
+++ b/src/en/pages/index.md
@@ -27,7 +27,7 @@ GC Design System is the source for public servants delivering Government of Cana
 
 ### Learn more
 
-Learn <gcds-link href="{{ links.aboutUs }}">about us</gcds-link>, our regular <gcds-link href="{{ links.accessibility }}">accessibility testing</gcds-link>, and how you can improve accessibility in your products and websites.
+Learn <gcds-link href="{{ links.about }}">about us</gcds-link>, our regular <gcds-link href="{{ links.accessibility }}">accessibility testing</gcds-link>, and how you can improve accessibility in your products and websites.
 
 ### Get involved
 

--- a/src/fr/pages/index.md
+++ b/src/fr/pages/index.md
@@ -26,7 +26,7 @@ Système de design GC est la source pour les fonctionnaires qui assurent la pres
 
 ### Pour en savoir plus
 
-Renseignez-vous <gcds-link href="{{ links.aboutUs }}">sur le SNC</gcds-link>, nos <gcds-link href="{{ links.accessibility }}">tests réguliers en matière d’accessibilité</gcds-link> et sur les manières dont vous pouvez améliorer l’accessibilité de vos produits et sites Web.
+Renseignez-vous <gcds-link href="{{ links.about }}">sur le SNC</gcds-link>, nos <gcds-link href="{{ links.accessibility }}">tests réguliers en matière d’accessibilité</gcds-link> et sur les manières dont vous pouvez améliorer l’accessibilité de vos produits et sites Web.
 
 ### S’impliquer
 


### PR DESCRIPTION
# Summary | Résumé

As mentioned in https://github.com/cds-snc/design-gc-conception/issues/1928, the about us link on the homepage does not correctly link to the right page. Fix the link to navigate to the about us page.
