### PR TITLE
fix(a11y): give each component tab its own page title (#738)

### DIFF
--- a/src/_includes/layouts/component-documentation.njk
+++ b/src/_includes/layouts/component-documentation.njk
@@ -4,6 +4,20 @@
   {% set tabs = collections.all | tabs(tags[0]) %}
 {% endif %}
 
+{# Every tab of a component shares one `title`, so "Card" was the whole <title> on the
+   Use case, Design and Code pages alike. Name the tab as well, so each page is
+   identifiable on its own. `tags[1]` is the tab key, the same one the nav below keys
+   off, and the label comes from `documentation[locale]`, so this is the exact string
+   shown on the tab and it is translated already. Pages whose tab key has no label,
+   such as the preview, fall back to the original title. #}
+{% block page_title %}
+  {%- if documentation[locale][tags[1]] -%}
+    {{ title }} - {{ documentation[locale][tags[1]] }} - {{ base[locale].gcds }}
+  {%- else -%}
+    {{ title }} - {{ base[locale].gcds }}
+  {%- endif -%}
+{% endblock %}
+
 {% block content %}
   {% if tabs %}
     {{ tabs.header.templateContent | safe }}


### PR DESCRIPTION
# 📝 Summary | Résumé

Every tab of a component shares one `title` in front matter, so the Use case, Design and Code pages all rendered the same `<title>`:

```html
<title>Card - GC Design System</title>
```

WCAG 2.4.2 Page Titled, Level A, asks that a title describe the topic or purpose of the page. Three pages answering three different questions cannot be told apart by a title that names only the component. It shows up as three identical browser tabs, three identical bookmarks, three identical entries in history and search results, and a screen reader announcing the same thing on arrival at each.

**The change is one layout file.** `component-documentation.njk` overrides the `page_title` block to name the tab as well:

```html
<title>Card - Use case - GC Design System</title>
<title>Card - Design - GC Design System</title>
<title>Card - Code - GC Design System</title>
```

Two details worth noting, both chosen to avoid adding anything you would have to maintain:

- `tags[1]` is the tab key, **the same one the tab nav in this layout already keys off**, so there is no new convention to keep in step.
- The label comes from `documentation[locale]`, so the title reuses **the exact string already shown on the tab**, and French is translated with no new content:

```html
<title>Carte - Cas d'utilisation - Système de design GC</title>
```

Pages whose tab key has no label, such as the component preview, keep their original title.

## 🧩 Related Issues | Cartes liées

- Issue #738
- Zenhub issue:

Partial. It closes the `<title>` half. The `<h1>` half is discussed under Impact/Risks below, and I have deliberately left it out of this PR.

## 🧪 Test instructions | Instructions pour tester la modification

Counting `<title>` strings across every generated page of a full `npm run build`:

| | distinct titles | strings shared by >1 page | pages affected |
|---|---|---|---|
| before | 329 | 80 | **240** |
| after | 487 | 2 | **4** |

The 4 remaining are the two page-template pages, `Basic Page Template (EN)` and `Modèle de page de base (FR)`, which use a different layout and are outside the scope of this change.

To reproduce:

```bash
npm ci && npm run build
cd _site && find . -name '*.html' -exec grep -ho '<title>[^<]*</title>' {} \; \
  | sort | uniq -c | sort -rn | awk '$1 > 1'
```

Worst offenders before the change were `Image` at 4 pages per language, then `Zone de texte`, `Téléverseur de fichiers` and `Top navigation` at 3 each.

Spot check, English and French:

- `/en/components/card/` → `Card - Use case - GC Design System`
- `/en/components/card/design/` → `Card - Design - GC Design System`
- `/en/components/card/code/` → `Card - Code - GC Design System`
- `/fr/composants/carte/` → `Carte - Cas d'utilisation - Système de design GC`
- `/fr/composants/carte/design/` → `Carte - Design - Système de design GC`
- `/fr/composants/carte/code/` → `Carte - Code - Système de design GC`

## ✍️ Author checklist | Liste de vérification de l'auteur

**Choose one (primary change type):**
- [x] This PR introduces structural changes (add/remove pages, navigation updates).

**Breaking / impact flag:**
- [x] This PR does not break existing links (URLs, anchors, navigation).

**Ready for review:**
- [x] I have verified the English and French versions are accurate, consistent, and properly displayed.
- [x] I have checked accessibility and ensured accessibility requirements continue to meet standards. :accessibility:
- [x] I have verified links, routes, and navigation behave correctly. No URL, route or anchor changes; only the contents of the `<title>` element.
- [x] I have ensured test instructions are clear and reproducible.
- [ ] Mobile viewports and supported browsers: **not applicable**, nothing renders differently. `<title>` is not painted.
- [ ] For visual or design changes, I have posted in the dev-design Slack channel: **not applicable** for this PR, but see Impact/Risks, the `<h1>` half would need it.

## ⚠️ Impact/Risks | Risques

**Why the `<h1>` half of #738 is not here.**

#738 also asks for unique `<h1>`s, and suggests `Card – Design guidance`, `Card – Code implementation` and so on. I stopped short of that on purpose.

The `<h1>` is not set per page. It comes from the header page's content, rendered into every tab through `tabs.header.templateContent`, and it carries the component tag with it:

```html
<h1>Card <br><code>&lt;gcds-card&gt;</code></h1>
```

So making it vary per tab means appending to that rendered content inside the layout, which is a **visible change to every component page in both languages**, and it has to read well after a `<code>` element. That is a design decision about the look of the docs, not an accessibility bug fix, and per your own checklist it wants a post in the dev-design channel before it happens.

There is also a reasonable argument that the shared `<h1>` is defensible as it stands: it names the component, and the tab nav directly beneath it carries `aria-current="page"` to say which view you are on. 2.4.2 is the Level A failure and it is unambiguous. 2.4.6 Headings and Labels is AA and, here, arguable.

**Happy to add the `<h1>` change to this PR if you tell me the wording you want**, or to leave #738 open for that half after this merges. I would rather ask than pick a heading style for your design system.

---

Filed following #738, opened by @shawnthompson in January and acknowledged by @adorayi. Nothing in this PR touches components, patterns or features, so I do not believe it falls under the "next priorities" restriction in CONTRIBUTING, but say the word if you would rather it went through the contribution form instead.
